### PR TITLE
[configure] Use Python2

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# 
+#!/usr/bin/env python2
+#
 # Attribution Notice
 # ------------------
 # This file uses parts of Node.js `configure`.


### PR DESCRIPTION
This pull request changes to use `python2` instead of `python` because `python` is incorrectly `python3` on some systems. Note, [PEP 394](http://legacy.python.org/dev/peps/pep-0394/) actually states that `python` should invoke `python2` and not `python3`.

We can make the configure script work on Python 3, but the dependency (GYP) doesn't yet have Python 3 support. Therefore I have instead made it so we evoke python2. There is an [open issue in their tracker regarding Python 3 support](https://code.google.com/p/gyp/issues/detail?id=36). This issue has been open for 4 years and doesn't seem like there is much interest in getting this fixed.

Closes #261.