### PR TITLE
Attributes Sourcemap & AST changes

### DIFF
--- a/features/fixtures/ast.json
+++ b/features/fixtures/ast.json
@@ -15,18 +15,20 @@
       "description": "<resource group description>\n\n",
       "resources": [
         {
+          "element": "resource",
           "name": "<resource name>",
           "description": "<resource description>\n\n",
           "uriTemplate": "/resource/{parameter}",
           "model": {
             "name": "<resource name>",
-            "description": "<resource model description>",
+            "description": "<resource model description>\n",
             "headers": [
               {
                 "name": "<header1>",
                 "value": "<header1 value>"
               }
             ],
+            "content": [],
             "body": "<resource model body>\n",
             "schema": "<resource model schema>\n",
             "assets": {
@@ -50,7 +52,10 @@
               "example": "<example value>",
               "values": [
                 {
-                  "value": "<element>"
+                  "value": "<default value>"
+                },
+                {
+                  "value": "<example value>"
                 }
               ]
             }
@@ -70,11 +75,15 @@
                   "example": "<example value>",
                   "values": [
                     {
-                      "value": "<element>"
+                      "value": "<default value>"
+                    },
+                    {
+                      "value": "<example value>"
                     }
                   ]
                 }
               ],
+              "content": [],
               "examples": [
                 {
                   "name": "",
@@ -101,6 +110,7 @@
                           "value": "<header4 value>"
                         }
                       ],
+                      "content": [],
                       "body": "<request body>\n",
                       "schema": "<request schema>\n",
                       "assets": {
@@ -137,6 +147,7 @@
                           "value": "<header5 value>"
                         }
                       ],
+                      "content": [],
                       "body": "<response body>\n",
                       "schema": "<response schema>\n",
                       "assets": {
@@ -151,11 +162,11 @@
                       }
                     },
                     {
-                      "name": "201",
                       "reference": {
                         "id": "<resource name>"
                       },
-                      "description": "<resource model description>",
+                      "name": "201",
+                      "description": "<resource model description>\n",
                       "headers": [
                         {
                           "name": "<header2>",
@@ -170,6 +181,7 @@
                           "value": "<header1 value>"
                         }
                       ],
+                      "content": [],
                       "body": "<resource model body>\n",
                       "schema": "<resource model schema>\n",
                       "assets": {
@@ -182,6 +194,104 @@
                           "resolved": ""
                         }
                       }
+                    },
+                    {
+                      "name": "201",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "<header2>",
+                          "value": "<header2 value>"
+                        },
+                        {
+                          "name": "<header3>",
+                          "value": "<header3 value>"
+                        },
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "name": {
+                            "literal": "",
+                            "variable": false
+                          },
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": {
+                                "literal": "<data structure name>",
+                                "variable": false
+                              },
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          },
+                          "sections": []
+                        }
+                      ],
+                      "body": "",
+                      "schema": "",
+                      "assets": {
+                        "body": {
+                          "source": "",
+                          "resolved": ""
+                        },
+                        "schema": {
+                          "source": "",
+                          "resolved": ""
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": [
+            {
+              "element": "dataStructure",
+              "name": {
+                "literal": "<resource name>",
+                "variable": false
+              },
+              "typeDefinition": {
+                "typeSpecification": {
+                  "name": "object",
+                  "nestedTypes": []
+                },
+                "attributes": []
+              },
+              "sections": [
+                {
+                  "class": "memberType",
+                  "content": [
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "<attribute property name>"
+                        },
+                        "description": "<attribute property description>",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "<attribute property value>",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "number",
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
                     }
                   ]
                 }
@@ -204,19 +314,20 @@
           "content": "<resource group description>\n\n"
         },
         {
+          "element": "resource",
           "name": "<resource name>",
           "description": "<resource description>\n\n",
-          "element": "resource",
           "uriTemplate": "/resource/{parameter}",
           "model": {
             "name": "<resource name>",
-            "description": "<resource model description>",
+            "description": "<resource model description>\n",
             "headers": [
               {
                 "name": "<header1>",
                 "value": "<header1 value>"
               }
             ],
+            "content": [],
             "body": "<resource model body>\n",
             "schema": "<resource model schema>\n",
             "assets": {
@@ -240,7 +351,10 @@
               "example": "<example value>",
               "values": [
                 {
-                  "value": "<element>"
+                  "value": "<default value>"
+                },
+                {
+                  "value": "<example value>"
                 }
               ]
             }
@@ -260,11 +374,15 @@
                   "example": "<example value>",
                   "values": [
                     {
-                      "value": "<element>"
+                      "value": "<default value>"
+                    },
+                    {
+                      "value": "<example value>"
                     }
                   ]
                 }
               ],
+              "content": [],
               "examples": [
                 {
                   "name": "",
@@ -291,6 +409,7 @@
                           "value": "<header4 value>"
                         }
                       ],
+                      "content": [],
                       "body": "<request body>\n",
                       "schema": "<request schema>\n",
                       "assets": {
@@ -327,6 +446,7 @@
                           "value": "<header5 value>"
                         }
                       ],
+                      "content": [],
                       "body": "<response body>\n",
                       "schema": "<response schema>\n",
                       "assets": {
@@ -341,11 +461,11 @@
                       }
                     },
                     {
-                      "name": "201",
                       "reference": {
                         "id": "<resource name>"
                       },
-                      "description": "<resource model description>",
+                      "name": "201",
+                      "description": "<resource model description>\n",
                       "headers": [
                         {
                           "name": "<header2>",
@@ -360,6 +480,7 @@
                           "value": "<header1 value>"
                         }
                       ],
+                      "content": [],
                       "body": "<resource model body>\n",
                       "schema": "<resource model schema>\n",
                       "assets": {
@@ -372,8 +493,164 @@
                           "resolved": ""
                         }
                       }
