### PR TITLE
Use modern `git clone --recursive` option in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ Other systems refer to [build notes](#build).
 1. Clone the repo + fetch the submodules:
 
 	```sh
-	$ git clone git://github.com/apiaryio/snowcrash.git
+	$ git clone --recursive git://github.com/apiaryio/snowcrash.git
 	$ cd snowcrash
-	$ git submodule update --init --recursive
 	```
 
 2. Build & test Snow Crash:


### PR DESCRIPTION
Update build instructions to use the (newer) short option for cloning the repo+submodules.
