### PR TITLE
portable homebrew install (mitigates hardcoded /usr/local/bin)

### DIFF
--- a/tools/homebrew/snowcrash.rb
+++ b/tools/homebrew/snowcrash.rb
@@ -6,6 +6,7 @@ class Snowcrash < Formula
 
   def install
     system "./configure"
-    system "make", "install"
+    system "make", "snowcrash"
+    bin.install Dir["bin/snowcrash"]
   end
 end


### PR DESCRIPTION
This mitigates the fact that the `make install` target hard-codes the `/usr/local/bin` path as a destination directory. As-is, the current formula **appears** to work but likely only because it's only been tested on homebrew installs that do not deviate from `/usr/local`. 

The updated formula is portable.