+                    },
+                    {
+                      "name": "201",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "<header2>",
+                          "value": "<header2 value>"
+                        },
+                        {
+                          "name": "<header3>",
+                          "value": "<header3 value>"
+                        },
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "name": {
+                            "literal": "",
+                            "variable": false
+                          },
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": {
+                                "literal": "<data structure name>",
+                                "variable": false
+                              },
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          },
+                          "sections": []
+                        }
+                      ],
+                      "body": "",
+                      "schema": "",
+                      "assets": {
+                        "body": {
+                          "source": "",
+                          "resolved": ""
+                        },
+                        "schema": {
+                          "source": "",
+                          "resolved": ""
+                        }
+                      }
                     }
                   ]
+                }
+              ]
+            }
+          ],
+          "content": [
+            {
+              "element": "dataStructure",
+              "name": {
+                "literal": "<resource name>",
+                "variable": false
+              },
+              "typeDefinition": {
+                "typeSpecification": {
+                  "name": "object",
+                  "nestedTypes": []
+                },
+                "attributes": []
+              },
+              "sections": [
+                {
+                  "class": "memberType",
+                  "content": [
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "<attribute property name>"
+                        },
+                        "description": "<attribute property description>",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "<attribute property value>",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "number",
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "dataStructure",
+          "name": {
+            "literal": "<data structure name>",
+            "variable": false
+          },
+          "typeDefinition": {
+            "typeSpecification": {
+              "name": {
+                "literal": "",
+                "variable": false
+              },
+              "nestedTypes": []
+            },
+            "attributes": []
+          },
+          "sections": [
+            {
+              "class": "blockDescription",
+              "content": "<data structure description>\n\n"
+            },
+            {
+              "class": "memberType",
+              "content": [
+                {
+                  "content": {
+                    "name": {
+                      "literal": "<data structure property name>"
+                    },
+                    "description": "<data structure property description>",
+                    "valueDefinition": {
+                      "values": [
+                        {
+                          "literal": "<data structure property value>",
+                          "variable": false
+                        }
+                      ],
+                      "typeDefinition": {
+                        "typeSpecification": {
+                          "name": "number",
+                          "nestedTypes": []
+                        },
+                        "attributes": []
+                      }
+                    },
+                    "sections": []
+                  },
+                  "class": "property"
                 }
               ]
             }

--- a/features/fixtures/ast.yaml
+++ b/features/fixtures/ast.yaml
@@ -12,16 +12,18 @@ resourceGroups:
     description: "<resource group description>\n\n"
     resources:
       -
+        element: "resource"
         name: "<resource name>"
         description: "<resource description>\n\n"
         uriTemplate: "/resource/{parameter}"
         model:
           name: "<resource name>"
-          description: "<resource model description>"
+          description: "<resource model description>\n"
           headers:
             -
               name: "<header1>"
               value: "<header1 value>"
+          content: []
           body: "<resource model body>\n"
           schema: "<resource model schema>\n"
           assets:
@@ -41,7 +43,9 @@ resourceGroups:
             example: "<example value>"
             values:
               -
-                value: "<element>"
+                value: "<default value>"
+              -
+                value: "<example value>"
         actions:
           -
             name: "<action name>"
@@ -57,7 +61,10 @@ resourceGroups:
                 example: "<example value>"
                 values:
                   -
-                    value: "<element>"
+                    value: "<default value>"
+                  -
+                    value: "<example value>"
+            content: []
             examples:
               -
                 name: ""
@@ -79,6 +86,7 @@ resourceGroups:
                       -
                         name: "<header4>"
                         value: "<header4 value>"
+                    content: []
                     body: "<request body>\n"
                     schema: "<request schema>\n"
                     assets:
@@ -105,6 +113,7 @@ resourceGroups:
                       -
                         name: "<header5>"
                         value: "<header5 value>"
+                    content: []
                     body: "<response body>\n"
                     schema: "<response schema>\n"
                     assets:
@@ -115,10 +124,10 @@ resourceGroups:
                         source: "<response schema>\n"
                         resolved: ""
                   -
-                    name: "201"
                     reference:
                       id: "<resource name>"
-                    description: "<resource model description>"
+                    name: "201"
+                    description: "<resource model description>\n"
                     headers:
                       -
                         name: "<header2>"
@@ -129,6 +138,7 @@ resourceGroups:
                       -
                         name: "<header1>"
                         value: "<header1 value>"
+                    content: []
                     body: "<resource model body>\n"
                     schema: "<resource model schema>\n"
                     assets:
@@ -138,6 +148,74 @@ resourceGroups:
                       schema:
                         source: "<resource model schema>\n"
                         resolved: ""
+                  -
+                    name: "201"
+                    description: ""
+                    headers:
+                      -
+                        name: "<header2>"
+                        value: "<header2 value>"
+                      -
+                        name: "<header3>"
+                        value: "<header3 value>"
+                      -
+                        name: "Content-Type"
+                        value: "application/json"
+                    content:
+                      -
+                        element: "dataStructure"
+                        name:
+                          literal: ""
+                          variable: false
+                        typeDefinition:
+                          typeSpecification:
+                            name:
+                              literal: "<data structure name>"
+                              variable: false
+                            nestedTypes: []
+                          attributes: []
+                        sections: []
+                    body: ""
+                    schema: ""
+                    assets:
+                      body:
+                        source: ""
+                        resolved: ""
+                      schema:
+                        source: ""
+                        resolved: ""
+        content:
+          -
+            element: "dataStructure"
+            name:
+              literal: "<resource name>"
+              variable: false
+            typeDefinition:
+              typeSpecification:
+                name: "object"
+                nestedTypes: []
+              attributes: []
+            sections:
+              -
+                class: "memberType"
+                content:
+                  -
+                    content:
+                      name:
+                        literal: "<attribute property name>"
+                      description: "<attribute property description>"
+                      valueDefinition:
+                        values:
+                          -
+                            literal: "<attribute property value>"
+                            variable: false
+                        typeDefinition:
+                          typeSpecification:
+                            name: "number"
+                            nestedTypes: []
+                          attributes: []
+                      sections: []
+                    class: "property"
 content:
   -
     element: "category"
@@ -148,17 +226,18 @@ content:
         element: "copy"
         content: "<resource group description>\n\n"
       -
+        element: "resource"
         name: "<resource name>"
         description: "<resource description>\n\n"
-        element: "resource"
         uriTemplate: "/resource/{parameter}"
         model:
           name: "<resource name>"
-          description: "<resource model description>"
+          description: "<resource model description>\n"
           headers:
             -
               name: "<header1>"
               value: "<header1 value>"
+          content: []
           body: "<resource model body>\n"
           schema: "<resource model schema>\n"
           assets:
@@ -178,7 +257,9 @@ content:
             example: "<example value>"
             values:
               -
-                value: "<element>"
+                value: "<default value>"
+              -
+                value: "<example value>"
         actions:
           -
             name: "<action name>"
@@ -194,7 +275,10 @@ content:
                 example: "<example value>"
                 values:
                   -
-                    value: "<element>"
+                    value: "<default value>"
+                  -
+                    value: "<example value>"
+            content: []
             examples:
               -
                 name: ""
@@ -216,6 +300,7 @@ content:
                       -
                         name: "<header4>"
                         value: "<header4 value>"
+                    content: []
                     body: "<request body>\n"
                     schema: "<request schema>\n"
                     assets:
@@ -242,6 +327,7 @@ content:
                       -
                         name: "<header5>"
                         value: "<header5 value>"
+                    content: []
                     body: "<response body>\n"
                     schema: "<response schema>\n"
                     assets:
@@ -252,10 +338,10 @@ content:
                         source: "<response schema>\n"
                         resolved: ""
                   -
-                    name: "201"
                     reference:
                       id: "<resource name>"
-                    description: "<resource model description>"
+                    name: "201"
+                    description: "<resource model description>\n"
                     headers:
                       -
                         name: "<header2>"
@@ -266,6 +352,7 @@ content:
                       -
                         name: "<header1>"
                         value: "<header1 value>"
+                    content: []
                     body: "<resource model body>\n"
                     schema: "<resource model schema>\n"
                     assets:
@@ -275,3 +362,110 @@ content:
                       schema:
                         source: "<resource model schema>\n"
                         resolved: ""
+                  -
+                    name: "201"
+                    description: ""
+                    headers:
+                      -
+                        name: "<header2>"
+                        value: "<header2 value>"
+                      -
+                        name: "<header3>"
+                        value: "<header3 value>"
+                      -
+                        name: "Content-Type"
+                        value: "application/json"
+                    content:
+                      -
+                        element: "dataStructure"
+                        name:
+                          literal: ""
+                          variable: false
+                        typeDefinition:
+                          typeSpecification:
+                            name:
+                              literal: "<data structure name>"
+                              variable: false
+                            nestedTypes: []
+                          attributes: []
+                        sections: []
+                    body: ""
+                    schema: ""
+                    assets:
+                      body:
+                        source: ""
+                        resolved: ""
+                      schema:
+                        source: ""
+                        resolved: ""
+        content:
+          -
+            element: "dataStructure"
+            name:
+              literal: "<resource name>"
+              variable: false
+            typeDefinition:
+              typeSpecification:
+                name: "object"
+                nestedTypes: []
+              attributes: []
+            sections:
+              -
+                class: "memberType"
+                content:
+                  -
+                    content:
+                      name:
+                        literal: "<attribute property name>"
+                      description: "<attribute property description>"
+                      valueDefinition:
+                        values:
+                          -
+                            literal: "<attribute property value>"
+                            variable: false
+                        typeDefinition:
+                          typeSpecification:
+                            name: "number"
+                            nestedTypes: []
+                          attributes: []
+                      sections: []
+                    class: "property"
+  -
+    element: "category"
+    content:
+      -
+        element: "dataStructure"
+        name:
+          literal: "<data structure name>"
+          variable: false
+        typeDefinition:
+          typeSpecification:
+            name:
+              literal: ""
+              variable: false
+            nestedTypes: []
+          attributes: []
+        sections:
+          -
+            class: "blockDescription"
+            content: "<data structure description>\n\n"
+          -
+            class: "memberType"
+            content:
+              -
+                content:
+                  name:
+                    literal: "<data structure property name>"
+                  description: "<data structure property description>"
+                  valueDefinition:
+                    values:
+                      -
+                        literal: "<data structure property value>"
+                        variable: false
+                    typeDefinition:
+                      typeSpecification:
+                        name: "number"
+                        nestedTypes: []
+                      attributes: []
+                  sections: []
+                class: "property"

--- a/features/fixtures/blueprint.apib
+++ b/features/fixtures/blueprint.apib
@@ -9,7 +9,12 @@ Format: 1A
 ## <resource name> [/resource/{parameter}]
 <resource description>
 
++ Attributes (object)
+
+    + `<attribute property name>`: `<attribute property value>` (number) - <attribute property description>
+
 + Model
+
     <resource model description>
 
     + Headers
@@ -28,7 +33,8 @@ Format: 1A
     + parameter = `<default value>` (<type>, optional, `<example value>`) ... <description>
 
         + Values
-            + `<element>`
+            + `<default value>`
+            + `<example value>`
 
 + Headers
 
@@ -41,7 +47,8 @@ Format: 1A
     + parameter = `<default value>` (<type>, optional, `<example value>`) ... <description>
 
         + Values
-            + `<element>`
+            + `<default value>`
+            + `<example value>`
 
 + Headers
 
@@ -82,3 +89,15 @@ Format: 1A
 + Response 201
 
     [<resource name>][]
+
++ Response 201 (application/json)
+
+    + Attributes (<data structure name>)
+
+# Data Structures
+
+## <data structure name>
+<data structure description>
+
+### Properties
++ `<data structure property name>`: `<data structure property value>` (number) - <data structure property description>

--- a/src/AttributesParser.h
+++ b/src/AttributesParser.h
@@ -46,6 +46,13 @@ namespace snowcrash {
 
             mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.source.typeDefinition);
 
+            if (pd.exportSourceMap()) {
+
+                if (!out.node.source.typeDefinition.empty()) {
+                    out.sourceMap.typeDefinition.sourceMap = node->sourceMap;
+                }
+            }
+
             // Default to `object` type specification
             if (out.node.source.typeDefinition.baseType == mson::UndefinedBaseType) {
                 out.node.source.typeDefinition.baseType = mson::ImplicitObjectBaseType;

--- a/src/AttributesParser.h
+++ b/src/AttributesParser.h
@@ -44,22 +44,22 @@ namespace snowcrash {
                 return node;
             }
 
-            mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.source.typeDefinition);
+            mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.typeDefinition);
 
             if (pd.exportSourceMap()) {
 
-                if (!out.node.source.typeDefinition.empty()) {
+                if (!out.node.typeDefinition.empty()) {
                     out.sourceMap.typeDefinition.sourceMap = node->sourceMap;
                 }
             }
 
             // Default to `object` type specification
-            if (out.node.source.typeDefinition.baseType == mson::UndefinedBaseType) {
-                out.node.source.typeDefinition.baseType = mson::ImplicitObjectBaseType;
+            if (out.node.typeDefinition.baseType == mson::UndefinedBaseType) {
+                out.node.typeDefinition.baseType = mson::ImplicitObjectBaseType;
             }
 
             SectionProcessor<mson::ValueMember>::parseRemainingContent(node, pd, signature.remainingContent,
-                                                                       out.node.source.sections, out.sourceMap.sections);
+                                                                       out.node.sections, out.sourceMap.sections);
 
             return ++MarkdownNodeIterator(node);
         }
@@ -69,7 +69,7 @@ namespace snowcrash {
                                                        SectionParserData& pd,
                                                        const ParseResultRef<Attributes>& out) {
 
-            return SectionProcessor<mson::ValueMember>::blockDescription(node, pd, out.node.source.sections, out.sourceMap.sections);
+            return SectionProcessor<mson::ValueMember>::blockDescription(node, pd, out.node.sections, out.sourceMap.sections);
         }
 
         static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
@@ -77,11 +77,11 @@ namespace snowcrash {
                                                          SectionParserData& pd,
                                                          const ParseResultRef<Attributes>& out) {
 
-            ParseResultRef<mson::TypeSections> typeSections(out.report, out.node.source.sections, out.sourceMap.sections);
+            ParseResultRef<mson::TypeSections> typeSections(out.report, out.node.sections, out.sourceMap.sections);
 
             return SectionProcessor<mson::ValueMember>
                     ::processNestedMembers<MSONTypeSectionListParser>(node, siblings, pd, typeSections,
-                                                                      out.node.source.typeDefinition.baseType);
+                                                                      out.node.typeDefinition.baseType);
         }
 
         static bool isDescriptionNode(const MarkdownNodeIterator& node,

--- a/src/Blueprint.cc
+++ b/src/Blueprint.cc
@@ -10,6 +10,15 @@
 
 using namespace snowcrash;
 
+DataStructure& DataStructure::operator=(const mson::NamedType &rhs)
+{
+    this->name = rhs.name;
+    this->typeDefinition = rhs.typeDefinition;
+    this->sections = rhs.sections;
+
+    return *this;
+}
+
 Elements& Element::Content::elements()
 {
     if (!m_elements.get())

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -166,13 +166,10 @@ namespace snowcrash {
     /**
      * Data Structure
      */
-    struct DataStructure {
+    struct DataStructure : public mson::NamedType {
 
-        /** As described in source */
-        mson::NamedType source;
-
-        /** As resolved by subsequent tooling */
-        mson::NamedType resolved;
+        /** Assignment operator for Named Type */
+        DataStructure& operator=(const mson::NamedType& rhs);
     };
 
     /**
@@ -207,7 +204,7 @@ namespace snowcrash {
         /** Payload-specific Headers */
         Headers headers;
 
-        /** Payload-specific Attributes */
+        /** Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         Attributes attributes;
 
         /** Body (deprecated - only present in serialization & c-interface) */
@@ -278,7 +275,7 @@ namespace snowcrash {
         /** Action-specific Parameters */
         Parameters parameters;
 
-        /** Action-specific Attributes */
+        /** Action-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         Attributes attributes;
 
         /**
@@ -319,7 +316,7 @@ namespace snowcrash {
         /** Model representing this Resource */
         ResourceModel model;
 
-        /** Resource-specific Attributes */
+        /** Resource-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         Attributes attributes;
 
         /** Parameters */

--- a/src/BlueprintSourcemap.h
+++ b/src/BlueprintSourcemap.h
@@ -67,8 +67,8 @@ namespace snowcrash {
     struct SourceMap<DataStructure> : public SourceMap<mson::NamedType> {
     };
 
-    /** Source Map of Attributes */
-    // 'Attributes' type is same as 'DataStructure'
+    /** Source Map Structure for Attributes */
+    // 'Attributes' is the same as 'DataStructure'
 
     /**
      * Source Map Structure for Assets in Payload

--- a/src/BlueprintSourcemap.h
+++ b/src/BlueprintSourcemap.h
@@ -101,7 +101,7 @@ namespace snowcrash {
         /** Source Map of Payload-specific Headers */
         SourceMap<Headers> headers;
 
-        /** Source Map of Payload-specific Attributes */
+        /** Source Map of Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Attributes> attributes;
 
         /** Source Map of Body (deprecated - only present in serialization & c-interface) */
@@ -160,7 +160,7 @@ namespace snowcrash {
         /** Action-specific Parameters */
         SourceMap<Parameters> parameters;
 
-        /** Action-specific Attributes */
+        /** Action-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Attributes> attributes;
 
         /**
@@ -202,7 +202,7 @@ namespace snowcrash {
         /** Model representing this Resource */
         SourceMap<ResourceModel> model;
 
-        /** Source Map of Resource-specific Attributes */
+        /** Source Map of Resource-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Attributes> attributes;
 
         /** Parameters */

--- a/src/DataStructureGroupParser.h
+++ b/src/DataStructureGroupParser.h
@@ -52,7 +52,7 @@ namespace snowcrash {
                 else {
 
                     Element element(Element::DataStructureElement);
-                    element.content.dataStructure.source = namedType.node;
+                    element.content.dataStructure = namedType.node;
 
                     out.node.content.elements().push_back(element);
 
@@ -129,13 +129,13 @@ namespace snowcrash {
                          ++subIt) {
 
                         if (subIt->element == Element::ResourceElement &&
-                            subIt->content.resource.attributes.source.name.symbol.literal == name) {
+                            subIt->content.resource.attributes.name.symbol.literal == name) {
 
                             return true;
                         }
 
                         if (subIt->element == Element::DataStructureElement &&
-                            subIt->content.dataStructure.source.name.symbol.literal == name) {
+                            subIt->content.dataStructure.name.symbol.literal == name) {
 
                             return true;
                         }

--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -609,7 +609,7 @@ namespace snowcrash {
                 }
             }
 
-            if (out.node.assets.body.source.empty() && out.node.attributes.source.empty() &&
+            if (out.node.assets.body.source.empty() && out.node.attributes.empty() &&
                 out.node.reference.meta.state != Reference::StatePending) {
 
                 // Warn when content-length or transfer-encoding is specified or both headers and body are empty

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -122,12 +122,12 @@ namespace snowcrash {
                                                                   sourceMap));
 
                             // Remove the attributes data from the AST since we are ignoring this
-                            out.node.attributes.source = mson::NamedType();
+                            out.node.attributes = mson::NamedType();
 
                             return cur;
                         }
 
-                        attributes.node.source.name.symbol.literal = out.node.name;
+                        attributes.node.name.symbol.literal = out.node.name;
 
                         if (pd.exportSourceMap()) {
                             attributes.sourceMap.name.sourceMap = out.sourceMap.name.sourceMap;

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -128,6 +128,10 @@ namespace snowcrash {
                         }
 
                         attributes.node.source.name.symbol.literal = out.node.name;
+
+                        if (pd.exportSourceMap()) {
+                            attributes.sourceMap.name.sourceMap = out.sourceMap.name.sourceMap;
+                        }
                     }
 
                     return cur;

--- a/test/test-AttributesParser.cc
+++ b/test/test-AttributesParser.cc
@@ -35,14 +35,13 @@ TEST_CASE("Parse canonical attributes", "[attributes]")
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());
 
-    REQUIRE(attributes.node.resolved.empty());
-    REQUIRE(attributes.node.source.name.empty());
-    REQUIRE(attributes.node.source.sections.empty());
-    REQUIRE(attributes.node.source.typeDefinition.attributes == 0);
-    REQUIRE(attributes.node.source.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(attributes.node.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(attributes.node.source.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
-    REQUIRE(attributes.node.source.typeDefinition.baseType == mson::ValueBaseType);
+    REQUIRE(attributes.node.name.empty());
+    REQUIRE(attributes.node.sections.empty());
+    REQUIRE(attributes.node.typeDefinition.attributes == 0);
+    REQUIRE(attributes.node.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(attributes.node.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(attributes.node.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(attributes.node.typeDefinition.baseType == mson::ValueBaseType);
 
     REQUIRE(attributes.sourceMap.name.sourceMap.empty());
     SourceMapHelper::check(attributes.sourceMap.typeDefinition.sourceMap, 0, 40);
@@ -62,22 +61,21 @@ TEST_CASE("Parse attributes with nested members", "[attributes]")
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());
 
-    REQUIRE(attributes.node.resolved.empty());
-    REQUIRE(attributes.node.source.name.empty());
-    REQUIRE(attributes.node.source.typeDefinition.empty());
-    REQUIRE(attributes.node.source.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(attributes.node.source.sections.size() == 1);
-    REQUIRE(attributes.node.source.sections[0].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(attributes.node.source.sections[0].content.elements().size() == 2);
+    REQUIRE(attributes.node.name.empty());
+    REQUIRE(attributes.node.typeDefinition.empty());
+    REQUIRE(attributes.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(attributes.node.sections.size() == 1);
+    REQUIRE(attributes.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(attributes.node.sections[0].content.elements().size() == 2);
 
-    mson::Element element = attributes.node.source.sections[0].content.elements().at(0);
+    mson::Element element = attributes.node.sections[0].content.elements().at(0);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "message");
     REQUIRE(element.content.property.description == "The blog post article");
     REQUIRE(element.content.property.valueDefinition.values.empty());
     REQUIRE(element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
 
-    element = attributes.node.source.sections[0].content.elements().at(1);
+    element = attributes.node.sections[0].content.elements().at(1);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "author");
     REQUIRE(element.content.property.description == "Author of the blog post");
@@ -116,15 +114,14 @@ TEST_CASE("Parse attributes with block description", "[attributes]")
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());
 
-    REQUIRE(attributes.node.resolved.empty());
-    REQUIRE(attributes.node.source.name.empty());
-    REQUIRE(attributes.node.source.typeDefinition.empty());
-    REQUIRE(attributes.node.source.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(attributes.node.source.sections.size() == 2);
-    REQUIRE(attributes.node.source.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(attributes.node.source.sections[0].content.description == "Awesome description\n\n+ With list\n");
-    REQUIRE(attributes.node.source.sections[1].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(attributes.node.source.sections[1].content.elements().size() == 1);
+    REQUIRE(attributes.node.name.empty());
+    REQUIRE(attributes.node.typeDefinition.empty());
+    REQUIRE(attributes.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(attributes.node.sections.size() == 2);
+    REQUIRE(attributes.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(attributes.node.sections[0].content.description == "Awesome description\n\n+ With list\n");
+    REQUIRE(attributes.node.sections[1].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(attributes.node.sections[1].content.elements().size() == 1);
 
     REQUIRE(attributes.sourceMap.name.sourceMap.empty());
     REQUIRE(attributes.sourceMap.typeDefinition.sourceMap.empty());

--- a/test/test-AttributesParser.cc
+++ b/test/test-AttributesParser.cc
@@ -43,6 +43,10 @@ TEST_CASE("Parse canonical attributes", "[attributes]")
     REQUIRE(attributes.node.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
     REQUIRE(attributes.node.source.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
     REQUIRE(attributes.node.source.typeDefinition.baseType == mson::ValueBaseType);
+
+    REQUIRE(attributes.sourceMap.name.sourceMap.empty());
+    SourceMapHelper::check(attributes.sourceMap.typeDefinition.sourceMap, 0, 40);
+    REQUIRE(attributes.sourceMap.sections.collection.empty());
 }
 
 TEST_CASE("Parse attributes with nested members", "[attributes]")
@@ -52,7 +56,6 @@ TEST_CASE("Parse attributes with nested members", "[attributes]")
     "    + message (string) - The blog post article\n"\
     "    + author: john@appleseed.com (string) - Author of the blog post";
 
-    mson::Element element;
     ParseResult<Attributes> attributes;
     SectionParserHelper<Attributes, AttributesParser>::parse(source, AttributesSectionType, attributes, ExportSourcemapOption);
 
@@ -61,14 +64,13 @@ TEST_CASE("Parse attributes with nested members", "[attributes]")
 
     REQUIRE(attributes.node.resolved.empty());
     REQUIRE(attributes.node.source.name.empty());
-    REQUIRE(attributes.node.source.typeDefinition.attributes == 0);
-    REQUIRE(attributes.node.source.typeDefinition.typeSpecification.empty());
+    REQUIRE(attributes.node.source.typeDefinition.empty());
     REQUIRE(attributes.node.source.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(attributes.node.source.sections.size() == 1);
     REQUIRE(attributes.node.source.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(attributes.node.source.sections[0].content.elements().size() == 2);
 
-    element = attributes.node.source.sections[0].content.elements().at(0);
+    mson::Element element = attributes.node.source.sections[0].content.elements().at(0);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "message");
     REQUIRE(element.content.property.description == "The blog post article");
@@ -82,6 +84,21 @@ TEST_CASE("Parse attributes with nested members", "[attributes]")
     REQUIRE(element.content.property.valueDefinition.values.size() == 1);
     REQUIRE(element.content.property.valueDefinition.values[0].literal == "john@appleseed.com");
     REQUIRE(element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+
+    REQUIRE(attributes.sourceMap.name.sourceMap.empty());
+    REQUIRE(attributes.sourceMap.typeDefinition.sourceMap.empty());
+    REQUIRE(attributes.sourceMap.sections.collection.size() == 1);
+    REQUIRE(attributes.sourceMap.sections.collection[0].elements().collection.size() == 2);
+
+    SourceMap<mson::Element> elementSM = attributes.sourceMap.sections.collection[0].elements().collection[0];
+    SourceMapHelper::check(elementSM.property.name.sourceMap, 18, 41);
+    SourceMapHelper::check(elementSM.property.description.sourceMap, 18, 41);
+    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 18, 41);
+
+    elementSM = attributes.sourceMap.sections.collection[0].elements().collection[1];
+    SourceMapHelper::check(elementSM.property.name.sourceMap, 63, 64);
+    SourceMapHelper::check(elementSM.property.description.sourceMap, 63, 64);
+    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 63, 64);
 }
 
 TEST_CASE("Parse attributes with block description", "[attributes]")
@@ -101,12 +118,19 @@ TEST_CASE("Parse attributes with block description", "[attributes]")
 
     REQUIRE(attributes.node.resolved.empty());
     REQUIRE(attributes.node.source.name.empty());
-    REQUIRE(attributes.node.source.typeDefinition.attributes == 0);
-    REQUIRE(attributes.node.source.typeDefinition.typeSpecification.empty());
+    REQUIRE(attributes.node.source.typeDefinition.empty());
     REQUIRE(attributes.node.source.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(attributes.node.source.sections.size() == 2);
     REQUIRE(attributes.node.source.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
     REQUIRE(attributes.node.source.sections[0].content.description == "Awesome description\n\n+ With list\n");
     REQUIRE(attributes.node.source.sections[1].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(attributes.node.source.sections[1].content.elements().size() == 1);
+
+    REQUIRE(attributes.sourceMap.name.sourceMap.empty());
+    REQUIRE(attributes.sourceMap.typeDefinition.sourceMap.empty());
+    REQUIRE(attributes.sourceMap.sections.collection.size() == 2);
+    SourceMapHelper::check(attributes.sourceMap.sections.collection[0].description.sourceMap, 2, 11, 1);
+    SourceMapHelper::check(attributes.sourceMap.sections.collection[0].description.sourceMap, 17, 20, 2);
+    SourceMapHelper::check(attributes.sourceMap.sections.collection[0].description.sourceMap, 42, 12, 3);
+    REQUIRE(attributes.sourceMap.sections.collection[1].elements().collection.size() == 1);
 }

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -590,8 +590,8 @@ TEST_CASE("Parsing blueprint with mson data structures", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().at(2).element == Element::CategoryElement);
     REQUIRE(blueprint.node.content.elements().at(2).content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.dataStructure.source.name.symbol.literal == "Plan Base");
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(1).content.dataStructure.source.name.symbol.literal == "Timestamp");
+    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.dataStructure.name.symbol.literal == "Plan Base");
+    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(1).content.dataStructure.name.symbol.literal == "Timestamp");
 }
 
 TEST_CASE("Parse blueprint with two named types having the same name", "[blueprint]")
@@ -616,7 +616,7 @@ TEST_CASE("Parse blueprint with two named types having the same name", "[bluepri
     REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
     REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.attributes.source.empty());
+    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.attributes.empty());
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
 }

--- a/test/test-DataStructureGroupParser.cc
+++ b/test/test-DataStructureGroupParser.cc
@@ -48,21 +48,19 @@ TEST_CASE("Parse canonical data structures", "[data_structure_group]")
     REQUIRE(dataStructureGroup.node.content.elements().at(1).element == Element::DataStructureElement);
 
     dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
-    REQUIRE(dataStructure.resolved.empty());
-    REQUIRE(dataStructure.source.name.symbol.literal == "User");
-    REQUIRE(dataStructure.source.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(dataStructure.source.typeDefinition.attributes == 0);
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.nestedTypes.empty());
-    REQUIRE(dataStructure.source.sections.size() == 1);
-    REQUIRE(dataStructure.source.sections[0].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(dataStructure.source.sections[0].content.elements().size() == 2);
+    REQUIRE(dataStructure.name.symbol.literal == "User");
+    REQUIRE(dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(dataStructure.typeDefinition.attributes == 0);
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.empty());
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.empty());
+    REQUIRE(dataStructure.sections.size() == 1);
+    REQUIRE(dataStructure.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(dataStructure.sections[0].content.elements().size() == 2);
 
     dataStructure = dataStructureGroup.node.content.elements().at(1).content.dataStructure;
-    REQUIRE(dataStructure.resolved.empty());
-    REQUIRE(dataStructure.source.name.symbol.literal == "Email");
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(dataStructure.name.symbol.literal == "Email");
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
 }
 
 TEST_CASE("Parse multiple data structures with type sections", "[data_structure_group]")
@@ -94,21 +92,19 @@ TEST_CASE("Parse multiple data structures with type sections", "[data_structure_
     REQUIRE(dataStructureGroup.node.content.elements().at(1).element == Element::DataStructureElement);
 
     dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
-    REQUIRE(dataStructure.resolved.empty());
-    REQUIRE(dataStructure.source.name.symbol.literal == "User");
-    REQUIRE(dataStructure.source.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(dataStructure.source.typeDefinition.attributes == 0);
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.nestedTypes.empty());
-    REQUIRE(dataStructure.source.sections.size() == 2);
-    REQUIRE(dataStructure.source.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(dataStructure.source.sections[0].content.description == "Some description\n\n");
-    REQUIRE(dataStructure.source.sections[1].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(dataStructure.source.sections[1].content.elements().size() == 2);
+    REQUIRE(dataStructure.name.symbol.literal == "User");
+    REQUIRE(dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(dataStructure.typeDefinition.attributes == 0);
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.empty());
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.empty());
+    REQUIRE(dataStructure.sections.size() == 2);
+    REQUIRE(dataStructure.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(dataStructure.sections[0].content.description == "Some description\n\n");
+    REQUIRE(dataStructure.sections[1].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(dataStructure.sections[1].content.elements().size() == 2);
 
     dataStructure = dataStructureGroup.node.content.elements().at(1).content.dataStructure;
-    REQUIRE(dataStructure.resolved.empty());
-    REQUIRE(dataStructure.source.name.symbol.literal == "Email");
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(dataStructure.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(dataStructure.name.symbol.literal == "Email");
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
 }

--- a/test/test-DataStructureGroupParser.cc
+++ b/test/test-DataStructureGroupParser.cc
@@ -35,9 +35,8 @@ TEST_CASE("Parse canonical data structures", "[data_structure_group]")
     "- last_name\n\n"\
     "## Email (array[string])";
 
-    DataStructure dataStructure;
     ParseResult<DataStructureGroup> dataStructureGroup;
-    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup);
+    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup, ExportSourcemapOption);
 
     REQUIRE(dataStructureGroup.report.error.code == Error::OK);
     REQUIRE(dataStructureGroup.report.warnings.empty());
@@ -47,12 +46,10 @@ TEST_CASE("Parse canonical data structures", "[data_structure_group]")
     REQUIRE(dataStructureGroup.node.content.elements().at(0).element == Element::DataStructureElement);
     REQUIRE(dataStructureGroup.node.content.elements().at(1).element == Element::DataStructureElement);
 
-    dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
+    DataStructure dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
     REQUIRE(dataStructure.name.symbol.literal == "User");
     REQUIRE(dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(dataStructure.typeDefinition.attributes == 0);
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.empty());
+    REQUIRE(dataStructure.typeDefinition.empty());
     REQUIRE(dataStructure.sections.size() == 1);
     REQUIRE(dataStructure.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dataStructure.sections[0].content.elements().size() == 2);
@@ -61,6 +58,15 @@ TEST_CASE("Parse canonical data structures", "[data_structure_group]")
     REQUIRE(dataStructure.name.symbol.literal == "Email");
     REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
     REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+
+    SourceMap<DataStructure> dataStructureSM = dataStructureGroup.sourceMap.content.elements().collection[0].content.dataStructure;
+    SourceMapHelper::check(dataStructureSM.name.sourceMap, 19, 9);
+    REQUIRE(dataStructureSM.typeDefinition.sourceMap.empty());
+    REQUIRE(dataStructureSM.sections.collection[0].elements().collection.size() == 2);
+
+    dataStructureSM = dataStructureGroup.sourceMap.content.elements().collection[1].content.dataStructure;
+    SourceMapHelper::check(dataStructureSM.name.sourceMap, 54, 24);
+    SourceMapHelper::check(dataStructureSM.typeDefinition.sourceMap, 54, 24);
 }
 
 TEST_CASE("Parse multiple data structures with type sections", "[data_structure_group]")
@@ -79,9 +85,8 @@ TEST_CASE("Parse multiple data structures with type sections", "[data_structure_
     "\n"\
     "## Email (array[string])";
 
-    DataStructure dataStructure;
     ParseResult<DataStructureGroup> dataStructureGroup;
-    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup);
+    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup, ExportSourcemapOption);
 
     REQUIRE(dataStructureGroup.report.error.code == Error::OK);
     REQUIRE(dataStructureGroup.report.warnings.empty());
@@ -91,12 +96,10 @@ TEST_CASE("Parse multiple data structures with type sections", "[data_structure_
     REQUIRE(dataStructureGroup.node.content.elements().at(0).element == Element::DataStructureElement);
     REQUIRE(dataStructureGroup.node.content.elements().at(1).element == Element::DataStructureElement);
 
-    dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
+    DataStructure dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
     REQUIRE(dataStructure.name.symbol.literal == "User");
     REQUIRE(dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(dataStructure.typeDefinition.attributes == 0);
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.empty());
+    REQUIRE(dataStructure.typeDefinition.empty());
     REQUIRE(dataStructure.sections.size() == 2);
     REQUIRE(dataStructure.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
     REQUIRE(dataStructure.sections[0].content.description == "Some description\n\n");
@@ -107,4 +110,14 @@ TEST_CASE("Parse multiple data structures with type sections", "[data_structure_
     REQUIRE(dataStructure.name.symbol.literal == "Email");
     REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
     REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+
+    SourceMap<DataStructure> dataStructureSM = dataStructureGroup.sourceMap.content.elements().collection[0].content.dataStructure;
+    SourceMapHelper::check(dataStructureSM.name.sourceMap, 19, 9);
+    REQUIRE(dataStructureSM.typeDefinition.sourceMap.empty());
+    SourceMapHelper::check(dataStructureSM.sections.collection[0].description.sourceMap, 28, 18);
+    REQUIRE(dataStructureSM.sections.collection[1].elements().collection.size() == 2);
+
+    dataStructureSM = dataStructureGroup.sourceMap.content.elements().collection[1].content.dataStructure;
+    SourceMapHelper::check(dataStructureSM.name.sourceMap, 88, 24);
+    SourceMapHelper::check(dataStructureSM.typeDefinition.sourceMap, 88, 24);
 }

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -677,13 +677,12 @@ TEST_CASE("Parse a payload with attributes", "[payload]")
     REQUIRE(payload.node.assets.body.source.empty());
     REQUIRE(payload.node.assets.schema.source.empty());
     REQUIRE(payload.node.description.empty());
-    REQUIRE(payload.node.attributes.resolved.empty());
-    REQUIRE(payload.node.attributes.source.name.empty());
-    REQUIRE(payload.node.attributes.source.typeDefinition.attributes == 0);
-    REQUIRE(payload.node.attributes.source.typeDefinition.typeSpecification.name.base == mson::ObjectTypeName);
-    REQUIRE(payload.node.attributes.source.sections.size() == 1);
-    REQUIRE(payload.node.attributes.source.sections[0].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(payload.node.attributes.source.sections[0].content.elements().size() == 4);
+    REQUIRE(payload.node.attributes.name.empty());
+    REQUIRE(payload.node.attributes.typeDefinition.attributes == 0);
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.name.base == mson::ObjectTypeName);
+    REQUIRE(payload.node.attributes.sections.size() == 1);
+    REQUIRE(payload.node.attributes.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(payload.node.attributes.sections[0].content.elements().size() == 4);
 }
 
 TEST_CASE("Parse a request with attributes and no body", "[payload]")
@@ -704,11 +703,10 @@ TEST_CASE("Parse a request with attributes and no body", "[payload]")
     REQUIRE(payload.node.assets.body.source.empty());
     REQUIRE(payload.node.assets.schema.source.empty());
     REQUIRE(payload.node.description.empty());
-    REQUIRE(payload.node.attributes.resolved.empty());
-    REQUIRE(payload.node.attributes.source.name.empty());
-    REQUIRE(payload.node.attributes.source.typeDefinition.attributes == 0);
-    REQUIRE(payload.node.attributes.source.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(payload.node.attributes.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(payload.node.attributes.source.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
-    REQUIRE(payload.node.attributes.source.sections.empty());
+    REQUIRE(payload.node.attributes.name.empty());
+    REQUIRE(payload.node.attributes.typeDefinition.attributes == 0);
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(payload.node.attributes.sections.empty());
 }

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -972,10 +972,10 @@ TEST_CASE("Parse resource attributes", "[resource]")
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.name == "Coupons");
-    REQUIRE(resource.node.attributes.source.name.symbol.literal == "Coupons");
-    REQUIRE(resource.node.attributes.source.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(resource.node.attributes.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(resource.node.attributes.source.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(resource.node.attributes.name.symbol.literal == "Coupons");
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
 
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].examples.size() == 1);
@@ -1001,10 +1001,10 @@ TEST_CASE("Parse unnamed resource attributes", "[resource]")
     REQUIRE(resource.report.warnings.size() == 1); // Unknown type 'Coupons'
 
     REQUIRE(resource.node.name.empty());
-    REQUIRE(resource.node.attributes.source.name.empty());
-    REQUIRE(resource.node.attributes.source.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(resource.node.attributes.source.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(resource.node.attributes.source.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(resource.node.attributes.name.empty());
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
 
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].examples.size() == 1);


### PR DESCRIPTION
1. Added source maps for `Attributes`
2. Changed the structure for `DataStructure` and thus `Attributes` to be up to date with latest spec.
3. Serialised `Resource`, `Payload` & `Action` in accordance with the new spec.

Debt: We haven't changed the actual structures of `Resource`, `Payload` and `Action` to represent the exact structures in the latest spec.

For @zdne to review & merge.