### PR TITLE
Fix compatibility with Python 3.x

### DIFF
--- a/configure
+++ b/configure
@@ -45,7 +45,7 @@ parser.add_option("--include-integration-tests",
 
 def write(filename, data):
   filename = os.path.join(root_dir, filename)
-  print "creating ", filename
+  print("creating " + filename)
   f = open(filename, 'w+')
   f.write(data)
 
@@ -58,12 +58,12 @@ def cc_macros():
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
   except OSError:
-    print '''Configure error: No acceptable C compiler found!
+    print('''Configure error: No acceptable C compiler found!
 
         Please make sure you have a C compiler installed on your system and/or
         consider adjusting the CC environment variable if you installed
         it in a non-standard prefix.
-        '''
+        ''')
     sys.exit()
 
   p.stdin.write('\n')
@@ -129,7 +129,7 @@ def configure_snowcrash(o):
 #
 # TODO: use bundle check
 if options.include_integration_tests:
-    print "Installing dependencies for integration tests..."
+    print("Installing dependencies for integration tests...")
     try:
         if sys.platform == 'win32':
             subprocess.call(["bundle.bat", "install"])
@@ -188,7 +188,7 @@ write('config.mk',
 #
 # Gyp call
 #
-print "creating makefiles"
+print("creating makefiles")
 
 gyp_args = ['--generator-output', build_dir, '--depth', '.']
 if sys.platform == 'win32':
@@ -210,4 +210,4 @@ if os.path.exists(options_fn):
 subprocess.call([sys.executable, 'tools/gyp/gyp_main.py'] + gyp_args)
 
 # All done
-print "All OK."
+print("All OK.")


### PR DESCRIPTION
In Python 3 `print` is no longer a statement
