### PR TITLE
fix bug on `SectionParser.h`

### DIFF
--- a/src/SectionParser.h
+++ b/src/SectionParser.h
@@ -91,9 +91,10 @@ namespace snowcrash {
                     cur = SectionProcessor<T>::processUnexpectedNode(cur, collection, pd, lastSectionType, report, out);
                 }
                 
-                if (pd.sectionContext() != UndefinedSectionType ||
+                if (cur != collection.end() &&
+                    (pd.sectionContext() != UndefinedSectionType ||
                     (cur->type != mdp::ParagraphMarkdownNodeType &&
-                     cur->type != mdp::CodeMarkdownNodeType)) {
+                     cur->type != mdp::CodeMarkdownNodeType))) {
 
                     lastSectionType = pd.sectionContext();
                 }


### PR DESCRIPTION
test crashes when running [`test-Indentation.cc`](https://github.com/apiaryio/snowcrash/blob/shared/refactor-integration/test/test-Indentation.cc#L77) test case `No Indentation` on windows due to the calling the property of an `end` iterator.

cc. @zdne 
