### PR TITLE
Enabled RuntimeTypeInfo for Windows to fix crash.

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
             'MinimalRebuild': 'false',
             'OmitFramePointers': 'false',
             'BasicRuntimeChecks': 3, # /RTC1
-            'RuntimeTypeInfo': 'false',
+            'RuntimeTypeInfo':  'true', # /GR, determine object type at runtime
             'ExceptionHandling': 1            
           },
           'VCLinkerTool': {
@@ -60,7 +60,7 @@
             'OmitFramePointers': 'true',
             'EnableFunctionLevelLinking': 'true',
             'EnableIntrinsicFunctions': 'true',
-            'RuntimeTypeInfo': 'false',
+            'RuntimeTypeInfo': 'true', # /GR, determine object type at runtime
             'ExceptionHandling': 1,
             'AdditionalOptions': [
               '/MP', # compile across multiple CPUs


### PR DESCRIPTION
When I pulled snowcrash from Github today, and built it on Windows, I experienced a crash after sending EOF to STD IN. I took a look at the output from the build process, and there was a warning about unpredictable behavior if RuntimeTypeInfo is disabled. I enabled RuntimeTypeInfo, and it fixed the crash.
