### PR TITLE
Implement Asset Object

### DIFF
--- a/features/fixtures/ast.json
+++ b/features/fixtures/ast.json
@@ -27,7 +27,17 @@
               }
             ],
             "body": "<resource model body>\n",
-            "schema": "<resource model schema>\n"
+            "schema": "<resource model schema>\n",
+            "assets": {
+              "body": {
+                "source": "<resource model body>\n",
+                "resolved": ""
+              },
+              "schema": {
+                "source": "<resource model schema>\n",
+                "resolved": ""
+              }
+            }
           },
           "parameters": [
             {
@@ -91,7 +101,17 @@
                         }
                       ],
                       "body": "<request body>\n",
-                      "schema": "<request schema>\n"
+                      "schema": "<request schema>\n",
+                      "assets": {
+                        "body": {
+                          "source": "<request body>\n",
+                          "resolved": ""
+                        },
+                        "schema": {
+                          "source": "<request schema>\n",
+                          "resolved": ""
+                        }
+                      }
                     }
                   ],
                   "responses": [
@@ -117,7 +137,17 @@
                         }
                       ],
                       "body": "<response body>\n",
-                      "schema": "<response schema>\n"
+                      "schema": "<response schema>\n",
+                      "assets": {
+                        "body": {
+                          "source": "<response body>\n",
+                          "resolved": ""
+                        },
+                        "schema": {
+                          "source": "<response schema>\n",
+                          "resolved": ""
+                        }
+                      }
                     },
                     {
                       "name": "201",
@@ -140,7 +170,17 @@
                         }
                       ],
                       "body": "<resource model body>\n",
-                      "schema": "<resource model schema>\n"
+                      "schema": "<resource model schema>\n",
+                      "assets": {
+                        "body": {
+                          "source": "<resource model body>\n",
+                          "resolved": ""
+                        },
+                        "schema": {
+                          "source": "<resource model schema>\n",
+                          "resolved": ""
+                        }
+                      }
                     }
                   ]
                 }

--- a/features/fixtures/ast.yaml
+++ b/features/fixtures/ast.yaml
@@ -23,6 +23,13 @@ resourceGroups:
               value: "<header1 value>"
           body: "<resource model body>\n"
           schema: "<resource model schema>\n"
+          assets:
+            body:
+              source: "<resource model body>\n"
+              resolved: ""
+            schema:
+              source: "<resource model schema>\n"
+              resolved: ""
         parameters:
           -
             name: "parameter"
@@ -73,6 +80,13 @@ resourceGroups:
                         value: "<header4 value>"
                     body: "<request body>\n"
                     schema: "<request schema>\n"
+                    assets:
+                      body:
+                        source: "<request body>\n"
+                        resolved: ""
+                      schema:
+                        source: "<request schema>\n"
+                        resolved: ""
                 responses:
                   -
                     name: "200"
@@ -92,6 +106,13 @@ resourceGroups:
                         value: "<header5 value>"
                     body: "<response body>\n"
                     schema: "<response schema>\n"
+                    assets:
+                      body:
+                        source: "<response body>\n"
+                        resolved: ""
+                      schema:
+                        source: "<response schema>\n"
+                        resolved: ""
                   -
                     name: "201"
                     reference:
@@ -109,3 +130,10 @@ resourceGroups:
                         value: "<header1 value>"
                     body: "<resource model body>\n"
                     schema: "<resource model schema>\n"
+                    assets:
+                      body:
+                        source: "<resource model body>\n"
+                        resolved: ""
+                      schema:
+                        source: "<resource model schema>\n"
+                        resolved: ""

