### PR TITLE
Source map export is no longer the default for tests.

### DIFF
--- a/test/snowcrashtest.h
+++ b/test/snowcrashtest.h
@@ -28,8 +28,8 @@ namespace snowcrashtest {
         static void parse(const mdp::ByteBuffer& source,
                           snowcrash::SectionType type,
                           const snowcrash::ParseResultRef<T>& out,
-                          const Symbols& symbols = Symbols(),
                           const snowcrash::BlueprintParserOptions& opts = 0,
+                          const Symbols& symbols = Symbols(),
                           snowcrash::ParseResult<snowcrash::Blueprint>* bp = NULL) {
 
             mdp::MarkdownParser markdownParser;
@@ -48,10 +48,7 @@ namespace snowcrashtest {
                 bppointer = bp;
             }
 
-            // Export source maps
-            snowcrash::BlueprintParserOptions options = opts | snowcrash::ExportSourcemapOption;
-
-            snowcrash::SectionParserData pd(options, source, bppointer->node);
+            snowcrash::SectionParserData pd(opts, source, bppointer->node);
 
             pd.sectionsContext.push_back(type);
 

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -39,7 +39,7 @@ TEST_CASE("Method block classifier", "[action]")
 TEST_CASE("Parsing action", "[action]")
 {
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(ActionFixture, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(ActionFixture, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -93,7 +93,7 @@ TEST_CASE("Parse Action description with list", "[action]")
     "+ Response 204\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -139,7 +139,7 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
     "            J\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // warn responses with the same name
@@ -202,7 +202,7 @@ TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
     "+ Response 200\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 2); // empty asset & preformatted asset
@@ -251,7 +251,7 @@ TEST_CASE("Parse method with foreign item", "[action]")
     "+ Response 200\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -290,7 +290,7 @@ TEST_CASE("Parse method with a HR", "[action]")
     "B\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // no response
@@ -315,7 +315,7 @@ TEST_CASE("Parse method without name", "[action]")
     mdp::ByteBuffer source = "# GET";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // no response
@@ -343,7 +343,7 @@ TEST_CASE("Parse action with parameters", "[action]")
     "\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -378,7 +378,7 @@ TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
     "        {}\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -406,7 +406,7 @@ TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
     "        {}\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -434,7 +434,7 @@ TEST_CASE("Missing 'LINK' HTTP request method", "[action]")
     "+ Response 204\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -466,7 +466,7 @@ TEST_CASE("Warn when request is not followed by a response", "[action]")
     "        A\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);

--- a/test/test-AssetParser.cc
+++ b/test/test-AssetParser.cc
@@ -62,7 +62,7 @@ TEST_CASE("recognize schema signature", "[asset]")
 TEST_CASE("parse body asset", "[asset]")
 {
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(BodyAssetFixture, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(BodyAssetFixture, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -76,7 +76,7 @@ TEST_CASE("parse body asset", "[asset]")
 TEST_CASE("parse schema asset", "[asset]")
 {
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(SchemaAssetFixture, SchemaSectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(SchemaAssetFixture, SchemaSectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -95,7 +95,7 @@ TEST_CASE("Foreign block inside", "[asset]")
     "    Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -117,7 +117,7 @@ TEST_CASE("Nested list block inside", "[asset]")
     "    + Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -140,7 +140,7 @@ TEST_CASE("Multiline signature", "[asset]")
     "        Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -168,7 +168,7 @@ TEST_CASE("Multiple blocks", "[asset]")
     "    Block 3\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 2);
@@ -193,7 +193,7 @@ TEST_CASE("Extra spaces before signature", "[asset]")
     "        Lorem Ipsum\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -212,7 +212,7 @@ TEST_CASE("Asset parser greediness", "[asset]")
     "+ Another Block\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -52,7 +52,7 @@ TEST_CASE("Blueprint block classifier", "[blueprint]")
 TEST_CASE("Parse canonical blueprint", "[blueprint]")
 {
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(BlueprintFixture, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(BlueprintFixture, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -92,7 +92,7 @@ TEST_CASE("Parse blueprint with multiple metadata sections", "[blueprint]")
     source += BlueprintFixture;
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -142,7 +142,7 @@ TEST_CASE("Parse API with Name and abbreviated resource", "[blueprint]")
     "        {}";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -180,7 +180,7 @@ TEST_CASE("Parse nameless blueprint description", "[blueprint]")
     "# B\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -203,7 +203,7 @@ TEST_CASE("Parse nameless blueprint with a list description", "[blueprint]")
     mdp::ByteBuffer source = "+ List\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -233,7 +233,7 @@ TEST_CASE("Parse two groups with the same name", "[blueprint]")
     "# Group Name\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 2); // groups with same name & no response
@@ -266,7 +266,7 @@ TEST_CASE("Test parser options - required blueprint name", "[blueprint]")
     REQUIRE(blueprint.report.warnings.size() == 1);
     REQUIRE(blueprint.report.warnings[0].code == APINameWarning);
 
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, Symbols(), RequireBlueprintNameOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, RequireBlueprintNameOption);
     REQUIRE(blueprint.report.error.code != Error::OK);
 }
 
@@ -279,7 +279,7 @@ TEST_CASE("Test required blueprint name on blueprint that starts with metadata",
 
     ParseResult<Blueprint> blueprint;
 
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, Symbols(), RequireBlueprintNameOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, RequireBlueprintNameOption);
     REQUIRE(blueprint.report.error.code != Error::OK);
 }
 
@@ -291,7 +291,7 @@ TEST_CASE("Should parse nested lists in description", "[blueprint]")
     "   + Nested Item\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -334,7 +334,7 @@ TEST_CASE("Blueprint starting with Resource Group should be parsed", "[blueprint
     "## /posts";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -357,7 +357,7 @@ TEST_CASE("Blueprint starting with Resource should be parsed", "[blueprint]")
     mdp::ByteBuffer source = "# /posts";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -385,7 +385,7 @@ TEST_CASE("Checking a resource with global resources for duplicates", "[blueprin
     "### List posts [GET]\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, Symbols(), 0, &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Symbols(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 3); // 2x no response & duplicate resource
@@ -429,7 +429,7 @@ TEST_CASE("Parsing unexpected blocks", "[blueprint]")
 
     ParseResult<Blueprint> blueprint;
 
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, Symbols(), 0, &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Symbols(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1); // no response

--- a/test/test-HeadersParser.cc
+++ b/test/test-HeadersParser.cc
@@ -37,7 +37,7 @@ TEST_CASE("recognize headers signature", "[headers]")
 TEST_CASE("parse headers fixture", "[headers]")
 {
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(HeadersFixture, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(HeadersFixture, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.empty());
@@ -64,7 +64,7 @@ TEST_CASE("parse headers fixture", "[headers]")
 TEST_CASE("parse headers fixture with no empty line between signature and content", "[headers]")
 {
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(HeadersSignatureContentFixture, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(HeadersSignatureContentFixture, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // content in signature
@@ -90,7 +90,7 @@ TEST_CASE("parse malformed headers fixture", "[headers]")
     source += "        X-Custom-Header:\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // malformed header
@@ -136,7 +136,7 @@ TEST_CASE("Parse header section composed of multiple blocks", "[headers]")
     source += "        X-My-Header: 42\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // not a code block
@@ -166,7 +166,7 @@ TEST_CASE("Parse header section with missing headers", "[headers]")
     mdp::ByteBuffer source = "+ Headers\n\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // no headers

--- a/test/test-ParameterParser.cc
+++ b/test/test-ParameterParser.cc
@@ -34,7 +34,7 @@ TEST_CASE("Recognize parameter definition signature", "[parameter]")
 TEST_CASE("Parse canonical parameter definition", "[parameter]")
 {
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(ParameterFixture, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(ParameterFixture, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     CHECK(parameter.report.warnings.empty());
@@ -90,7 +90,7 @@ TEST_CASE("Warn when re-setting the values attribute", "[parameter]")
     "        + `Hello`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -133,7 +133,7 @@ TEST_CASE("Parse full abbreviated syntax", "[parameter]")
     mdp::ByteBuffer source = "+ limit = `20` (optional, number, `42`) ... This is a limit\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     CHECK(parameter.report.warnings.empty());
@@ -172,7 +172,7 @@ TEST_CASE("Warn on error in  abbreviated syntax attribute bracket", "[parameter]
     mdp::ByteBuffer source = "+ limit (string1, string2, string3) ... This is a limit\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -204,7 +204,7 @@ TEST_CASE("Warn about required vs default clash", "[parameter]")
     mdp::ByteBuffer source = "+ id = `42` (required)\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -234,7 +234,7 @@ TEST_CASE("Warn about implicit required vs default clash", "[parameter_definitio
     mdp::ByteBuffer source = "+ id = `42`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -265,7 +265,7 @@ TEST_CASE("Unrecognized 'values' keyword", "[parameter]")
     "        + `lorem`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -298,7 +298,7 @@ TEST_CASE("warn missing example item in values", "[parameter]")
     "        + `Value2`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -322,7 +322,7 @@ TEST_CASE("warn missing default value in values", "[parameter]")
     "        + `Value2`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -343,7 +343,7 @@ TEST_CASE("Parse parameters with dot in its name", "[parameter]")
     mdp::ByteBuffer source = "+ product.id ... Hello\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -369,7 +369,7 @@ TEST_CASE("Parentheses in parameter description", "[parameter]")
     mdp::ByteBuffer source = "+ id (string) ... lorem (ipsum)\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -400,7 +400,7 @@ TEST_CASE("Parameter with additional description", "[parameter]")
     "  Additional description";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -433,7 +433,7 @@ TEST_CASE("Parameter with additional description as continuation of signature", 
     "  Additional description\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -468,7 +468,7 @@ TEST_CASE("Parameter with list in description", "[parameter]")
     "  + Mauris condimentum\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());

--- a/test/test-ParametersParser.cc
+++ b/test/test-ParametersParser.cc
@@ -37,7 +37,10 @@ TEST_CASE("Recognize Parameters section block", "[parameters]")
 TEST_CASE("Parse canonical parameters", "[parameters]")
 {
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(ParametersFixture, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(ParametersFixture,
+                                                             ParametersSectionType,
+                                                             parameters,
+                                                             ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());
@@ -84,7 +87,10 @@ TEST_CASE("Parse illegal parameter among legal ones", "[parameters]")
     "    + OK-2\n";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(source,
+                                                             ParametersSectionType,
+                                                             parameters,
+                                                             ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -115,7 +121,10 @@ TEST_CASE("Warn about additional content in parameters section", "[parameters]")
     "    + id\n";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(source,
+                                                             ParametersSectionType,
+                                                             parameters,
+                                                             ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -140,7 +149,10 @@ TEST_CASE("Warn about additional content block in parameters section", "[paramet
     "    + id\n";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(source,
+                                                             ParametersSectionType,
+                                                             parameters,
+                                                             ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -165,7 +177,10 @@ TEST_CASE("Warn about multiple parameters with the same name", "[parameters]")
     "    + id (`43`)\n";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(source,
+                                                             ParametersSectionType,
+                                                             parameters,
+                                                             ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -202,7 +217,10 @@ TEST_CASE("Recognize parameter when there is no description on its signature and
     "            + `vent`";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(source,
+                                                             ParametersSectionType,
+                                                             parameters,
+                                                             ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -85,7 +85,7 @@ TEST_CASE("recognize empty body response signature as non-abbreviated", "[payloa
 TEST_CASE("Parse request payload", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(RequestFixture, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(RequestFixture, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -126,7 +126,7 @@ TEST_CASE("Parse request payload", "[payload]")
 TEST_CASE("Parse abbreviated payload body", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(ResponseBodyFixture, ResponseBodySectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(ResponseBodyFixture, ResponseBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -158,7 +158,7 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     source += "  B\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.size() == 1); // preformatted code block
@@ -203,7 +203,7 @@ TEST_CASE("Parse payload description with list", "[payload]")
     "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -246,7 +246,7 @@ TEST_CASE("Parse payload with foreign list item", "[payload]")
     "    + Bar\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.size() == 1); // dangling block
@@ -285,7 +285,7 @@ TEST_CASE("Parse payload with dangling body", "[payload]")
     source += "    Bar\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1); // dangling block
@@ -315,7 +315,7 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     SymbolHelper::buildSymbol("Symbol", symbols);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(SymbolFixture, RequestBodySectionType, payload, symbols);
+    SectionParserHelper<Payload, PayloadParser>::parse(SymbolFixture, RequestBodySectionType, payload, ExportSourcemapOption, symbols);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 0);
@@ -348,7 +348,7 @@ TEST_CASE("Parse inline payload with symbol reference with extra indentation", "
     SymbolHelper::buildSymbol("Symbol", symbols);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, symbols);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption, symbols);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -379,7 +379,7 @@ TEST_CASE("Parse inline payload with symbol reference with foreign content", "[p
     SymbolHelper::buildSymbol("Symbol", symbols);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, symbols);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption, symbols);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1); // ignoring foreign entry
@@ -415,7 +415,7 @@ TEST_CASE("Parse named model", "[payload]")
     source += "        Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -456,7 +456,7 @@ TEST_CASE("Parse nameless model", "[payload]")
     source += "        Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -504,7 +504,7 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     source += "            Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -541,7 +541,7 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     "            Content-Length: 100\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -594,7 +594,7 @@ TEST_CASE("Give a warning when 100 response has a body", "[payload]")
 TEST_CASE("Empty body section should shouldn't be parsed as description", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(EmptyBodyFixture, ResponseSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(EmptyBodyFixture, ResponseSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -614,7 +614,7 @@ TEST_CASE("Parameters section should be taken as a description node", "[payload]
     "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -654,6 +654,4 @@ TEST_CASE("Report ignoring nested request objects", "[payload][#163][#189]")
 
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.body.empty());
-
-    REQUIRE(payload.sourceMap.body.sourceMap.empty());
 }

--- a/test/test-ResourceGroupParser.cc
+++ b/test/test-ResourceGroupParser.cc
@@ -47,7 +47,10 @@ TEST_CASE("Resource group block classifier", "[resource_group]")
 TEST_CASE("Parse canonical resource group", "[resource_group]")
 {
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(ResourceGroupFixture, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(ResourceGroupFixture,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -78,7 +81,10 @@ TEST_CASE("Parse resource group with empty resource", "[resource_group]")
     "## /resource";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -110,7 +116,10 @@ TEST_CASE("Parse multiple resource in anonymous group", "[resource_group]")
     "p2\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -140,7 +149,10 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     "+ Request\n\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 4);
@@ -187,7 +199,10 @@ TEST_CASE("Parse multiple resources with the same name", "[resource_group]")
     "## /r1\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 1);
@@ -213,7 +228,10 @@ TEST_CASE("Parse resource with list in its description", "[resource_group]")
     "+ Lorem Ipsum\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 3);   // preformatted asset & ignoring unrecognized node & no response
@@ -241,7 +259,10 @@ TEST_CASE("Parse resource groups with hr in description", "[resource_group]")
     "A\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -268,7 +289,10 @@ TEST_CASE("Make sure method followed by a group does not eat the group", "[resou
     "# Group Two\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 1); // no response
@@ -295,7 +319,10 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
     "# POST\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 2); // no response && unexpected action POST
@@ -324,7 +351,10 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     "# POST /2\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 2); // 2x no response
@@ -362,7 +392,10 @@ TEST_CASE("Resource followed by a complete action", "[resource_group][regression
     "+ Response 201\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -407,7 +440,10 @@ TEST_CASE("Too eager complete action processing", "[resource_group][regression][
     "Lorem Ipsum\n";
 
     ParseResult<ResourceGroup> resourceGroup;
-    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source, ResourceGroupSectionType, resourceGroup);
+    SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
+                                                                   ResourceGroupSectionType,
+                                                                   resourceGroup,
+                                                                   ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -61,7 +61,7 @@ TEST_CASE("Resource block classifier", "[resource]")
 TEST_CASE("Parse resource", "[resource]")
 {
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(ResourceFixture, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(ResourceFixture, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -120,7 +120,7 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     "p1\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // no response & preformatted asset
@@ -162,7 +162,7 @@ TEST_CASE("Parse multiple method descriptions", "[resource]")
     "p2\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // 2x no response
@@ -211,7 +211,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     "E\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // empty reuqest asset & no response
@@ -272,7 +272,7 @@ TEST_CASE("Parse description with list", "[resource]")
     "p1\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -302,7 +302,7 @@ TEST_CASE("Parse resource with a HR", "[resource][block]")
     "B\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -333,7 +333,7 @@ TEST_CASE("Parse resource method abbreviation", "[resource]")
     "            {}\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -364,7 +364,7 @@ TEST_CASE("Parse resource without name", "[resource]")
     mdp::ByteBuffer source = "# /resource\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -396,7 +396,7 @@ TEST_CASE("Warn about parameters not in URI template", "[resource][source]")
     "+ Response 204\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2);
@@ -428,7 +428,7 @@ TEST_CASE("Parse nameless resource with named model", "[resource][model][source]
     "\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -459,7 +459,7 @@ TEST_CASE("Parse nameless resource with nameless model", "[resource][model][sour
     "\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == SymbolError);
     REQUIRE(resource.report.warnings.empty());
@@ -488,7 +488,7 @@ TEST_CASE("Parse named resource with nameless model", "[resource][model][source]
     "    [Message][]\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -624,7 +624,7 @@ TEST_CASE("Parse root resource", "[resource]")
     mdp::ByteBuffer source = "# API Root [/]\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -649,7 +649,7 @@ TEST_CASE("Parse resource with invalid URI Tempalte", "[resource]")
     mdp::ByteBuffer source = "# Resource [/id{? limit}]\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1);
@@ -684,7 +684,7 @@ TEST_CASE("Deprecated resource and action headers", "[resource]")
     "            header3: value3\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2);
@@ -784,7 +784,7 @@ TEST_CASE("Dangling transaction example assets", "[resource]")
     "```\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 3);
@@ -831,7 +831,7 @@ TEST_CASE("Body list item in description", "[resource][regression][#190]")
     "+ Response 200\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());

--- a/test/test-SymbolTable.cc
+++ b/test/test-SymbolTable.cc
@@ -25,7 +25,7 @@ TEST_CASE("Parse object resource symbol", "[symbol_table]")
     SymbolHelper::buildSymbol("Super", symbols);
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ModelBodySectionType, resource, symbols);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ModelBodySectionType, resource, 0, symbols);
 
     REQUIRE(resource.report.error.code != Error::OK);
 }

--- a/test/test-ValuesParser.cc
+++ b/test/test-ValuesParser.cc
@@ -33,7 +33,7 @@ TEST_CASE("Recognize values signature", "[values]")
 TEST_CASE("Parse canonical values", "[values]")
 {
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(ValuesFixture, ValuesSectionType, values);
+    SectionParserHelper<Values, ValuesParser>::parse(ValuesFixture, ValuesSectionType, values, ExportSourcemapOption);
 
     REQUIRE(values.report.error.code == Error::OK);
     CHECK(values.report.warnings.empty());
@@ -63,7 +63,7 @@ TEST_CASE("Warn superfluous content in values attribute", "[values]")
     "    + `Hello`\n";
 
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values);
+    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values, ExportSourcemapOption);
 
     REQUIRE(values.report.error.code == Error::OK);
     REQUIRE(values.report.warnings.size() == 1);
@@ -87,7 +87,7 @@ TEST_CASE("Warn about illegal entities in values attribute", "[values]")
     "    + `Hi`\n";
 
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values);
+    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values, ExportSourcemapOption);
 
     REQUIRE(values.report.error.code == Error::OK);
     REQUIRE(values.report.warnings.size() == 1);


### PR DESCRIPTION
By an error the export of source map was turned on as default for all the test cases using `SectionParserHelper::parse`. This was incorrect as the export of source map is not the default behavior of the parser. Therefore most of the existing unit test were run with this option. As the result a code that is not executed during normal parsing was being executed during the tests making the tests not testing the default code path used in normal operating scenarios.

This commit changes the default behavior of `SectionParserHelper::parse()` to NOT use the `ExportSourcemapOption` option. This change alone is not enough to address the issue described above as most of the existing test are still executing code that is not normally executed. For that a much bigger change is needed – to separate source map related unit tests for other unit test.

The coupling of unit tests cases clearly points to the issue in the current test code base where many of the tests are not testing one particular unit (case). Therefore the tests are not relying on other test covering their respective test cases. This results in duplicate tests, more code, higher complexity and thus worse maintenance.
