### PR TITLE
add an option to CLI tool for reporting annotation by line and column number

### DIFF
--- a/features/validate.feature
+++ b/features/validate.feature
@@ -42,5 +42,5 @@ Feature: Validate a blueprint
     Then the output should contain:
     """
     OK.
-    warning: (5)  unexpected header block, expected a group, resource or an action definition, e.g. '# Group <name>', '# <resource name> [<URI>]' or '# <HTTP method> <URI>' : on line 4, column 1 - line 4, column 29
+    warning: (5)  unexpected header block, expected a group, resource or an action definition, e.g. '# Group <name>', '# <resource name> [<URI>]' or '# <HTTP method> <URI>'; line 4, column 1 - line 4, column 29
     """


### PR DESCRIPTION
fixes issue #162.
In the mentioned issue there is a need for reporting annotation with line and column number, in order to make them more readable for human to debug their code.
In this PR a function has been added [`snowcrash.cc`](https://github.com/alikh31/snowcrash/commit/d8397c2e1b6f7bcc74b3a9357284231408dd93d3#diff-6a5a8e0ab7a5b957ab294981f601a3d4R42) to convert character map into line number, in order to do so there is the need of passing the blueprint source string to the mentioned function for being able to count the lines and columns accordingly. inside the function by two `for` loop the function returns the starting and ending of character map + length.
There are also some notation fix for `snowcrash.cc` for constancy of the code in compare with snowcrash library.