--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -191,10 +191,10 @@ namespace snowcrash {
                 !out.node.examples.empty() &&
                 !out.node.examples.back().responses.empty()) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().responses.back().body);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().responses.back().assets.body.source);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.examples.collection.back().responses.collection.back().body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.examples.collection.back().responses.collection.back().assets.body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -207,10 +207,10 @@ namespace snowcrash {
                 !out.node.examples.empty() &&
                 !out.node.examples.back().requests.empty()) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().requests.back().body);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().requests.back().assets.body.source);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.examples.collection.back().requests.collection.back().body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.examples.collection.back().requests.collection.back().assets.body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -382,7 +382,7 @@ namespace snowcrash {
 
                 HTTPMethodTraits methodTraits = GetMethodTrait(out.node.method);
 
-                if (!methodTraits.allowBody && !payload.body.empty()) {
+                if (!methodTraits.allowBody && !payload.assets.body.source.empty()) {
 
                     // WARN: Edge case for 2xx CONNECT
                     if (out.node.method == HTTPMethodName::Connect && code/100 == 2) {
@@ -393,7 +393,8 @@ namespace snowcrash {
                         out.report.warnings.push_back(Warning(ss.str(),
                                                               EmptyDefinitionWarning,
                                                               sourceMap));
-                    } else if (out.node.method != HTTPMethodName::Connect && !methodTraits.allowBody) {
+                    }
+                    else if (out.node.method != HTTPMethodName::Connect && !methodTraits.allowBody) {
 
                         std::stringstream ss;
                         ss << "the response for " << out.node.method << " request MUST NOT include a " << SectionName(BodySectionType);

--- a/src/AssetParser.h
+++ b/src/AssetParser.h
@@ -42,10 +42,10 @@ namespace snowcrash {
                                                      SectionLayout& layout,
                                                      const ParseResultRef<Asset>& out) {
 
-            out.node = "";
-            CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node);
+            out.node.source = "";
+            CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node.source);
 
-            if (pd.exportSourceMap() && !out.node.empty()) {
+            if (pd.exportSourceMap() && !out.node.source.empty()) {
                 out.sourceMap.sourceMap.append(node->sourceMap);
             }
 
@@ -62,7 +62,7 @@ namespace snowcrash {
             mdp::ByteBuffer content;
             CodeBlockUtility::contentAsCodeBlock(node, pd, out.report, content);
 
-            out.node += content;
+            out.node.source += content;
 
             if (pd.exportSourceMap() && !content.empty()) {
                 out.sourceMap.sourceMap.append(node->sourceMap);

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -54,9 +54,6 @@ namespace snowcrash {
     /** A generic key - value pair */
     typedef std::pair<std::string, std::string> KeyValuePair;
 
-    /** An asset data */
-    typedef std::string Asset;
-
     /**
      *  \brief Metadata key-value pair,
      *
@@ -85,6 +82,16 @@ namespace snowcrash {
         UndefinedParameterUse,
         OptionalParameterUse,
         RequiredParameterUse
+    };
+
+    /** Asset */
+    struct Asset {
+
+        /** Asset as written in source */
+        std::string source;
+
+        /** Asset as resolved by tooling */
+        std::string resolved;
     };
 
     /** Parameter */
@@ -181,6 +188,16 @@ namespace snowcrash {
      */
     struct Payload {
 
+        /** Assets Structure of the Payload */
+        struct Assets {
+
+            /** Body */
+            Asset body;
+
+            /** Schema */
+            Asset schema;
+        };
+
         /** A Payload Name */
         Name name;
 
@@ -196,11 +213,11 @@ namespace snowcrash {
         /** Payload-specific Attributes */
         Attributes attributes;
 
-        /** Body */
-        Asset body;
+        /** Body (deprecated - only present in serialization & c-interface) */
+        /** Schema (deprecated - only present in serialization & c-interface) */
 
-        /** Schema */
-        Asset schema;
+        /** Assets of the Payload */
+        Assets assets;
 
         /** Reference */
         Reference reference;

--- a/src/BlueprintSourcemap.h
+++ b/src/BlueprintSourcemap.h
@@ -73,6 +73,19 @@ namespace snowcrash {
     SOURCE_MAP_COLLECTION(DataStructure, DataStructures)
 
     /**
+     * Source Map Structure for Assets in Payload
+     */
+    template<>
+    struct SourceMap<Payload::Assets> : public SourceMapBase {
+
+        /** Source Map of Body */
+        SourceMap<Asset> body;
+
+        /** Source Map of Schema */
+        SourceMap<Asset> schema;
+    };
+
+    /**
      * Source Map Structure for Payload
      */
     template<>
@@ -93,11 +106,11 @@ namespace snowcrash {
         /** Source Map of Payload-specific Attributes */
         SourceMap<Attributes> attributes;
 
-        /** Source Map of Body */
-        SourceMap<Asset> body;
+        /** Source Map of Body (deprecated - only present in serialization & c-interface) */
+        /** Source Map of Schema (deprecated - only present in serialization & c-interface) */
 
-        /** Source Map of Schema */
-        SourceMap<Asset> schema;
+        /** Source Map of Assets */
+        SourceMap<Payload::Assets> assets;
 
         /** Source Map of Model Reference */
         SourceMap<Reference> reference;

--- a/src/CBlueprint.cc
+++ b/src/CBlueprint.cc
@@ -267,7 +267,7 @@ SC_API const char* sc_payload_body(const sc_payload_t* handle)
     if(!p)
         return "";
 
-    return p->body.c_str();
+    return p->assets.body.source.c_str();
 }
 
 SC_API const char* sc_payload_schema(const sc_payload_t* handle)
@@ -276,7 +276,45 @@ SC_API const char* sc_payload_schema(const sc_payload_t* handle)
     if(!p)
         return "";
 
-    return p->schema.c_str();
+    return p->assets.schema.source.c_str();
+}
+
+/*----------------------------------------------------------------------*/
+
+SC_API const sc_asset_t* sc_asset_body_handle(const sc_payload_t* handle)
+{
+    const snowcrash::Payload* p = AS_CTYPE(snowcrash::Payload, handle);
+    if (!p)
+        return NULL;
+
+    return AS_CTYPE(sc_asset_t, &p->assets.body);
+}
+
+SC_API const sc_asset_t* sc_asset_schema_handle(const sc_payload_t* handle)
+{
+    const snowcrash::Payload* p = AS_CTYPE(snowcrash::Payload, handle);
+    if (!p)
+        return NULL;
+
+    return AS_CTYPE(sc_asset_t, &p->assets.schema);
+}
+
+SC_API const char* sc_asset_source(const sc_asset_t* handle)
+{
+    const snowcrash::Asset* p = AS_CTYPE(snowcrash::Asset, handle);
+    if (!p)
+        return "";
+
+    return p->source.c_str();
+}
+
+SC_API const char* sc_asset_resolved(const sc_asset_t* handle)
+{
+    const snowcrash::Asset* p = AS_CTYPE(snowcrash::Asset, handle);
+    if (!p)
+        return "";
+
+    return p->resolved.c_str();
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/CBlueprint.h
+++ b/src/CBlueprint.h
@@ -82,6 +82,10 @@ extern "C" {
     struct sc_payload_s;
     typedef struct sc_payload_s sc_payload_t;
 
+    /** Class Asset wrapper */
+    struct sc_asset_s;
+    typedef struct sc_asset_s sc_asset_t;
+
     /** Array Parameter wrapper */
     struct sc_parameter_collection_s;
     typedef struct sc_parameter_collection_s sc_parameter_collection_t;
@@ -226,6 +230,20 @@ extern "C" {
 
     /** \returns Payload schema */
     SC_API const char* sc_payload_schema(const sc_payload_t* handle);
+
+    /*----------------------------------------------------------------------*/
+
+    /** \returns Body asset handle from payload */
+    SC_API const sc_asset_t* sc_asset_body_handle(const sc_payload_t* handle);
+
+    /** \returns Schema asset handle from payload */
+    SC_API const sc_asset_t* sc_asset_schema_handle(const sc_payload_t* handle);
+
+    /** \returns Asset source */
+    SC_API const char* sc_asset_source(const sc_asset_t* handle);
+
+    /** \returns Asset resolved */
+    SC_API const char* sc_asset_resolved(const sc_asset_t* handle);
 
     /*----------------------------------------------------------------------*/
 

--- a/src/CBlueprintSourcemap.cc
+++ b/src/CBlueprintSourcemap.cc
@@ -287,7 +287,7 @@ SC_API const sc_source_map_t* sc_sm_payload_body(const sc_sm_payload_t* handle)
     if(!p)
         return NULL;
 
-    return AS_CTYPE(sc_source_map_t, &p->body.sourceMap);
+    return AS_CTYPE(sc_source_map_t, &p->assets.body.sourceMap);
 }
 
 SC_API const sc_source_map_t* sc_sm_payload_schema(const sc_sm_payload_t* handle)
@@ -296,7 +296,7 @@ SC_API const sc_source_map_t* sc_sm_payload_schema(const sc_sm_payload_t* handle
     if(!p)
         return NULL;
 
-    return AS_CTYPE(sc_source_map_t, &p->schema.sourceMap);
+    return AS_CTYPE(sc_source_map_t, &p->assets.schema.sourceMap);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ModelTable.h
+++ b/src/ModelTable.h
@@ -62,7 +62,7 @@ namespace snowcrash {
              it != modelTable.end();
              ++it) {
 
-            std::cout << "- " << it->first << " - body: '" << sos::escapeNewlines(it->second.body) << "'\n";
+            std::cout << "- " << it->first << " - body: '" << sos::escapeNewlines(it->second.assets.body.source) << "'\n";
         }
 
         std::cout << std::endl;

--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -83,11 +83,11 @@ namespace snowcrash {
                     // NOTE: NOT THE CORRECT WAY TO DO THIS
                     // https://github.com/apiaryio/snowcrash/commit/a7c5868e62df0048a85e2f9aeeb42c3b3e0a2f07#commitcomment-7322085
                     pd.sectionsContext.push_back(BodySectionType);
-                    CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node.body);
+                    CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node.assets.body.source);
                     pd.sectionsContext.pop_back();
 
-                    if (pd.exportSourceMap() && !out.node.body.empty()) {
-                        out.sourceMap.body.sourceMap.append(node->sourceMap);
+                    if (pd.exportSourceMap() && !out.node.assets.body.source.empty()) {
+                        out.sourceMap.assets.body.sourceMap.append(node->sourceMap);
                     }
                 }
             }
@@ -115,7 +115,7 @@ namespace snowcrash {
                                                       sourceMap));
             } else {
 
-                if (!out.node.body.empty() ||
+                if (!out.node.assets.body.source.empty() ||
                     node->type != mdp::ParagraphMarkdownNodeType ||
                     !parseModelReference(node, pd, node->text, out)) {
 
@@ -125,10 +125,10 @@ namespace snowcrash {
                     CodeBlockUtility::contentAsCodeBlock(node, pd, out.report, content);
                     pd.sectionsContext.pop_back();
 
-                    out.node.body += content;
+                    out.node.assets.body.source += content;
 
                     if (pd.exportSourceMap() && !content.empty()) {
-                        out.sourceMap.body.sourceMap.append(node->sourceMap);
+                        out.sourceMap.assets.body.sourceMap.append(node->sourceMap);
                     }
                 }
             }
@@ -156,7 +156,7 @@ namespace snowcrash {
 
                 case BodySectionType:
                 {
-                    if (!out.node.body.empty()) {
+                    if (!out.node.assets.body.source.empty()) {
                         // WARN: Multiple body section
                         mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceData);
                         out.report.warnings.push_back(Warning("ignoring additional 'body' content, it is already defined",
@@ -164,13 +164,13 @@ namespace snowcrash {
                                                               sourceMap));
                     }
 
-                    ParseResultRef<Asset> asset(out.report, out.node.body, out.sourceMap.body);
+                    ParseResultRef<Asset> asset(out.report, out.node.assets.body, out.sourceMap.assets.body);
                     return AssetParser::parse(node, siblings, pd, asset);
                 }
 
                 case SchemaSectionType:
                 {
-                    if (!out.node.schema.empty()) {
+                    if (!out.node.assets.schema.source.empty()) {
                         // WARN: Multiple schema section
                         mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceData);
                         out.report.warnings.push_back(Warning("ignoring additional 'schema' content, it is already defined",
@@ -178,7 +178,7 @@ namespace snowcrash {
                                                               sourceMap));
                     }
 
-                    ParseResultRef<Asset> asset(out.report, out.node.schema, out.sourceMap.schema);
+                    ParseResultRef<Asset> asset(out.report, out.node.assets.schema, out.sourceMap.assets.schema);
                     return AssetParser::parse(node, siblings, pd, asset);
                 }
 
@@ -199,10 +199,10 @@ namespace snowcrash {
                  node->type == mdp::CodeMarkdownNodeType) &&
                 sectionType == BodySectionType) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.body);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.assets.body.source);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.assets.body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -316,10 +316,9 @@ namespace snowcrash {
             SectionType sectionType = pd.sectionContext();
 
             if (sectionType == RequestSectionType || sectionType == RequestBodySectionType) {
-
                 checkRequest(node, pd, out);
-            } else if (sectionType == ResponseSectionType || sectionType == ResponseBodySectionType) {
-
+            }
+            else if (sectionType == ResponseSectionType || sectionType == ResponseBodySectionType) {
                 checkResponse(node, pd, out);
             }
         }
@@ -506,7 +505,6 @@ namespace snowcrash {
                 if (pd.modelTable.find(symbol) == pd.modelTable.end()) {
 
                     out.node.reference.meta.state = Reference::StatePending;
-
                     return true;
                 }
 
@@ -563,8 +561,8 @@ namespace snowcrash {
                 out.node.headers = model.headers;
             }
 
-            out.node.body = model.body;
-            out.node.schema = model.schema;
+            out.node.assets.body.source = model.assets.body.source;
+            out.node.assets.schema.source = model.assets.schema.source;
 
             if (pd.exportSourceMap()) {
 
@@ -572,8 +570,8 @@ namespace snowcrash {
 
                 out.sourceMap.description = modelSM.description;
                 out.sourceMap.parameters = modelSM.parameters;
-                out.sourceMap.body = modelSM.body;
-                out.sourceMap.schema = modelSM.schema;
+                out.sourceMap.assets.body = modelSM.assets.body;
+                out.sourceMap.assets.schema = modelSM.assets.schema;
 
                 if (isPayloadContentType && !isModelContentType) {
                     out.sourceMap.headers.collection.insert(out.sourceMap.headers.collection.end(), modelSM.headers.collection.begin(), modelSM.headers.collection.end());
@@ -611,7 +609,7 @@ namespace snowcrash {
                 }
             }
 
-            if (out.node.body.empty() && out.node.attributes.source.empty() &&
+            if (out.node.assets.body.source.empty() && out.node.attributes.source.empty() &&
                 out.node.reference.meta.state != Reference::StatePending) {
 
                 // Warn when content-length or transfer-encoding is specified or both headers and body are empty
@@ -660,7 +658,7 @@ namespace snowcrash {
             StatusCodeTraits statusCodeTraits = GetStatusCodeTrait(code);
 
             if (!statusCodeTraits.allowBody &&
-                !out.node.body.empty() &&
+                !out.node.assets.body.source.empty() &&
                 out.node.reference.meta.state != Reference::StatePending) {
 
                 // WARN: not empty body

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -151,20 +151,20 @@ namespace snowcrash {
                 (sectionType == ModelBodySectionType ||
                  sectionType == ModelSectionType)) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.model.body);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.model.assets.body.source);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.model.body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.model.assets.body.sourceMap.append(node->sourceMap);
                 }
 
                 // Update model in the model table as well
                 ModelTable::iterator it = pd.modelTable.find(out.node.model.name);
 
                 if (it != pd.modelTable.end()) {
-                    it->second.body = out.node.model.body;
+                    it->second.assets.body.source = out.node.model.assets.body.source;
 
                     if (pd.exportSourceMap()) {
-                        pd.modelSourceMapTable[out.node.model.name].body = out.sourceMap.model.body;
+                        pd.modelSourceMapTable[out.node.model.name].assets.body = out.sourceMap.model.assets.body;
                     }
                 }
 

--- a/src/Serialize.cc
+++ b/src/Serialize.cc
@@ -21,6 +21,7 @@ const std::string SerializeKey::ResourceGroups = "resourceGroups";
 const std::string SerializeKey::Resources = "resources";
 const std::string SerializeKey::URI = "uri";
 const std::string SerializeKey::URITemplate = "uriTemplate";
+const std::string SerializeKey::Assets = "assets";
 const std::string SerializeKey::Actions = "actions";
 const std::string SerializeKey::Action = "action";
 const std::string SerializeKey::Attributes = "attributes";
@@ -39,6 +40,9 @@ const std::string SerializeKey::Required = "required";
 const std::string SerializeKey::Default = "default";
 const std::string SerializeKey::Example = "example";
 const std::string SerializeKey::Values = "values";
+
+const std::string SerializeKey::Source = "source";
+const std::string SerializeKey::Resolved = "resolved";
 
 const std::string SerializeKey::Literal = "literal";
 const std::string SerializeKey::Variable = "variable";

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -32,6 +32,7 @@ namespace snowcrash {
         static const std::string Resources;
         static const std::string URI;
         static const std::string URITemplate;
+        static const std::string Assets;
         static const std::string Actions;
         static const std::string Action;
         static const std::string Attributes;
@@ -51,6 +52,9 @@ namespace snowcrash {
         static const std::string Default;
         static const std::string Example;
         static const std::string Values;
+
+        static const std::string Source;
+        static const std::string Resolved;
 
         static const std::string Literal;
         static const std::string Variable;

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -383,6 +383,19 @@ sos::Object WrapReference(const Reference& reference)
     return referenceObject;
 }
 
+sos::Object WrapAsset(const Asset& asset)
+{
+    sos::Object assetObject;
+
+    // Source
+    assetObject.set(SerializeKey::Source, sos::String(asset.source));
+
+    // Resolved
+    assetObject.set(SerializeKey::Resolved, sos::String(asset.resolved));
+
+    return assetObject;
+}
+
 sos::Object WrapPayload(const Payload& payload)
 {
     sos::Object payloadObject;
@@ -411,10 +424,18 @@ sos::Object WrapPayload(const Payload& payload)
     payloadObject.set(SerializeKey::Headers, headers);
 
     // Body
-    payloadObject.set(SerializeKey::Body, sos::String(payload.body));
+    payloadObject.set(SerializeKey::Body, sos::String(payload.assets.body.source));
 
     // Schema
-    payloadObject.set(SerializeKey::Schema, sos::String(payload.schema));
+    payloadObject.set(SerializeKey::Schema, sos::String(payload.assets.schema.source));
+
+    // Assets
+    sos::Object assets;
+
+    assets.set(SerializeKey::Body, WrapAsset(payload.assets.body));
+    assets.set(SerializeKey::Schema, WrapAsset(payload.assets.schema));
+
+    payloadObject.set(SerializeKey::Assets, assets);
 
     return payloadObject;
 }

--- a/src/SerializeSourcemap.cc
+++ b/src/SerializeSourcemap.cc
@@ -177,10 +177,18 @@ sos::Object WrapPayloadSourcemap(const SourceMap<Payload>& payload)
     payloadObject.set(SerializeKey::Headers, headers);
 
     // Body
-    payloadObject.set(SerializeKey::Body, WrapSourcemap(payload.body));
+    payloadObject.set(SerializeKey::Body, WrapSourcemap(payload.assets.body));
 
     // Schema
-    payloadObject.set(SerializeKey::Schema, WrapSourcemap(payload.schema));
+    payloadObject.set(SerializeKey::Schema, WrapSourcemap(payload.assets.schema));
+
+    // Assets
+    sos::Object assets;
+
+    assets.set(SerializeKey::Body, WrapSourcemap(payload.assets.body));
+    assets.set(SerializeKey::Schema, WrapSourcemap(payload.assets.schema));
+
+    payloadObject.set(SerializeKey::Assets, assets);
 
     return payloadObject;
 }

--- a/test/snowcrashtest.h
+++ b/test/snowcrashtest.h
@@ -93,10 +93,13 @@ namespace snowcrashtest {
 
             model.description = "Foo";
             model.body = "Bar";
-            models.modelTable[name] = model;
+            model.assets.body.source = "Bar";
 
             modelSM.description.sourceMap = sourcemap;
             modelSM.body.sourceMap = sourcemap;
+            modelSM.assets.body.sourceMap = sourcemap;
+
+            models.modelTable[name] = model;
             models.modelSourceMapTable[name] = modelSM;
         }
     };

--- a/test/snowcrashtest.h
+++ b/test/snowcrashtest.h
@@ -92,11 +92,9 @@ namespace snowcrashtest {
             sourcemap.push_back(mdp::BytesRange(0, 1));
 
             model.description = "Foo";
-            model.body = "Bar";
             model.assets.body.source = "Bar";
 
             modelSM.description.sourceMap = sourcemap;
-            modelSM.body.sourceMap = sourcemap;
             modelSM.assets.body.sourceMap = sourcemap;
 
             models.modelTable[name] = model;
@@ -162,7 +160,7 @@ namespace snowcrashtest {
          * If 'nth' is given, check that particular row of the given sourceMap with the
          * given location & length.
          */
-        static void check(mdp::BytesRangeSet& sourceMap, int loc, int len, int nth = 0) {
+        static void check(mdp::BytesRangeSet& sourceMap, int loc, int len, size_t nth = 0) {
 
             if (nth == 0) {
 

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -53,7 +53,7 @@ TEST_CASE("Parsing action", "[action]")
     REQUIRE(action.node.examples.front().responses.size() == 1);
 
     REQUIRE(action.node.examples.front().responses[0].name == "200");
-    REQUIRE(action.node.examples.front().responses[0].body == "OK.\n");
+    REQUIRE(action.node.examples.front().responses[0].assets.body.source == "OK.\n");
     REQUIRE(action.node.examples.front().responses[0].headers.size() == 1);
     REQUIRE(action.node.examples.front().responses[0].headers[0].first == "Content-Type");
     REQUIRE(action.node.examples.front().responses[0].headers[0].second == "text/plain");
@@ -71,9 +71,9 @@ TEST_CASE("Parsing action", "[action]")
     REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
 
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap[0].location == 72);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap[0].length == 7);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].assets.body.sourceMap.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].assets.body.sourceMap[0].location == 72);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].assets.body.sourceMap[0].length == 7);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap.size() == 1);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap[0].location == 41);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap[0].length == 27);
@@ -154,15 +154,15 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
 
     REQUIRE(action.node.examples.front().requests[0].name == "A");
     REQUIRE(action.node.examples.front().requests[0].description == "B");
-    REQUIRE(action.node.examples.front().requests[0].body == "C\n");
-    REQUIRE(action.node.examples.front().requests[0].schema.empty());
+    REQUIRE(action.node.examples.front().requests[0].assets.body.source == "C\n");
+    REQUIRE(action.node.examples.front().requests[0].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().requests[0].parameters.empty());
     REQUIRE(action.node.examples.front().requests[0].headers.empty());
 
     REQUIRE(action.node.examples.front().requests[1].name == "D");
     REQUIRE(action.node.examples.front().requests[1].description == "E");
-    REQUIRE(action.node.examples.front().requests[1].body == "F\n");
-    REQUIRE(action.node.examples.front().requests[1].schema.empty());
+    REQUIRE(action.node.examples.front().requests[1].assets.body.source == "F\n");
+    REQUIRE(action.node.examples.front().requests[1].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().requests[1].parameters.empty());
     REQUIRE(action.node.examples.front().requests[1].headers.empty());
 
@@ -170,15 +170,15 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
 
     REQUIRE(action.node.examples.front().responses[0].name == "200");
     REQUIRE(action.node.examples.front().responses[0].description == "G");
-    REQUIRE(action.node.examples.front().responses[0].body == "H\n");
-    REQUIRE(action.node.examples.front().responses[0].schema.empty());
+    REQUIRE(action.node.examples.front().responses[0].assets.body.source == "H\n");
+    REQUIRE(action.node.examples.front().responses[0].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().responses[0].parameters.empty());
     REQUIRE(action.node.examples.front().responses[0].headers.empty());
 
     REQUIRE(action.node.examples.front().responses[1].name == "200");
     REQUIRE(action.node.examples.front().responses[1].description == "I");
-    REQUIRE(action.node.examples.front().responses[1].body == "J\n");
-    REQUIRE(action.node.examples.front().responses[1].schema.empty());
+    REQUIRE(action.node.examples.front().responses[1].assets.body.source == "J\n");
+    REQUIRE(action.node.examples.front().responses[1].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().responses[1].parameters.empty());
     REQUIRE(action.node.examples.front().responses[1].headers.empty());
 
@@ -216,15 +216,15 @@ TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
 
     REQUIRE(action.node.examples.front().requests.size() == 2);
     REQUIRE(action.node.examples.front().requests[0].name == "A");
-    REQUIRE(action.node.examples.front().requests[0].body.empty());
-    REQUIRE(action.node.examples.front().requests[0].schema.empty());
+    REQUIRE(action.node.examples.front().requests[0].assets.body.source.empty());
+    REQUIRE(action.node.examples.front().requests[0].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().requests[0].parameters.empty());
     REQUIRE(action.node.examples.front().requests[0].headers.empty());
 
     REQUIRE(action.node.examples.front().requests[1].name == "B");
     REQUIRE(action.node.examples.front().requests[1].description.empty());
-    REQUIRE(action.node.examples.front().requests[1].body == "C\n\n");
-    REQUIRE(action.node.examples.front().requests[1].schema.empty());
+    REQUIRE(action.node.examples.front().requests[1].assets.body.source == "C\n\n");
+    REQUIRE(action.node.examples.front().requests[1].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().requests[1].parameters.empty());
     REQUIRE(action.node.examples.front().requests[1].headers.empty());
 
@@ -265,8 +265,8 @@ TEST_CASE("Parse method with foreign item", "[action]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples.front().requests.size() == 1);
     REQUIRE(action.node.examples.front().requests[0].name.empty());
-    REQUIRE(action.node.examples.front().requests[0].body == "Foo\n");
-    REQUIRE(action.node.examples.front().requests[0].schema.empty());
+    REQUIRE(action.node.examples.front().requests[0].assets.body.source == "Foo\n");
+    REQUIRE(action.node.examples.front().requests[0].assets.schema.source.empty());
     REQUIRE(action.node.examples.front().requests[0].parameters.empty());
     REQUIRE(action.node.examples.front().requests[0].headers.empty());
     REQUIRE(action.node.examples.front().responses.size() == 1);
@@ -386,7 +386,7 @@ TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
     REQUIRE(action.node.method == "CONNECT");
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
-    REQUIRE(action.node.examples[0].responses[0].body == "{}\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{}\n");
 
     REQUIRE(action.sourceMap.name.sourceMap.empty());
     REQUIRE(action.sourceMap.method.sourceMap.size() == 1);
@@ -415,7 +415,7 @@ TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
     REQUIRE(action.node.method == "HEAD");
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
-    REQUIRE(action.node.examples[0].responses[0].body == "{}\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{}\n");
 
     REQUIRE(action.sourceMap.name.sourceMap.empty());
     REQUIRE(action.sourceMap.method.sourceMap.size() == 1);

--- a/test/test-AssetParser.cc
+++ b/test/test-AssetParser.cc
@@ -66,7 +66,8 @@ TEST_CASE("Parse body asset", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node == "Lorem Ipsum\n");
+    REQUIRE(asset.node.source == "Lorem Ipsum\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -80,7 +81,8 @@ TEST_CASE("Parse schema asset", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node == "Dolor Sit Amet\n");
+    REQUIRE(asset.node.source == "Dolor Sit Amet\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 14);
@@ -100,7 +102,8 @@ TEST_CASE("Foreign block inside", "[asset]")
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
-    REQUIRE(asset.node == "Lorem Ipsum\nHello World!\n");
+    REQUIRE(asset.node.source == "Lorem Ipsum\nHello World!\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 2);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -122,7 +125,8 @@ TEST_CASE("Nested list block inside", "[asset]")
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
-    REQUIRE(asset.node == "Lorem Ipsum\n+ Hello World!\n");
+    REQUIRE(asset.node.source == "Lorem Ipsum\n+ Hello World!\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 2);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -145,7 +149,8 @@ TEST_CASE("Multiline signature", "[asset]")
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
-    REQUIRE(asset.node == "Multiline Signature Content\nHello World!\n");
+    REQUIRE(asset.node.source == "Multiline Signature Content\nHello World!\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 3);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 2);
@@ -174,7 +179,8 @@ TEST_CASE("Multiple blocks", "[asset]")
     REQUIRE(asset.report.warnings.size() == 2);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
     REQUIRE(asset.report.warnings[1].code == IndentationWarning);
-    REQUIRE(asset.node == "Block 1\n\nBlock 2\nBlock 3\n");
+    REQUIRE(asset.node.source == "Block 1\n\nBlock 2\nBlock 3\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 3);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -197,7 +203,8 @@ TEST_CASE("Extra spaces before signature", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node == "Lorem Ipsum\n");
+    REQUIRE(asset.node.source == "Lorem Ipsum\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 14);
@@ -216,7 +223,8 @@ TEST_CASE("Asset parser greediness", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node == "Lorem Ipsum\n");
+    REQUIRE(asset.node.source == "Lorem Ipsum\n");
+    REQUIRE(asset.node.resolved.empty());
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -161,7 +161,7 @@ TEST_CASE("Parse API with Name and abbreviated resource", "[blueprint]")
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions.front().examples.size() == 1);
     REQUIRE(resource.actions.front().examples.front().responses.size() == 1);
-    REQUIRE(resource.actions.front().examples.front().responses.front().body == "{}\n");
+    REQUIRE(resource.actions.front().examples.front().responses.front().assets.body.source == "{}\n");
 
     REQUIRE(blueprint.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(blueprint.sourceMap.name.sourceMap[0].location == 0);

--- a/test/test-Indentation.cc
+++ b/test/test-Indentation.cc
@@ -38,7 +38,7 @@ TEST_CASE("Correct indentation", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n");
 }
 
 TEST_CASE("No Indentation & No Newline", "[indentation]")
@@ -59,7 +59,7 @@ TEST_CASE("No Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
 }
 
 TEST_CASE("No Indentation", "[indentation]")
@@ -81,7 +81,7 @@ TEST_CASE("No Indentation", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
 }
 
 TEST_CASE("Poor Indentation & No Newline", "[indentation]")
@@ -102,7 +102,7 @@ TEST_CASE("Poor Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
 }
 
 TEST_CASE("Poor Indentation", "[indentation]")
@@ -124,7 +124,7 @@ TEST_CASE("Poor Indentation", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n");
 }
 
 TEST_CASE("OK Indentation & No Newline", "[indentation]")
@@ -145,7 +145,7 @@ TEST_CASE("OK Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "    { ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "    { ... }\n\n");
 }
 
 TEST_CASE("Full syntax - correct", "[indentation]")
@@ -166,7 +166,7 @@ TEST_CASE("Full syntax - correct", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n");
 }
 
 TEST_CASE("Full syntax - Poor Body Indentation", "[indentation]")
@@ -189,7 +189,7 @@ TEST_CASE("Full syntax - Poor Body Indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body.empty());
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
 }
 
 TEST_CASE("Full syntax - Poor Body & Body Asset Indentation", "[indentation]")
@@ -212,7 +212,7 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body.empty());
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
 }
 
 TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline", "[indentation]")
@@ -234,7 +234,7 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline", "[ind
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body.empty());
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
 }
 
 TEST_CASE("Full syntax - No Indentation", "[indentation]")
@@ -259,7 +259,7 @@ TEST_CASE("Full syntax - No Indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
 }
 
 TEST_CASE("Full syntax - No Indentation & No Newline", "[indentation]")
@@ -281,7 +281,7 @@ TEST_CASE("Full syntax - No Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body.empty());
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
 }
 
 TEST_CASE("Full syntax - Extra indentation", "[indentation]")
@@ -305,7 +305,7 @@ TEST_CASE("Full syntax - Extra indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "+ Body\n\n        { ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "+ Body\n\n        { ... }\n");
 }
 
 TEST_CASE("No Indentation & No Newline multi-line", "[indentation]")
@@ -332,5 +332,5 @@ TEST_CASE("No Indentation & No Newline multi-line", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "{\nHello\n}\n");
+    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{\nHello\n}\n");
 }

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -98,8 +98,8 @@ TEST_CASE("Parse request payload", "[payload]")
     REQUIRE(payload.node.headers[0].second == "text/plain");
     REQUIRE(payload.node.headers[1].first == "X-Header");
     REQUIRE(payload.node.headers[1].second == "42");
-    REQUIRE(payload.node.body == "Code\n");
-    REQUIRE(payload.node.schema == "Code 2\n");
+    REQUIRE(payload.node.assets.body.source == "Code\n");
+    REQUIRE(payload.node.assets.schema.source == "Code 2\n");
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -115,12 +115,12 @@ TEST_CASE("Parse request payload", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[1].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[1].sourceMap[0].location == 74);
     REQUIRE(payload.sourceMap.headers.collection[1].sourceMap[0].length == 17);
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 112);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 9);
-    REQUIRE(payload.sourceMap.schema.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.schema.sourceMap[0].location == 144);
-    REQUIRE(payload.sourceMap.schema.sourceMap[0].length == 11);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 112);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 9);
+    REQUIRE(payload.sourceMap.assets.schema.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.schema.sourceMap[0].location == 144);
+    REQUIRE(payload.sourceMap.assets.schema.sourceMap[0].length == 11);
 }
 
 TEST_CASE("Parse abbreviated payload body", "[payload]")
@@ -135,8 +135,8 @@ TEST_CASE("Parse abbreviated payload body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.size() == 1);
-    REQUIRE(payload.node.body == "Hello World!\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -147,9 +147,9 @@ TEST_CASE("Parse abbreviated payload body", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].location == 2);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].length == 27);
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 33);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 33);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
 }
 
 TEST_CASE("Parse abbreviated inline payload body", "[payload]")
@@ -167,8 +167,8 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "Hello World!\nB\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Hello World!\nB\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -176,11 +176,11 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 2);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 17);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
-    REQUIRE(payload.sourceMap.body.sourceMap[1].location == 36);
-    REQUIRE(payload.sourceMap.body.sourceMap[1].length == 2);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 2);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 17);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].location == 36);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].length == 2);
 }
 
 TEST_CASE("Parse payload description with list", "[payload]")
@@ -212,8 +212,8 @@ TEST_CASE("Parse payload description with list", "[payload]")
     REQUIRE(payload.node.description == "+ B\n");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "{}\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "{}\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 1);
