### PR TITLE
[README] Fix broken example using `SourceData`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Other systems refer to [build notes](#build).
 ```c++
 #include "snowcrash.h"
 
-snowcrash::SourceData blueprint = R"(
+mdp::ByteBuffer blueprint = R"(
 # My API
 ## GET /message
 + Response 200 (text/plain)


### PR DESCRIPTION
Tried using the example in the README but quickly discovered that `snowcrash::SourceData` doesn't exist.

``` bash
$ git grep SourceData
README.md:snowcrash::SourceData blueprint = R"(
```

This PR changes the use here for `mdp::ByteBuffer` which is what the tests are using. I was thinking that perhaps defining `SourceData` would be better so we're not exposing the implementation details. Let me know if that's preferred and I'll amend the PR.
