### PR TITLE
Include all overshadowed parameters in output. Fixes #201.

### DIFF
--- a/src/ParametersParser.h
+++ b/src/ParametersParser.h
@@ -95,8 +95,6 @@ namespace snowcrash {
                     report.warnings.push_back(Warning(ss.str(),
                                                       RedefinitionWarning,
                                                       sourceMap));
-
-                    out.erase(duplicate);
                 }
             }
 

--- a/test/test-ParametersParser.cc
+++ b/test/test-ParametersParser.cc
@@ -147,9 +147,12 @@ TEST_CASE("Warn about multiple parameters with the same name", "[parameters]")
     REQUIRE(report.warnings.size() == 1);
     REQUIRE(report.warnings[0].code == RedefinitionWarning);
 
-    REQUIRE(parameters.size() == 1);
+    REQUIRE(parameters.size() == 2);
     REQUIRE(parameters[0].name == "id");
-    REQUIRE(parameters[0].exampleValue == "43");
+    REQUIRE(parameters[0].exampleValue == "42");
+
+    REQUIRE(parameters[1].name == "id");
+    REQUIRE(parameters[1].exampleValue == "43");
 }
 
 TEST_CASE("Recognize parameter when there is no description on its signature and remaining description is not a new node", "[parameters]")


### PR DESCRIPTION
We were running a little bit around this already. However I believe that original behavior is correct.
That is including any and all parameters as written in blueprint in the AST – only warn about the overshadowing them.

Reminder: The goal is to have AST capturing the blueprint as it was written by user and making it accessible to machine.
Not to optimize the AST for possible subsequent use by a tool (drafter can do this). So lets keep the data in the AST and let
the tool to decide what to do with multiple parameter definitions.