@@ -221,9 +221,9 @@ TEST_CASE("Parse payload description with list", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap[0].length == 4);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 40);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 7);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 40);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 7);
 }
 
 TEST_CASE("Parse payload with foreign list item", "[payload]")
@@ -255,16 +255,16 @@ TEST_CASE("Parse payload with foreign list item", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "{}\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "{}\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 31);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 7);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 31);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 7);
 }
 
 TEST_CASE("Parse payload with dangling body", "[payload]")
@@ -295,18 +295,18 @@ TEST_CASE("Parse payload with dangling body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "Foo\nBar\n\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Foo\nBar\n\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 2);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 30);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 8);
-    REQUIRE(payload.sourceMap.body.sourceMap[1].location == 43);
-    REQUIRE(payload.sourceMap.body.sourceMap[1].length == 4);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 2);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 30);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 8);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].location == 43);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].length == 4);
 }
 
 TEST_CASE("Parse inline payload with symbol reference", "[payload]")
@@ -324,8 +324,8 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     REQUIRE(payload.node.description == "Foo");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "Bar");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Bar");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 1);
@@ -333,9 +333,9 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap[0].length == 1);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 0);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 0);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 1);
 }
 
 TEST_CASE("Parse inline payload with symbol reference with extra indentation", "[payload]")
