### PR TITLE
Unify processor interface. Check boundaries while processing. Fixes #205

### DIFF
--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -43,6 +43,7 @@ namespace snowcrash {
     struct SectionProcessor<Action> : public SectionProcessorBase<Action> {
 
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,

--- a/src/AssetParser.h
+++ b/src/AssetParser.h
@@ -37,6 +37,7 @@ namespace snowcrash {
     struct SectionProcessor<Asset> : public SectionProcessorBase<Asset> {
         
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,
@@ -48,6 +49,7 @@ namespace snowcrash {
         }
         
         static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+                                                       const MarkdownNodes& siblings,
                                                        SectionParserData& pd,
                                                        Report& report,
                                                        Asset& out) {
@@ -55,6 +57,7 @@ namespace snowcrash {
         }
 
         static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+                                                   const MarkdownNodes& siblings,
                                                    SectionParserData& pd,
                                                    Report& report,
                                                    Asset& out) {

--- a/src/HeadersParser.h
+++ b/src/HeadersParser.h
@@ -33,6 +33,7 @@ namespace snowcrash {
     struct SectionProcessor<Headers> : public SectionProcessorBase<Headers> {
         
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,
@@ -47,6 +48,7 @@ namespace snowcrash {
         }
         
         static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+                                                       const MarkdownNodes& siblings,
                                                        SectionParserData& pd,
                                                        Report& report,
                                                        Headers& out) {
@@ -54,6 +56,7 @@ namespace snowcrash {
         }
 
         static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+                                                   const MarkdownNodes& siblings,
                                                    SectionParserData& pd,
                                                    Report& report,
                                                    Headers& out) {

--- a/src/ParameterParser.h
+++ b/src/ParameterParser.h
@@ -56,6 +56,7 @@ namespace snowcrash {
     struct SectionProcessor<Parameter> : public SectionProcessorBase<Parameter> {
 
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,

--- a/src/ParametersParser.h
+++ b/src/ParametersParser.h
@@ -35,6 +35,7 @@ namespace snowcrash {
     struct SectionProcessor<Parameters> : public SectionProcessorBase<Parameters> {
 
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,
@@ -61,6 +62,7 @@ namespace snowcrash {
         }
 
         static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+                                                       const MarkdownNodes& siblings,
                                                        SectionParserData& pd,
                                                        Report& report,
                                                        Parameters& out) {

--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -45,6 +45,7 @@ namespace snowcrash {
     struct SectionProcessor<Payload> : public SectionProcessorBase<Payload> {
 
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,
@@ -83,6 +84,7 @@ namespace snowcrash {
         }
 
         static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+                                                   const MarkdownNodes& siblings,
                                                    SectionParserData& pd,
                                                    Report& report,
                                                    Payload& out) {

--- a/src/ResourceGroupParser.h
+++ b/src/ResourceGroupParser.h
@@ -32,6 +32,7 @@ namespace snowcrash {
     struct SectionProcessor<ResourceGroup> : public SectionProcessorBase<ResourceGroup> {
 
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -36,6 +36,7 @@ namespace snowcrash {
     struct SectionProcessor<Resource> : public SectionProcessorBase<Resource> {
 
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,

--- a/src/SectionParser.h
+++ b/src/SectionParser.h
@@ -43,7 +43,7 @@ namespace snowcrash {
             
             // Signature node
             MarkdownNodeIterator lastCur = cur;
-            cur = SectionProcessor<T>::processSignature(cur, pd, layout, report, out);
+            cur = SectionProcessor<T>::processSignature(cur, collection, pd, layout, report, out);
 
             // Exclusive Nested Sections Layout
             if (layout == ExclusiveNestedSectionLayout) {
@@ -71,7 +71,7 @@ namespace snowcrash {
                   SectionProcessor<T>::isDescriptionNode(cur, pd.sectionContext())) {
                 
                 lastCur = cur;
-                cur = SectionProcessor<T>::processDescription(cur, pd, report, out);
+                cur = SectionProcessor<T>::processDescription(cur, collection, pd, report, out);
                 if (lastCur == cur)
                     return Adapter::nextStartingNode(node, siblings, cur);
             }
@@ -81,7 +81,7 @@ namespace snowcrash {
                   SectionProcessor<T>::isContentNode(cur, pd.sectionContext())) {
                 
                 lastCur = cur;
-                cur = SectionProcessor<T>::processContent(cur, pd, report, out);
+                cur = SectionProcessor<T>::processContent(cur, collection, pd, report, out);
                 if (lastCur == cur)
                     return Adapter::nextStartingNode(node, siblings, cur);
             }

--- a/src/SectionProcessor.h
+++ b/src/SectionProcessor.h
@@ -48,12 +48,14 @@ namespace snowcrash {
         /**
          *  \brief Process section signature Markdown node
          *  \param node     Node to process
+         *  \param siblings Siblings of the node being processed
          *  \param pd       Section parser state
          *  \param report   Process log report
          *  \param out      Processed output
          *  \return Result of the process operation
          */
         static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+                                                     const MarkdownNodes& siblings,
                                                      SectionParserData& pd,
                                                      SectionLayout& layout,
                                                      Report& report,
@@ -63,6 +65,7 @@ namespace snowcrash {
 
         /** Process section description Markdown node */
         static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+                                                       const MarkdownNodes& siblings,
                                                        SectionParserData& pd,
                                                        Report& report,
                                                        T& out) {
@@ -78,6 +81,7 @@ namespace snowcrash {
         
         /** Process section-specific content Markdown node */
         static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+                                                   const MarkdownNodes& siblings,
                                                    SectionParserData& pd,
                                                    Report& report,
                                                    T& out) {

--- a/src/ValuesParser.h
+++ b/src/ValuesParser.h
@@ -66,6 +66,7 @@ namespace snowcrash {
         }
 
         static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+                                                       const MarkdownNodes& siblings,
                                                        SectionParserData& pd,
                                                        Report& report,
                                                        Values& out) {

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -611,3 +611,21 @@ TEST_CASE("Overshadow parameters", "[parser][#201][regression][parameters]")
     REQUIRE(blueprint.resourceGroups[0].resources[0].actions[0].parameters[3].name == "a");
     REQUIRE(blueprint.resourceGroups[0].resources[0].actions[0].parameters[3].description == "4");
 }
+
+TEST_CASE("Segfault parsing metadata only", "[parser][#205][regression]")
+{
+    mdp::ByteBuffer source = \
+    "FORMAT: 1A : SOJ\n";
+
+    Blueprint blueprint;
+    Report report;
+    
+    parse(source, 0, report, blueprint);
+    REQUIRE(report.error.code == Error::OK);
+    REQUIRE(report.warnings.empty());
+
+    REQUIRE(blueprint.metadata.size() == 1);
+    REQUIRE(blueprint.metadata[0].first == "FORMAT");
+    REQUIRE(blueprint.metadata[0].second == "1A : SOJ");
+    REQUIRE(blueprint.resourceGroups.empty());
+}


### PR DESCRIPTION
This commit unifies the interface of all `SectionProcessorBase` `process...` methods.
Previously, it was expected that `processSignature()`, `processDescription()` and `processContent()`
always processes exactly one node (or none). However with the Blueprint `SectionProcessor` processing (arguably not correctly)
multiple nodes it is clear that is essential to expect any `process...` methods to process an arbitrary number of nodes. For this
the interface of aforementioned nodes needed to be extended to allow checking the boundary of the node iterator.
