### PR TITLE
Conteinarize snowcrash environment using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:12.04
+MAINTAINER Lukas Linhart "lukas@apiary.io"
+
+RUN ["apt-get", "-yq", "install", "sudo"]
+
+ADD ./provisioning.sh /
+
+RUN ["sh", "/provisioning.sh"]
+
+ADD ./ /snowcrash
+
+WORKDIR /snowcrash
+
+RUN ["./configure", "--include-integration-tests"]
+
+CMD ["make", "test"]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,19 @@ Refer to [AST Serialization Media Types](https://github.com/apiaryio/api-bluepri
 	```
 	
 We love **Windows** too! Please refer to [Building on Windows](https://github.com/apiaryio/snowcrash/wiki/Building-on-Windows).
-		
+
+## Build using docker
+
+	```sh
+	$ sudo docker build -t "apiaryio/snowcrash" . && sudo docker run -it "apiaryio/snowcrash"
+	```
+
+If you want to debug the environment, you can enter the container using
+
+	```sh
+	$ sudo docker run -it "apiaryio/snowcrash" /bin/bash
+	```
+
 ### Snow Crash command line tool
 1. Build `snowcrash`:
 	

--- a/provisioning.sh
+++ b/provisioning.sh
@@ -5,7 +5,7 @@ sudo apt-get update -y
 sudo apt-get install -y python-software-properties
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -y
-sudo apt-get install -y gcc-4.7 g++-4.7 gdb build-essential git-core
+sudo apt-get install -y gcc-4.7 g++-4.7 gdb build-essential git-core libgemplugin-ruby
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6 
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-4.7 
 


### PR DESCRIPTION
Few notes:
- The `libgemplugin-ruby` is needed to make `gem` command available
- It would be better to move `provisioning.sh` directly into `Dockerfile` because of caches, but wanted to keep things DRY. The "proper DRY" solution would be to run docker inside Vagrant, but don't want to impose that
- It might be worth uploading the image to DockerHub when snowcrash is released. Do that with `docker build apiaryio/snowcrash:$version . && docker push apiaryio/snowcrash:$version`. 