@@ -358,16 +358,16 @@ TEST_CASE("Parse inline payload with symbol reference with extra indentation", "
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "[Symbol][]\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "[Symbol][]\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 15);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 15);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 15);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 15);
 }
 
 TEST_CASE("Parse inline payload with symbol reference with foreign content", "[payload]")
@@ -388,8 +388,8 @@ TEST_CASE("Parse inline payload with symbol reference with foreign content", "[p
     REQUIRE(payload.node.description == "Foo");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "Bar");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Bar");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 1);
@@ -397,9 +397,9 @@ TEST_CASE("Parse inline payload with symbol reference with foreign content", "[p
     REQUIRE(payload.sourceMap.description.sourceMap[0].length == 1);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 0);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 0);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 1);
 }
 
 TEST_CASE("Parse named model", "[payload]")
@@ -426,8 +426,8 @@ TEST_CASE("Parse named model", "[payload]")
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Content-Type");
     REQUIRE(payload.node.headers[0].second == "text/plain");
-    REQUIRE(payload.node.body == "Hello World!\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -438,9 +438,9 @@ TEST_CASE("Parse named model", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].location == 2);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].length == 26);
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 32);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 32);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
 }
 
 TEST_CASE("Parse nameless model", "[payload]")
@@ -467,8 +467,8 @@ TEST_CASE("Parse nameless model", "[payload]")
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Content-Type");
     REQUIRE(payload.node.headers[0].second == "text/plain");
-    REQUIRE(payload.node.body == "Hello World!\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
@@ -477,10 +477,10 @@ TEST_CASE("Parse nameless model", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].location == 2);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].length == 20);
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 26);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
-    REQUIRE(payload.sourceMap.schema.sourceMap.empty());
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 26);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.assets.schema.sourceMap.empty());
 }
 
 TEST_CASE("Warn on malformed payload signature", "[payload]")
@@ -514,8 +514,8 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     REQUIRE(payload.node.description == "Description\n\nLine 2\n");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.body == "Hello World!\n");
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
+    REQUIRE(payload.node.assets.schema.source.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 3);
@@ -527,9 +527,9 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap[2].length == 7);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 82);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 82);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
 }
 
 TEST_CASE("Give a warning of empty message body for requests with certain headers", "[payload]")
@@ -550,9 +550,9 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Content-Length");
     REQUIRE(payload.node.headers[0].second == "100");
-    REQUIRE(payload.node.body.empty());
+    REQUIRE(payload.node.assets.body.source.empty());
 
-    REQUIRE(payload.sourceMap.body.sourceMap.empty());
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.empty());
 }
 
 TEST_CASE("Do not report empty message body for requests", "[payload]")
@@ -572,7 +572,7 @@ TEST_CASE("Do not report empty message body for requests", "[payload]")
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Accept");
     REQUIRE(payload.node.headers[0].second == "application/json, application/javascript");
-    REQUIRE(payload.node.body.empty());
+    REQUIRE(payload.node.assets.body.source.empty());
 }
 
 TEST_CASE("Give a warning when 100 response has a body", "[payload]")
@@ -588,7 +588,7 @@ TEST_CASE("Give a warning when 100 response has a body", "[payload]")
     REQUIRE(payload.report.warnings.size() == 1);
     REQUIRE(payload.report.warnings[0].code == EmptyDefinitionWarning);
 
-    REQUIRE(payload.node.body == "{}\n");
+    REQUIRE(payload.node.assets.body.source == "{}\n");
 }
 
 TEST_CASE("Empty body section should shouldn't be parsed as description", "[payload]")
@@ -599,9 +599,9 @@ TEST_CASE("Empty body section should shouldn't be parsed as description", "[payl
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
 
-    REQUIRE(payload.node.body == "");
+    REQUIRE(payload.node.assets.body.source == "");
 
-    REQUIRE(payload.sourceMap.body.sourceMap.empty());
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.empty());
 }
 
 TEST_CASE("Parameters section should be taken as a description node", "[payload]")
@@ -620,7 +620,7 @@ TEST_CASE("Parameters section should be taken as a description node", "[payload]
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.description == "+ Parameters\n\n    + id (string)\n");
-    REQUIRE(payload.node.body == "{}\n");
+    REQUIRE(payload.node.assets.body.source == "{}\n");
 
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 2);
     REQUIRE(payload.sourceMap.description.sourceMap[0].location == 20);
@@ -628,9 +628,9 @@ TEST_CASE("Parameters section should be taken as a description node", "[payload]
     REQUIRE(payload.sourceMap.description.sourceMap[1].location == 38);
     REQUIRE(payload.sourceMap.description.sourceMap[1].length == 18);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
-    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 77);
-    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 7);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 77);
+    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 7);
 }
 
 TEST_CASE("Report ignoring nested request objects", "[payload][#163][#189]")
@@ -653,7 +653,7 @@ TEST_CASE("Report ignoring nested request objects", "[payload][#163][#189]")
     REQUIRE(payload.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(payload.node.headers.size() == 1);
-    REQUIRE(payload.node.body.empty());
+    REQUIRE(payload.node.assets.body.source.empty());
 }
 
 TEST_CASE("Parse a payload with attributes", "[payload]")
@@ -674,8 +674,8 @@ TEST_CASE("Parse a payload with attributes", "[payload]")
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.headers.size() == 1);
-    REQUIRE(payload.node.body.empty());
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source.empty());
+    REQUIRE(payload.node.assets.schema.source.empty());
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.attributes.resolved.empty());
     REQUIRE(payload.node.attributes.source.name.empty());
@@ -701,8 +701,8 @@ TEST_CASE("Parse a request with attributes and no body", "[payload]")
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.headers.size() == 2);
-    REQUIRE(payload.node.body.empty());
-    REQUIRE(payload.node.schema.empty());
+    REQUIRE(payload.node.assets.body.source.empty());
+    REQUIRE(payload.node.assets.schema.source.empty());
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.attributes.resolved.empty());
     REQUIRE(payload.node.attributes.source.name.empty());

--- a/test/test-ResourceGroupParser.cc
+++ b/test/test-ResourceGroupParser.cc
@@ -171,7 +171,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resource1.actions[0].examples[0].requests.size() == 1);
     REQUIRE(resource1.actions[0].examples[0].requests[0].name.empty());
     REQUIRE(resource1.actions[0].examples[0].requests[0].description.empty());
-    REQUIRE(resource1.actions[0].examples[0].requests[0].body.empty());
+    REQUIRE(resource1.actions[0].examples[0].requests[0].assets.body.source.empty());
     REQUIRE(resource1.actions[0].examples[0].responses.empty());
 
     Resource resource2 = resourceGroup.node.resources[1];
@@ -183,7 +183,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resource2.actions[0].examples.size() == 1);
     REQUIRE(resource2.actions[0].examples[0].requests[0].name.empty());
     REQUIRE(resource2.actions[0].examples[0].requests[0].description.empty());
-    REQUIRE(resource2.actions[0].examples[0].requests[0].body.empty());
+    REQUIRE(resource2.actions[0].examples[0].requests[0].assets.body.source.empty());
     REQUIRE(resource2.actions[0].examples[0].responses.empty());
 
     REQUIRE(resourceGroup.sourceMap.name.sourceMap.empty());
@@ -335,7 +335,7 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
     REQUIRE(resourceGroup.node.resources[0].name.empty());
     REQUIRE(resourceGroup.node.resources[0].uriTemplate == "/resource");
     REQUIRE(resourceGroup.node.resources[0].model.name.empty());
-    REQUIRE(resourceGroup.node.resources[0].model.body.empty());
+    REQUIRE(resourceGroup.node.resources[0].model.assets.body.source.empty());
     REQUIRE(resourceGroup.node.resources[0].actions.size() == 1);
     REQUIRE(resourceGroup.node.resources[0].actions[0].method == "GET");
 
@@ -367,13 +367,13 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     REQUIRE(resourceGroup.node.resources[0].name.empty());
     REQUIRE(resourceGroup.node.resources[0].uriTemplate == "/resource");
     REQUIRE(resourceGroup.node.resources[0].model.name.empty());
-    REQUIRE(resourceGroup.node.resources[0].model.body.empty());
+    REQUIRE(resourceGroup.node.resources[0].model.assets.body.source.empty());
     REQUIRE(resourceGroup.node.resources[0].actions.size() == 1);
     REQUIRE(resourceGroup.node.resources[0].actions[0].method == "GET");
     REQUIRE(resourceGroup.node.resources[1].name.empty());
     REQUIRE(resourceGroup.node.resources[1].uriTemplate == "/2");
     REQUIRE(resourceGroup.node.resources[1].model.name.empty());
-    REQUIRE(resourceGroup.node.resources[1].model.body.empty());
+    REQUIRE(resourceGroup.node.resources[1].model.assets.body.source.empty());
     REQUIRE(resourceGroup.node.resources[1].actions.size() == 1);
     REQUIRE(resourceGroup.node.resources[1].actions[0].method == "POST");
 

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -72,7 +72,7 @@ TEST_CASE("Parse resource", "[resource]")
     REQUIRE(resource.node.headers.empty());
 
     REQUIRE(resource.node.model.name == "Resource");
-    REQUIRE(resource.node.model.body == "X.O.\n");
+    REQUIRE(resource.node.model.assets.body.source == "X.O.\n");
 
     REQUIRE(resource.node.parameters.size() == 2);
     REQUIRE(resource.node.parameters[0].name == "id");
@@ -102,9 +102,9 @@ TEST_CASE("Parse resource", "[resource]")
     REQUIRE(resource.sourceMap.model.name.sourceMap.size() == 1);
     REQUIRE(resource.sourceMap.model.name.sourceMap[0].location == 63);
     REQUIRE(resource.sourceMap.model.name.sourceMap[0].length == 29);
-    REQUIRE(resource.sourceMap.model.body.sourceMap.size() == 1);
-    REQUIRE(resource.sourceMap.model.body.sourceMap[0].location == 96);
-    REQUIRE(resource.sourceMap.model.body.sourceMap[0].length == 9);
+    REQUIRE(resource.sourceMap.model.assets.body.sourceMap.size() == 1);
+    REQUIRE(resource.sourceMap.model.assets.body.sourceMap[0].location == 96);
+    REQUIRE(resource.sourceMap.model.assets.body.sourceMap[0].length == 9);
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].method.sourceMap.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].method.sourceMap[0].location == 278);
@@ -131,7 +131,7 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description.empty());
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.body.empty());
+    REQUIRE(resource.node.model.assets.body.source.empty());
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions.front().method == "GET");
     REQUIRE(resource.node.actions.front().description.empty());
@@ -139,7 +139,7 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     REQUIRE(resource.node.actions.front().examples.front().requests.size() == 1);
     REQUIRE(resource.node.actions.front().examples.front().requests.front().name.empty());
     REQUIRE(resource.node.actions.front().examples.front().requests.front().description.empty());
-    REQUIRE(resource.node.actions.front().examples.front().requests.front().body == "p1\n\n");
+    REQUIRE(resource.node.actions.front().examples.front().requests.front().assets.body.source == "p1\n\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
@@ -170,7 +170,7 @@ TEST_CASE("Parse multiple method descriptions", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description.empty());
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.body.empty());
+    REQUIRE(resource.node.model.assets.body.source.empty());
     REQUIRE(resource.node.actions.size() == 2);
     REQUIRE(resource.node.actions[0].method == "GET");
     REQUIRE(resource.node.actions[0].description == "p1\n");
@@ -219,7 +219,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "A\n");
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.body.empty());
+    REQUIRE(resource.node.model.assets.body.source.empty());
     REQUIRE(resource.node.actions.size() == 3);
 
     REQUIRE(resource.node.actions[0].method == "GET");
@@ -229,7 +229,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
     REQUIRE(resource.node.actions[0].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "Code 1\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "Code 1\n");
 
     REQUIRE(resource.node.actions[1].method == "POST");
     REQUIRE(resource.node.actions[1].description == "C\n");
@@ -241,7 +241,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.actions[1].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[1].examples[0].responses[0].name == "200");
     REQUIRE(resource.node.actions[1].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[1].examples[0].responses[0].body == "{}\n");
+    REQUIRE(resource.node.actions[1].examples[0].responses[0].assets.body.source == "{}\n");
 
     REQUIRE(resource.node.actions[2].method == "PUT");
     REQUIRE(resource.node.actions[2].description == "E\n");
@@ -280,7 +280,7 @@ TEST_CASE("Parse description with list", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "+ A\n\n+ B\n\np1\n");
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.body.empty());
+    REQUIRE(resource.node.model.assets.body.source.empty());
     REQUIRE(resource.node.actions.empty());
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -310,7 +310,7 @@ TEST_CASE("Parse resource with a HR", "[resource][block]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "A\n---\n\nB\n");
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.body.empty());
+    REQUIRE(resource.node.model.assets.body.source.empty());
     REQUIRE(resource.node.actions.empty());
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -346,7 +346,7 @@ TEST_CASE("Parse resource method abbreviation", "[resource]")
 
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "{}\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "{}\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
@@ -372,7 +372,7 @@ TEST_CASE("Parse resource without name", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/resource");
     REQUIRE(resource.node.name.empty());
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.body.empty());
+    REQUIRE(resource.node.model.assets.body.source.empty());
     REQUIRE(resource.node.actions.size() == 0);
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -434,7 +434,7 @@ TEST_CASE("Parse nameless resource with named model", "[resource][model][source]
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.model.name == "Super");
-    REQUIRE(resource.node.model.body == "AAA\n");
+    REQUIRE(resource.node.model.assets.body.source == "AAA\n");
     REQUIRE(resource.node.actions.empty());
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -494,14 +494,14 @@ TEST_CASE("Parse named resource with nameless model", "[resource][model][source]
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.model.name == "Message");
-    REQUIRE(resource.node.model.body == "AAA\n");
+    REQUIRE(resource.node.model.assets.body.source == "AAA\n");
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].name == "Retrieve a message");
     REQUIRE(resource.node.actions[0].method == "GET");
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "AAA\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "AAA\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(resource.sourceMap.name.sourceMap[0].location == 0);
@@ -538,14 +538,14 @@ TEST_CASE("Parse model with unrecognised resource", "[resource][model]")
     REQUIRE(resource.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(resource.node.model.name == "Resource");
-    REQUIRE(resource.node.model.body == "AAA\n");
+    REQUIRE(resource.node.model.assets.body.source == "AAA\n");
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].name == "Retrieve a resource");
     REQUIRE(resource.node.actions[0].method == "GET");
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "[Resource][]\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "[Resource][]\n");
     REQUIRE(resource.node.actions[0].examples[0].responses[0].description == "");
 }
 
@@ -583,7 +583,7 @@ TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body == "`resource model` 2\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source == "`resource model` 2\n");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].headers.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].headers[0].first == "Content-Type");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].headers[0].second == "text/plain");
@@ -650,7 +650,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests.size() == 1);
 
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests[0].name == "");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests[0].body == "{ item }\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests[0].assets.body.source == "{ item }\n");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests[0].headers.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests[0].headers[0].first == "Content-Type");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].requests[0].headers[0].second == "application/json");
@@ -661,7 +661,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
 
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body == "[ { item 1 }, { item 2 } ]\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source == "[ { item 1 }, { item 2 } ]\n");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].headers.size() == 1);
 
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].reference.id == "Collection of Items");
@@ -863,7 +863,7 @@ TEST_CASE("Parse resource with multi-word named model", "[resource][model]")
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.model.name == "a really good name");
-    REQUIRE(resource.node.model.body == "body of the `model`\n");
+    REQUIRE(resource.node.model.assets.body.source == "body of the `model`\n");
     REQUIRE(resource.node.actions.empty());
 }
 
@@ -901,22 +901,22 @@ TEST_CASE("Dangling transaction example assets", "[resource]")
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].requests.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].requests[0].name == "A");
-    REQUIRE(resource.node.actions[0].examples[0].requests[0].body == "dangling request body\n\n");
+    REQUIRE(resource.node.actions[0].examples[0].requests[0].assets.body.source == "dangling request body\n\n");
 
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "dangling response body\n\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "dangling response body\n\n");
 
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].examples.collection.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap[0].location == 29);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap[0].length == 33);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].assets.body.sourceMap.size() == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].assets.body.sourceMap[0].location == 29);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].assets.body.sourceMap[0].length == 33);
     REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap[0].location == 78);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap[0].length == 31);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].assets.body.sourceMap.size() == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].assets.body.sourceMap[0].location == 78);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].assets.body.sourceMap[0].length == 31);
 }
 
 TEST_CASE("Body list item in description", "[resource][regression][#190]")

--- a/test/test-csnowcrash.cc
+++ b/test/test-csnowcrash.cc
@@ -131,6 +131,15 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     REQUIRE(std::string(sc_payload_name(resp)) == "200");
     REQUIRE(std::string(sc_payload_body(resp)) == "Hello World!\n");
 
+    const sc_asset_t* asset_body = sc_asset_body_handle(resp);
+    const sc_asset_t* asset_schema = sc_asset_schema_handle(resp);
+
+    REQUIRE(std::string(sc_asset_source(asset_body)) == "Hello World!\n");
+    REQUIRE(std::string(sc_asset_resolved(asset_body)) == "");
+
+    REQUIRE(std::string(sc_asset_source(asset_schema)) == "");
+    REQUIRE(std::string(sc_asset_resolved(asset_schema)) == "");
+
     const sc_source_map_t* sm_resp_name = sc_sm_payload_name(sm_resp);
     const sc_source_map_t* sm_resp_body = sc_sm_payload_body(sm_resp);
 

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -68,7 +68,7 @@ TEST_CASE("Parse simple blueprint", "[parser]")
 
     Response& response = action.examples.front().responses[0];
     REQUIRE(response.name == "200");
-    REQUIRE(response.body == "Text\n\n{ ... }\n");
+    REQUIRE(response.assets.body.source == "Text\n\n{ ... }\n");
 }
 
 TEST_CASE("Parse blueprint with unsupported characters", "[parser]")
@@ -128,7 +128,7 @@ TEST_CASE("Support description ending with an list item", "[parser][#8]")
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body == "...\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source == "...\n");
 }
 
 TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[parser][#13]")
@@ -150,7 +150,7 @@ TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "304");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body.empty());
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source.empty());
 }
 
 TEST_CASE("SIGTERM parsing blueprint", "[parser][#45]")
@@ -206,9 +206,9 @@ TEST_CASE("Parse adjacent asset blocks", "[parser][#9]")
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 2);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body == "asset\n\npre\n\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source == "asset\n\npre\n\n");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[1].name == "404");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[1].body == "Not found\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[1].assets.body.source == "Not found\n");
 }
 
 TEST_CASE("Parse adjacent asset list blocks", "[parser][#9]")
@@ -231,7 +231,7 @@ TEST_CASE("Parse adjacent asset list blocks", "[parser][#9]")
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].description.empty());
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body.empty());
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source.empty());
 }
 
 TEST_CASE("Parse adjacent nested asset blocks", "[parser][#9]")
@@ -260,7 +260,7 @@ TEST_CASE("Parse adjacent nested asset blocks", "[parser][#9]")
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].description.empty());
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].body == "A\nB\nC\n\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].actions[0].examples[0].responses[0].assets.body.source == "A\nB\nC\n\n");
 }
 
 TEST_CASE("Exception while parsing a blueprint with leading empty space", "[regression][parser]")
@@ -381,7 +381,7 @@ TEST_CASE("Dangling block not recognized", "[parser][regression][#186]")
     REQUIRE(blueprint.node.resourceGroups[0].resources.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].name == "A");
     REQUIRE(blueprint.node.resourceGroups[0].resources[0].uriTemplate == "/a");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[0].model.body == "    { ... }\n\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[0].model.assets.body.source == "    { ... }\n\n");
 }
 
 TEST_CASE("Ignoring block recovery", "[parser][regression][#188]")
@@ -441,7 +441,7 @@ TEST_CASE("Ignoring dangling model assets", "[parser][regression][#196]")
     REQUIRE(blueprint.node.resourceGroups[0].resources[1].actions[0].examples.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[1].actions[0].examples[0].responses.size() == 1);
     REQUIRE(blueprint.node.resourceGroups[0].resources[1].actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(blueprint.node.resourceGroups[0].resources[1].actions[0].examples[0].responses[0].body == "{ A }\n\n");
+    REQUIRE(blueprint.node.resourceGroups[0].resources[1].actions[0].examples[0].responses[0].assets.body.source == "{ A }\n\n");
 }
 
 TEST_CASE("Ignoring local media type", "[parser][regression][#195]")


### PR DESCRIPTION
Contains parser implementation along with source maps, Serialisation and C-interface.

`payload.body` and `payload.schema` are replaced by `payload.assets.body.source` and `payload.assets.schema.source` respectively in all the needed parsers.

The deprecated `payload.body` and `payload.schema` only live in the serialized output, not in the C++ AST.

https://trello.com/c/78vzrFUU/27-implement-asset-object-in-ast