### PR TITLE
Implement asset serialisation in the new format

### DIFF
--- a/features/fixtures/ast.json
+++ b/features/fixtures/ast.json
@@ -28,19 +28,24 @@
                 "value": "<header1 value>"
               }
             ],
-            "content": [],
             "body": "<resource model body>\n",
             "schema": "<resource model schema>\n",
-            "assets": {
-              "body": {
-                "source": "<resource model body>\n",
-                "resolved": ""
+            "content": [
+              {
+                "element": "asset",
+                "attributes": {
+                  "role": "bodyExample"
+                },
+                "content": "<resource model body>\n"
               },
-              "schema": {
-                "source": "<resource model schema>\n",
-                "resolved": ""
+              {
+                "element": "asset",
+                "attributes": {
+                  "role": "bodySchema"
+                },
+                "content": "<resource model schema>\n"
               }
-            }
+            ]
           },
           "parameters": [
             {
@@ -110,19 +115,24 @@
                           "value": "<header4 value>"
                         }
                       ],
-                      "content": [],
                       "body": "<request body>\n",
                       "schema": "<request schema>\n",
-                      "assets": {
-                        "body": {
-                          "source": "<request body>\n",
-                          "resolved": ""
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "<request body>\n"
                         },
-                        "schema": {
-                          "source": "<request schema>\n",
-                          "resolved": ""
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodySchema"
+                          },
+                          "content": "<request schema>\n"
                         }
-                      }
+                      ]
                     }
                   ],
                   "responses": [
@@ -147,19 +157,24 @@
                           "value": "<header5 value>"
                         }
                       ],
-                      "content": [],
                       "body": "<response body>\n",
                       "schema": "<response schema>\n",
-                      "assets": {
-                        "body": {
-                          "source": "<response body>\n",
-                          "resolved": ""
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "<response body>\n"
                         },
-                        "schema": {
-                          "source": "<response schema>\n",
-                          "resolved": ""
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodySchema"
+                          },
+                          "content": "<response schema>\n"
                         }
-                      }
+                      ]
                     },
                     {
                       "reference": {
@@ -181,19 +196,24 @@
                           "value": "<header1 value>"
                         }
                       ],
-                      "content": [],
                       "body": "<resource model body>\n",
                       "schema": "<resource model schema>\n",
-                      "assets": {
-                        "body": {
-                          "source": "<resource model body>\n",
-                          "resolved": ""
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "<resource model body>\n"
                         },
-                        "schema": {
-                          "source": "<resource model schema>\n",
-                          "resolved": ""
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodySchema"
+                          },
+                          "content": "<resource model schema>\n"
                         }
-                      }
+                      ]
                     },
                     {
                       "name": "201",
@@ -212,6 +232,8 @@
                           "value": "application/json"
                         }
                       ],
+                      "body": "",
+                      "schema": "",
                       "content": [
                         {
                           "element": "dataStructure",
@@ -231,19 +253,7 @@
                           },
                           "sections": []
                         }
-                      ],
-                      "body": "",
-                      "schema": "",
-                      "assets": {
-                        "body": {
-                          "source": "",
-                          "resolved": ""
-                        },
-                        "schema": {
-                          "source": "",
-                          "resolved": ""
-                        }
-                      }
+                      ]
                     }
                   ]
                 }
@@ -327,19 +337,24 @@
                 "value": "<header1 value>"
               }
             ],
-            "content": [],
             "body": "<resource model body>\n",
             "schema": "<resource model schema>\n",
-            "assets": {
-              "body": {
-                "source": "<resource model body>\n",
-                "resolved": ""
+            "content": [
+              {
+                "element": "asset",
+                "attributes": {
+                  "role": "bodyExample"
+                },
+                "content": "<resource model body>\n"
               },
-              "schema": {
-                "source": "<resource model schema>\n",
-                "resolved": ""
+              {
+                "element": "asset",
+                "attributes": {
+                  "role": "bodySchema"
+                },
+                "content": "<resource model schema>\n"
               }
-            }
+            ]
           },
           "parameters": [
             {
@@ -409,19 +424,24 @@
                           "value": "<header4 value>"
                         }
                       ],
-                      "content": [],
                       "body": "<request body>\n",
                       "schema": "<request schema>\n",
-                      "assets": {
-                        "body": {
-                          "source": "<request body>\n",
-                          "resolved": ""
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "<request body>\n"
                         },
-                        "schema": {
-                          "source": "<request schema>\n",
-                          "resolved": ""
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodySchema"
+                          },
+                          "content": "<request schema>\n"
                         }
-                      }
+                      ]
                     }
                   ],
                   "responses": [
@@ -446,19 +466,24 @@
                           "value": "<header5 value>"
                         }
                       ],
-                      "content": [],
                       "body": "<response body>\n",
                       "schema": "<response schema>\n",
-                      "assets": {
-                        "body": {
-                          "source": "<response body>\n",
-                          "resolved": ""
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "<response body>\n"
                         },
-                        "schema": {
-                          "source": "<response schema>\n",
-                          "resolved": ""
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodySchema"
+                          },
+                          "content": "<response schema>\n"
                         }
-                      }
+                      ]
                     },
                     {
                       "reference": {
@@ -480,19 +505,24 @@
                           "value": "<header1 value>"
                         }
                       ],
-                      "content": [],
                       "body": "<resource model body>\n",
                       "schema": "<resource model schema>\n",
-                      "assets": {
-                        "body": {
-                          "source": "<resource model body>\n",
-                          "resolved": ""
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "<resource model body>\n"
                         },
-                        "schema": {
-                          "source": "<resource model schema>\n",
-                          "resolved": ""
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodySchema"
+                          },
+                          "content": "<resource model schema>\n"
                         }
-                      }
+                      ]
                     },
                     {
                       "name": "201",
@@ -511,6 +541,8 @@
                           "value": "application/json"
                         }
                       ],
+                      "body": "",
+                      "schema": "",
                       "content": [
                         {
                           "element": "dataStructure",
@@ -530,19 +562,7 @@
                           },
                           "sections": []
                         }
-                      ],
-                      "body": "",
-                      "schema": "",
-                      "assets": {
-                        "body": {
-                          "source": "",
-                          "resolved": ""
-                        },
-                        "schema": {
-                          "source": "",
-                          "resolved": ""
-                        }
-                      }
+                      ]
                     }
                   ]
                 }

--- a/features/fixtures/ast.yaml
+++ b/features/fixtures/ast.yaml
@@ -23,16 +23,19 @@ resourceGroups:
             -
               name: "<header1>"
               value: "<header1 value>"
-          content: []
           body: "<resource model body>\n"
           schema: "<resource model schema>\n"
-          assets:
-            body:
-              source: "<resource model body>\n"
-              resolved: ""
-            schema:
-              source: "<resource model schema>\n"
-              resolved: ""
+          content:
+            -
+              element: "asset"
+              attributes:
+                role: "bodyExample"
+              content: "<resource model body>\n"
+            -
+              element: "asset"
+              attributes:
+                role: "bodySchema"
+              content: "<resource model schema>\n"
         parameters:
           -
             name: "parameter"
@@ -86,16 +89,19 @@ resourceGroups:
                       -
                         name: "<header4>"
                         value: "<header4 value>"
-                    content: []
                     body: "<request body>\n"
                     schema: "<request schema>\n"
-                    assets:
-                      body:
-                        source: "<request body>\n"
-                        resolved: ""
-                      schema:
-                        source: "<request schema>\n"
-                        resolved: ""
+                    content:
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodyExample"
+                        content: "<request body>\n"
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodySchema"
+                        content: "<request schema>\n"
                 responses:
                   -
                     name: "200"
@@ -113,16 +119,19 @@ resourceGroups:
                       -
                         name: "<header5>"
                         value: "<header5 value>"
-                    content: []
                     body: "<response body>\n"
                     schema: "<response schema>\n"
-                    assets:
-                      body:
-                        source: "<response body>\n"
-                        resolved: ""
-                      schema:
-                        source: "<response schema>\n"
-                        resolved: ""
+                    content:
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodyExample"
+                        content: "<response body>\n"
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodySchema"
+                        content: "<response schema>\n"
                   -
                     reference:
                       id: "<resource name>"
@@ -138,16 +147,19 @@ resourceGroups:
                       -
                         name: "<header1>"
                         value: "<header1 value>"
-                    content: []
                     body: "<resource model body>\n"
                     schema: "<resource model schema>\n"
-                    assets:
-                      body:
-                        source: "<resource model body>\n"
-                        resolved: ""
-                      schema:
-                        source: "<resource model schema>\n"
-                        resolved: ""
+                    content:
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodyExample"
+                        content: "<resource model body>\n"
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodySchema"
+                        content: "<resource model schema>\n"
                   -
                     name: "201"
                     description: ""
@@ -161,6 +173,8 @@ resourceGroups:
                       -
                         name: "Content-Type"
                         value: "application/json"
+                    body: ""
+                    schema: ""
                     content:
                       -
                         element: "dataStructure"
@@ -175,15 +189,6 @@ resourceGroups:
                             nestedTypes: []
                           attributes: []
                         sections: []
-                    body: ""
-                    schema: ""
-                    assets:
-                      body:
-                        source: ""
-                        resolved: ""
-                      schema:
-                        source: ""
-                        resolved: ""
         content:
           -
             element: "dataStructure"
@@ -237,16 +242,19 @@ content:
             -
               name: "<header1>"
               value: "<header1 value>"
-          content: []
           body: "<resource model body>\n"
           schema: "<resource model schema>\n"
-          assets:
-            body:
-              source: "<resource model body>\n"
-              resolved: ""
-            schema:
-              source: "<resource model schema>\n"
-              resolved: ""
+          content:
+            -
+              element: "asset"
+              attributes:
+                role: "bodyExample"
+              content: "<resource model body>\n"
+            -
+              element: "asset"
+              attributes:
+                role: "bodySchema"
+              content: "<resource model schema>\n"
         parameters:
           -
             name: "parameter"
@@ -300,16 +308,19 @@ content:
                       -
                         name: "<header4>"
                         value: "<header4 value>"
-                    content: []
                     body: "<request body>\n"
                     schema: "<request schema>\n"
-                    assets:
-                      body:
-                        source: "<request body>\n"
-                        resolved: ""
-                      schema:
-                        source: "<request schema>\n"
-                        resolved: ""
+                    content:
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodyExample"
+                        content: "<request body>\n"
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodySchema"
+                        content: "<request schema>\n"
                 responses:
                   -
                     name: "200"
@@ -327,16 +338,19 @@ content:
                       -
                         name: "<header5>"
                         value: "<header5 value>"
-                    content: []
                     body: "<response body>\n"
                     schema: "<response schema>\n"
-                    assets:
-                      body:
-                        source: "<response body>\n"
-                        resolved: ""
-                      schema:
-                        source: "<response schema>\n"
-                        resolved: ""
+                    content:
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodyExample"
+                        content: "<response body>\n"
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodySchema"
+                        content: "<response schema>\n"
                   -
                     reference:
                       id: "<resource name>"
@@ -352,16 +366,19 @@ content:
                       -
                         name: "<header1>"
                         value: "<header1 value>"
-                    content: []
                     body: "<resource model body>\n"
                     schema: "<resource model schema>\n"
-                    assets:
-                      body:
-                        source: "<resource model body>\n"
-                        resolved: ""
-                      schema:
-                        source: "<resource model schema>\n"
-                        resolved: ""
+                    content:
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodyExample"
+                        content: "<resource model body>\n"
+                      -
+                        element: "asset"
+                        attributes:
+                          role: "bodySchema"
+                        content: "<resource model schema>\n"
                   -
                     name: "201"
                     description: ""
@@ -375,6 +392,8 @@ content:
                       -
                         name: "Content-Type"
                         value: "application/json"
+                    body: ""
+                    schema: ""
                     content:
                       -
                         element: "dataStructure"
@@ -389,15 +408,6 @@ content:
                             nestedTypes: []
                           attributes: []
                         sections: []
-                    body: ""
-                    schema: ""
-                    assets:
-                      body:
-                        source: ""
-                        resolved: ""
-                      schema:
-                        source: ""
-                        resolved: ""
         content:
           -
             element: "dataStructure"

--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -191,10 +191,10 @@ namespace snowcrash {
                 !out.node.examples.empty() &&
                 !out.node.examples.back().responses.empty()) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().responses.back().assets.body.source);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().responses.back().body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.examples.collection.back().responses.collection.back().assets.body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.examples.collection.back().responses.collection.back().body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -207,10 +207,10 @@ namespace snowcrash {
                 !out.node.examples.empty() &&
                 !out.node.examples.back().requests.empty()) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().requests.back().assets.body.source);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.examples.back().requests.back().body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.examples.collection.back().requests.collection.back().assets.body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.examples.collection.back().requests.collection.back().body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -382,7 +382,7 @@ namespace snowcrash {
 
                 HTTPMethodTraits methodTraits = GetMethodTrait(out.node.method);
 
-                if (!methodTraits.allowBody && !payload.assets.body.source.empty()) {
+                if (!methodTraits.allowBody && !payload.body.empty()) {
 
                     // WARN: Edge case for 2xx CONNECT
                     if (out.node.method == HTTPMethodName::Connect && code/100 == 2) {
@@ -393,8 +393,7 @@ namespace snowcrash {
                         out.report.warnings.push_back(Warning(ss.str(),
                                                               EmptyDefinitionWarning,
                                                               sourceMap));
-                    }
-                    else if (out.node.method != HTTPMethodName::Connect && !methodTraits.allowBody) {
+                    } else if (out.node.method != HTTPMethodName::Connect && !methodTraits.allowBody) {
 
                         std::stringstream ss;
                         ss << "the response for " << out.node.method << " request MUST NOT include a " << SectionName(BodySectionType);

--- a/src/AssetParser.h
+++ b/src/AssetParser.h
@@ -42,10 +42,10 @@ namespace snowcrash {
                                                      SectionLayout& layout,
                                                      const ParseResultRef<Asset>& out) {
 
-            out.node.source = "";
-            CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node.source);
+            out.node = "";
+            CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node);
 
-            if (pd.exportSourceMap() && !out.node.source.empty()) {
+            if (pd.exportSourceMap() && !out.node.empty()) {
                 out.sourceMap.sourceMap.append(node->sourceMap);
             }
 
@@ -62,7 +62,7 @@ namespace snowcrash {
             mdp::ByteBuffer content;
             CodeBlockUtility::contentAsCodeBlock(node, pd, out.report, content);
 
-            out.node.source += content;
+            out.node += content;
 
             if (pd.exportSourceMap() && !content.empty()) {
                 out.sourceMap.sourceMap.append(node->sourceMap);

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -190,10 +190,10 @@ namespace snowcrash {
         /** Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         Attributes attributes;
 
-        /** Body */
+        /** Body (THIS SHOULD NOT BE HERE - should be under content) */
         Asset body;
 
-        /** Schema */
+        /** Schema (THIS SHOULD NOT BE HERE - should be under content) */
         Asset schema;
 
         /** Reference */
@@ -340,6 +340,7 @@ namespace snowcrash {
             UndefinedElement = 0, // Unknown
             CategoryElement,      // Group of other elements
             CopyElement,          // Human readable text
+            AssetElement,         // Asset of API description
             ResourceElement,      // Resource
             DataStructureElement  // Data Structure
         };

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -54,6 +54,9 @@ namespace snowcrash {
     /** A generic key - value pair */
     typedef std::pair<std::string, std::string> KeyValuePair;
 
+    /** An asset data */
+    typedef std::string Asset;
+
     /**
      *  \brief Metadata key-value pair,
      *
@@ -82,16 +85,6 @@ namespace snowcrash {
         UndefinedParameterUse,
         OptionalParameterUse,
         RequiredParameterUse
-    };
-
-    /** Asset */
-    struct Asset {
-
-        /** Asset as written in source */
-        std::string source;
-
-        /** Asset as resolved by tooling */
-        std::string resolved;
     };
 
     /** Parameter */
@@ -182,16 +175,6 @@ namespace snowcrash {
      */
     struct Payload {
 
-        /** Assets Structure of the Payload */
-        struct Assets {
-
-            /** Body */
-            Asset body;
-
-            /** Schema */
-            Asset schema;
-        };
-
         /** A Payload Name */
         Name name;
 
@@ -207,11 +190,11 @@ namespace snowcrash {
         /** Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         Attributes attributes;
 
-        /** Body (deprecated - only present in serialization & c-interface) */
-        /** Schema (deprecated - only present in serialization & c-interface) */
+        /** Body */
+        Asset body;
 
-        /** Assets of the Payload */
-        Assets assets;
+        /** Schema */
+        Asset schema;
 
         /** Reference */
         Reference reference;

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -80,6 +80,13 @@ namespace snowcrash {
     /** Collection of Parameter Values */
     typedef Collection<Value>::type Values;
 
+    /** Role of an element */
+    enum AssetRole {
+        UndefinedAssetRole = 0,   // Unknown
+        BodyExampleAssetRole,     // Body example for asset
+        BodySchemaAssetRole       // Body schema for asset
+    };
+
     /** Parameter Use flag */
     enum ParameterUse {
         UndefinedParameterUse,
@@ -343,13 +350,6 @@ namespace snowcrash {
             AssetElement,         // Asset of API description
             ResourceElement,      // Resource
             DataStructureElement  // Data Structure
-        };
-
-        /** Role of an element */
-        enum Role {
-            UndefinedRole = 0,   // Unknown
-            BodyExampleRole,     // Body example for asset
-            BodySchemaRole       // Body schema for asset
         };
 
         /** Attributes of an element */

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -345,6 +345,13 @@ namespace snowcrash {
             DataStructureElement  // Data Structure
         };
 
+        /** Role of an element */
+        enum Role {
+            UndefinedRole = 0,   // Unknown
+            BodyExampleRole,     // Body example for asset
+            BodySchemaRole       // Body schema for asset
+        };
+
         /** Attributes of an element */
         struct Attributes {
 

--- a/src/BlueprintSourcemap.h
+++ b/src/BlueprintSourcemap.h
@@ -71,19 +71,6 @@ namespace snowcrash {
     // 'Attributes' is the same as 'DataStructure'
 
     /**
-     * Source Map Structure for Assets in Payload
-     */
-    template<>
-    struct SourceMap<Payload::Assets> : public SourceMapBase {
-
-        /** Source Map of Body */
-        SourceMap<Asset> body;
-
-        /** Source Map of Schema */
-        SourceMap<Asset> schema;
-    };
-
-    /**
      * Source Map Structure for Payload
      */
     template<>
@@ -104,11 +91,11 @@ namespace snowcrash {
         /** Source Map of Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Attributes> attributes;
 
-        /** Source Map of Body (deprecated - only present in serialization & c-interface) */
-        /** Source Map of Schema (deprecated - only present in serialization & c-interface) */
+        /** Source Map of Body */
+        SourceMap<Asset> body;
 
-        /** Source Map of Assets */
-        SourceMap<Payload::Assets> assets;
+        /** Source Map of Schema */
+        SourceMap<Asset> schema;
 
         /** Source Map of Model Reference */
         SourceMap<Reference> reference;

--- a/src/BlueprintSourcemap.h
+++ b/src/BlueprintSourcemap.h
@@ -91,10 +91,10 @@ namespace snowcrash {
         /** Source Map of Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Attributes> attributes;
 
-        /** Source Map of Body */
+        /** Source Map of Body (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Asset> body;
 
-        /** Source Map of Schema */
+        /** Source Map of Schema (THIS SHOULD NOT BE HERE - should be under content) */
         SourceMap<Asset> schema;
 
         /** Source Map of Model Reference */

--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -318,7 +318,8 @@ namespace snowcrash {
             if (sectionType == RequestSectionType || sectionType == RequestBodySectionType) {
 
                 checkRequest(node, pd, out);
-            } else if (sectionType == ResponseSectionType || sectionType == ResponseBodySectionType) {
+            }
+            else if (sectionType == ResponseSectionType || sectionType == ResponseBodySectionType) {
 
                 checkResponse(node, pd, out);
             }

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -155,20 +155,20 @@ namespace snowcrash {
                 (sectionType == ModelBodySectionType ||
                  sectionType == ModelSectionType)) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.model.assets.body.source);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.model.body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.model.assets.body.sourceMap.append(node->sourceMap);
+                    out.sourceMap.model.body.sourceMap.append(node->sourceMap);
                 }
 
                 // Update model in the model table as well
                 ModelTable::iterator it = pd.modelTable.find(out.node.model.name);
 
                 if (it != pd.modelTable.end()) {
-                    it->second.assets.body.source = out.node.model.assets.body.source;
+                    it->second.body = out.node.model.body;
 
                     if (pd.exportSourceMap()) {
-                        pd.modelSourceMapTable[out.node.model.name].assets.body = out.sourceMap.model.assets.body;
+                        pd.modelSourceMapTable[out.node.model.name].body = out.sourceMap.model.body;
                     }
                 }
 

--- a/src/Serialize.cc
+++ b/src/Serialize.cc
@@ -55,3 +55,4 @@ const std::string SerializeKey::Content = "content";
 const std::string SerializeKey::ValueDefinition = "valueDefinition";
 
 const std::string SerializeKey::Element = "element";
+const std::string SerializeKey::Role = "role";

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -67,6 +67,7 @@ namespace snowcrash {
         static const std::string ValueDefinition;
 
         static const std::string Element;
+        static const std::string Role;
     };
 }
 

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -351,6 +351,26 @@ sos::Object WrapNamedType(const mson::NamedType& namedType)
     return namedTypeObject;
 }
 
+sos::String WrapElementRole(const Element::Role& role)
+{
+    std::string str;
+
+    switch (role) {
+        case Element::BodyExampleRole:
+            str = "bodyExample";
+            break;
+
+        case Element::BodySchemaRole:
+            str = "bodySchema";
+            break;
+
+        default:
+            break;
+    }
+
+    return sos::String(str);
+}
+
 sos::String WrapElementClass(const Element::Class& element)
 {
     std::string str;
@@ -416,7 +436,7 @@ sos::Object WrapReference(const Reference& reference)
     return referenceObject;
 }
 
-sos::Object WrapAsset(const Asset& asset, const std::string& role)
+sos::Object WrapAsset(const Asset& asset, const Element::Role& role)
 {
     sos::Object assetObject;
 
@@ -427,7 +447,7 @@ sos::Object WrapAsset(const Asset& asset, const std::string& role)
     sos::Object attributes;
 
     /// Role
-    attributes.set(SerializeKey::Role, sos::String(role));
+    attributes.set(SerializeKey::Role, WrapElementRole(role));
 
     assetObject.set(SerializeKey::Attributes, attributes);
 
@@ -499,12 +519,12 @@ sos::Object WrapPayload(const Payload& payload)
 
     /// Asset 'bodyExample'
     if (!payload.body.empty()) {
-        content.push(WrapAsset(payload.body, 'bodyExample'));
+        content.push(WrapAsset(payload.body, Element::BodyExampleRole));
     }
 
     /// Asset 'bodySchema'
     if (!payload.schema.empty()) {
-        content.push(WrapAsset(payload.schema, 'bodySchema'));
+        content.push(WrapAsset(payload.schema, Element::BodySchemaRole));
     }
 
     payloadObject.set(SerializeKey::Content, content);

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -372,6 +372,10 @@ sos::String WrapElementClass(const Element::Class& element)
             str = "dataStructure";
             break;
 
+        case Element::AssetElement:
+            str = "asset";
+            break;
+
         default:
             break;
     }
@@ -412,15 +416,23 @@ sos::Object WrapReference(const Reference& reference)
     return referenceObject;
 }
 
-sos::Object WrapAsset(const Asset& asset)
+sos::Object WrapAsset(const Asset& asset, const std::string& role)
 {
     sos::Object assetObject;
 
-    // Source
-    assetObject.set(SerializeKey::Source, sos::String(asset.source));
+    // Element
+    assetObject.set(SerializeKey::Element, WrapElementClass(Element::AssetElement));
 
-    // Resolved
-    assetObject.set(SerializeKey::Resolved, sos::String(asset.resolved));
+    // Attributes
+    sos::Object attributes;
+
+    /// Role
+    attributes.set(SerializeKey::Role, sos::String(role));
+
+    assetObject.set(SerializeKey::Attributes, attributes);
+
+    // Content
+    assetObject.set(SerializeKey::Content, sos::String(asset));
 
     return assetObject;
 }
@@ -471,28 +483,31 @@ sos::Object WrapPayload(const Payload& payload)
 
     payloadObject.set(SerializeKey::Headers, headers);
 
+    // Body
+    payloadObject.set(SerializeKey::Body, sos::String(payload.body));
+
+    // Schema
+    payloadObject.set(SerializeKey::Schema, sos::String(payload.schema));
+
     // Content
     sos::Array content;
 
+    /// Attributes
     if (!payload.attributes.empty()) {
         content.push(WrapDataStructure(payload.attributes));
     }
 
+    /// Asset 'bodyExample'
+    if (!payload.body.empty()) {
+        content.push(WrapAsset(payload.body, 'bodyExample'));
+    }
+
+    /// Asset 'bodySchema'
+    if (!payload.schema.empty()) {
+        content.push(WrapAsset(payload.schema, 'bodySchema'));
+    }
+
     payloadObject.set(SerializeKey::Content, content);
-
-    // Body
-    payloadObject.set(SerializeKey::Body, sos::String(payload.assets.body.source));
-
-    // Schema
-    payloadObject.set(SerializeKey::Schema, sos::String(payload.assets.schema.source));
-
-    // Assets
-    sos::Object assets;
-
-    assets.set(SerializeKey::Body, WrapAsset(payload.assets.body));
-    assets.set(SerializeKey::Schema, WrapAsset(payload.assets.schema));
-
-    payloadObject.set(SerializeKey::Assets, assets);
 
     return payloadObject;
 }

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -351,16 +351,16 @@ sos::Object WrapNamedType(const mson::NamedType& namedType)
     return namedTypeObject;
 }
 
-sos::String WrapElementRole(const Element::Role& role)
+sos::String WrapAssetRole(const AssetRole& role)
 {
     std::string str;
 
     switch (role) {
-        case Element::BodyExampleRole:
+        case BodyExampleAssetRole:
             str = "bodyExample";
             break;
 
-        case Element::BodySchemaRole:
+        case BodySchemaAssetRole:
             str = "bodySchema";
             break;
 
@@ -436,7 +436,7 @@ sos::Object WrapReference(const Reference& reference)
     return referenceObject;
 }
 
-sos::Object WrapAsset(const Asset& asset, const Element::Role& role)
+sos::Object WrapAsset(const Asset& asset, const AssetRole& role)
 {
     sos::Object assetObject;
 
@@ -447,7 +447,7 @@ sos::Object WrapAsset(const Asset& asset, const Element::Role& role)
     sos::Object attributes;
 
     /// Role
-    attributes.set(SerializeKey::Role, WrapElementRole(role));
+    attributes.set(SerializeKey::Role, WrapAssetRole(role));
 
     assetObject.set(SerializeKey::Attributes, attributes);
 
@@ -519,12 +519,12 @@ sos::Object WrapPayload(const Payload& payload)
 
     /// Asset 'bodyExample'
     if (!payload.body.empty()) {
-        content.push(WrapAsset(payload.body, Element::BodyExampleRole));
+        content.push(WrapAsset(payload.body, BodyExampleAssetRole));
     }
 
     /// Asset 'bodySchema'
     if (!payload.schema.empty()) {
-        content.push(WrapAsset(payload.schema, Element::BodySchemaRole));
+        content.push(WrapAsset(payload.schema, BodySchemaAssetRole));
     }
 
     payloadObject.set(SerializeKey::Content, content);

--- a/src/SerializeSourcemap.cc
+++ b/src/SerializeSourcemap.cc
@@ -177,18 +177,10 @@ sos::Object WrapPayloadSourcemap(const SourceMap<Payload>& payload)
     payloadObject.set(SerializeKey::Headers, headers);
 
     // Body
-    payloadObject.set(SerializeKey::Body, WrapSourcemap(payload.assets.body));
+    payloadObject.set(SerializeKey::Body, WrapSourcemap(payload.body));
 
     // Schema
-    payloadObject.set(SerializeKey::Schema, WrapSourcemap(payload.assets.schema));
-
-    // Assets
-    sos::Object assets;
-
-    assets.set(SerializeKey::Body, WrapSourcemap(payload.assets.body));
-    assets.set(SerializeKey::Schema, WrapSourcemap(payload.assets.schema));
-
-    payloadObject.set(SerializeKey::Assets, assets);
+    payloadObject.set(SerializeKey::Schema, WrapSourcemap(payload.schema));
 
     return payloadObject;
 }

--- a/test/snowcrashtest.h
+++ b/test/snowcrashtest.h
@@ -92,10 +92,10 @@ namespace snowcrashtest {
             sourcemap.push_back(mdp::BytesRange(0, 1));
 
             model.description = "Foo";
-            model.assets.body.source = "Bar";
+            model.body = "Bar";
 
             modelSM.description.sourceMap = sourcemap;
-            modelSM.assets.body.sourceMap = sourcemap;
+            modelSM.body.sourceMap = sourcemap;
 
             models.modelTable[name] = model;
             models.modelSourceMapTable[name] = modelSM;

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -53,7 +53,7 @@ TEST_CASE("Parsing action", "[action]")
     REQUIRE(action.node.examples.front().responses.size() == 1);
 
     REQUIRE(action.node.examples.front().responses[0].name == "200");
-    REQUIRE(action.node.examples.front().responses[0].assets.body.source == "OK.\n");
+    REQUIRE(action.node.examples.front().responses[0].body == "OK.\n");
     REQUIRE(action.node.examples.front().responses[0].headers.size() == 1);
     REQUIRE(action.node.examples.front().responses[0].headers[0].first == "Content-Type");
     REQUIRE(action.node.examples.front().responses[0].headers[0].second == "text/plain");
@@ -71,9 +71,9 @@ TEST_CASE("Parsing action", "[action]")
     REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
 
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].assets.body.sourceMap.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].assets.body.sourceMap[0].location == 72);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].assets.body.sourceMap[0].length == 7);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap[0].location == 72);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap[0].length == 7);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap.size() == 1);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap[0].location == 41);
     REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap[0].length == 27);
@@ -154,15 +154,15 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
 
     REQUIRE(action.node.examples.front().requests[0].name == "A");
     REQUIRE(action.node.examples.front().requests[0].description == "B");
-    REQUIRE(action.node.examples.front().requests[0].assets.body.source == "C\n");
-    REQUIRE(action.node.examples.front().requests[0].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().requests[0].body == "C\n");
+    REQUIRE(action.node.examples.front().requests[0].schema.empty());
     REQUIRE(action.node.examples.front().requests[0].parameters.empty());
     REQUIRE(action.node.examples.front().requests[0].headers.empty());
 
     REQUIRE(action.node.examples.front().requests[1].name == "D");
     REQUIRE(action.node.examples.front().requests[1].description == "E");
-    REQUIRE(action.node.examples.front().requests[1].assets.body.source == "F\n");
-    REQUIRE(action.node.examples.front().requests[1].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().requests[1].body == "F\n");
+    REQUIRE(action.node.examples.front().requests[1].schema.empty());
     REQUIRE(action.node.examples.front().requests[1].parameters.empty());
     REQUIRE(action.node.examples.front().requests[1].headers.empty());
 
@@ -170,15 +170,15 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
 
     REQUIRE(action.node.examples.front().responses[0].name == "200");
     REQUIRE(action.node.examples.front().responses[0].description == "G");
-    REQUIRE(action.node.examples.front().responses[0].assets.body.source == "H\n");
-    REQUIRE(action.node.examples.front().responses[0].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().responses[0].body == "H\n");
+    REQUIRE(action.node.examples.front().responses[0].schema.empty());
     REQUIRE(action.node.examples.front().responses[0].parameters.empty());
     REQUIRE(action.node.examples.front().responses[0].headers.empty());
 
     REQUIRE(action.node.examples.front().responses[1].name == "200");
     REQUIRE(action.node.examples.front().responses[1].description == "I");
-    REQUIRE(action.node.examples.front().responses[1].assets.body.source == "J\n");
-    REQUIRE(action.node.examples.front().responses[1].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().responses[1].body == "J\n");
+    REQUIRE(action.node.examples.front().responses[1].schema.empty());
     REQUIRE(action.node.examples.front().responses[1].parameters.empty());
     REQUIRE(action.node.examples.front().responses[1].headers.empty());
 
@@ -216,15 +216,15 @@ TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
 
     REQUIRE(action.node.examples.front().requests.size() == 2);
     REQUIRE(action.node.examples.front().requests[0].name == "A");
-    REQUIRE(action.node.examples.front().requests[0].assets.body.source.empty());
-    REQUIRE(action.node.examples.front().requests[0].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().requests[0].body.empty());
+    REQUIRE(action.node.examples.front().requests[0].schema.empty());
     REQUIRE(action.node.examples.front().requests[0].parameters.empty());
     REQUIRE(action.node.examples.front().requests[0].headers.empty());
 
     REQUIRE(action.node.examples.front().requests[1].name == "B");
     REQUIRE(action.node.examples.front().requests[1].description.empty());
-    REQUIRE(action.node.examples.front().requests[1].assets.body.source == "C\n\n");
-    REQUIRE(action.node.examples.front().requests[1].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().requests[1].body == "C\n\n");
+    REQUIRE(action.node.examples.front().requests[1].schema.empty());
     REQUIRE(action.node.examples.front().requests[1].parameters.empty());
     REQUIRE(action.node.examples.front().requests[1].headers.empty());
 
@@ -265,8 +265,8 @@ TEST_CASE("Parse method with foreign item", "[action]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples.front().requests.size() == 1);
     REQUIRE(action.node.examples.front().requests[0].name.empty());
-    REQUIRE(action.node.examples.front().requests[0].assets.body.source == "Foo\n");
-    REQUIRE(action.node.examples.front().requests[0].assets.schema.source.empty());
+    REQUIRE(action.node.examples.front().requests[0].body == "Foo\n");
+    REQUIRE(action.node.examples.front().requests[0].schema.empty());
     REQUIRE(action.node.examples.front().requests[0].parameters.empty());
     REQUIRE(action.node.examples.front().requests[0].headers.empty());
     REQUIRE(action.node.examples.front().responses.size() == 1);
@@ -386,7 +386,7 @@ TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
     REQUIRE(action.node.method == "CONNECT");
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{}\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{}\n");
 
     REQUIRE(action.sourceMap.name.sourceMap.empty());
     REQUIRE(action.sourceMap.method.sourceMap.size() == 1);
@@ -415,7 +415,7 @@ TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
     REQUIRE(action.node.method == "HEAD");
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{}\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{}\n");
 
     REQUIRE(action.sourceMap.name.sourceMap.empty());
     REQUIRE(action.sourceMap.method.sourceMap.size() == 1);

--- a/test/test-AssetParser.cc
+++ b/test/test-AssetParser.cc
@@ -66,8 +66,7 @@ TEST_CASE("Parse body asset", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node.source == "Lorem Ipsum\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Lorem Ipsum\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -81,8 +80,7 @@ TEST_CASE("Parse schema asset", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node.source == "Dolor Sit Amet\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Dolor Sit Amet\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 14);
@@ -102,8 +100,7 @@ TEST_CASE("Foreign block inside", "[asset]")
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
-    REQUIRE(asset.node.source == "Lorem Ipsum\nHello World!\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Lorem Ipsum\nHello World!\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 2);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -125,8 +122,7 @@ TEST_CASE("Nested list block inside", "[asset]")
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
-    REQUIRE(asset.node.source == "Lorem Ipsum\n+ Hello World!\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Lorem Ipsum\n+ Hello World!\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 2);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -149,8 +145,7 @@ TEST_CASE("Multiline signature", "[asset]")
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
-    REQUIRE(asset.node.source == "Multiline Signature Content\nHello World!\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Multiline Signature Content\nHello World!\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 3);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 2);
@@ -179,8 +174,7 @@ TEST_CASE("Multiple blocks", "[asset]")
     REQUIRE(asset.report.warnings.size() == 2);
     REQUIRE(asset.report.warnings[0].code == IndentationWarning);
     REQUIRE(asset.report.warnings[1].code == IndentationWarning);
-    REQUIRE(asset.node.source == "Block 1\n\nBlock 2\nBlock 3\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Block 1\n\nBlock 2\nBlock 3\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 3);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);
@@ -203,8 +197,7 @@ TEST_CASE("Extra spaces before signature", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node.source == "Lorem Ipsum\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Lorem Ipsum\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 14);
@@ -223,8 +216,7 @@ TEST_CASE("Asset parser greediness", "[asset]")
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
-    REQUIRE(asset.node.source == "Lorem Ipsum\n");
-    REQUIRE(asset.node.resolved.empty());
+    REQUIRE(asset.node == "Lorem Ipsum\n");
 
     REQUIRE(asset.sourceMap.sourceMap.size() == 1);
     REQUIRE(asset.sourceMap.sourceMap[0].location == 12);

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -169,7 +169,7 @@ TEST_CASE("Parse API with Name and abbreviated resource", "[blueprint]")
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions.front().examples.size() == 1);
     REQUIRE(resource.actions.front().examples.front().responses.size() == 1);
-    REQUIRE(resource.actions.front().examples.front().responses.front().assets.body.source == "{}\n");
+    REQUIRE(resource.actions.front().examples.front().responses.front().body == "{}\n");
 
     REQUIRE(blueprint.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(blueprint.sourceMap.name.sourceMap[0].location == 0);

--- a/test/test-Indentation.cc
+++ b/test/test-Indentation.cc
@@ -38,7 +38,7 @@ TEST_CASE("Correct indentation", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n");
 }
 
 TEST_CASE("No Indentation & No Newline", "[indentation]")
@@ -59,7 +59,7 @@ TEST_CASE("No Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
 }
 
 TEST_CASE("No Indentation", "[indentation]")
@@ -81,7 +81,7 @@ TEST_CASE("No Indentation", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
 }
 
 TEST_CASE("Poor Indentation & No Newline", "[indentation]")
@@ -102,7 +102,7 @@ TEST_CASE("Poor Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
 }
 
 TEST_CASE("Poor Indentation", "[indentation]")
@@ -124,7 +124,7 @@ TEST_CASE("Poor Indentation", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n");
 }
 
 TEST_CASE("OK Indentation & No Newline", "[indentation]")
@@ -145,7 +145,7 @@ TEST_CASE("OK Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.description.empty());
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "    { ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "    { ... }\n\n");
 }
 
 TEST_CASE("Full syntax - correct", "[indentation]")
@@ -166,7 +166,7 @@ TEST_CASE("Full syntax - correct", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n");
 }
 
 TEST_CASE("Full syntax - Poor Body Indentation", "[indentation]")
@@ -189,7 +189,7 @@ TEST_CASE("Full syntax - Poor Body Indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
+    REQUIRE(action.node.examples[0].responses[0].body.empty());
 }
 
 TEST_CASE("Full syntax - Poor Body & Body Asset Indentation", "[indentation]")
@@ -212,7 +212,7 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
+    REQUIRE(action.node.examples[0].responses[0].body.empty());
 }
 
 TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline", "[indentation]")
@@ -234,7 +234,7 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline", "[ind
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
+    REQUIRE(action.node.examples[0].responses[0].body.empty());
 }
 
 TEST_CASE("Full syntax - No Indentation", "[indentation]")
@@ -259,7 +259,7 @@ TEST_CASE("Full syntax - No Indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{ ... }\n\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{ ... }\n\n");
 }
 
 TEST_CASE("Full syntax - No Indentation & No Newline", "[indentation]")
@@ -281,7 +281,7 @@ TEST_CASE("Full syntax - No Indentation & No Newline", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source.empty());
+    REQUIRE(action.node.examples[0].responses[0].body.empty());
 }
 
 TEST_CASE("Full syntax - Extra indentation", "[indentation]")
@@ -305,7 +305,7 @@ TEST_CASE("Full syntax - Extra indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "+ Body\n\n        { ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "+ Body\n\n        { ... }\n");
 }
 
 TEST_CASE("No Indentation & No Newline multi-line", "[indentation]")
@@ -332,5 +332,5 @@ TEST_CASE("No Indentation & No Newline multi-line", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].assets.body.source == "{\nHello\n}\n");
+    REQUIRE(action.node.examples[0].responses[0].body == "{\nHello\n}\n");
 }

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -98,8 +98,8 @@ TEST_CASE("Parse request payload", "[payload]")
     REQUIRE(payload.node.headers[0].second == "text/plain");
     REQUIRE(payload.node.headers[1].first == "X-Header");
     REQUIRE(payload.node.headers[1].second == "42");
-    REQUIRE(payload.node.assets.body.source == "Code\n");
-    REQUIRE(payload.node.assets.schema.source == "Code 2\n");
+    REQUIRE(payload.node.body == "Code\n");
+    REQUIRE(payload.node.schema == "Code 2\n");
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -115,12 +115,12 @@ TEST_CASE("Parse request payload", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[1].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[1].sourceMap[0].location == 74);
     REQUIRE(payload.sourceMap.headers.collection[1].sourceMap[0].length == 17);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 112);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 9);
-    REQUIRE(payload.sourceMap.assets.schema.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.schema.sourceMap[0].location == 144);
-    REQUIRE(payload.sourceMap.assets.schema.sourceMap[0].length == 11);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 112);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 9);
+    REQUIRE(payload.sourceMap.schema.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.schema.sourceMap[0].location == 144);
+    REQUIRE(payload.sourceMap.schema.sourceMap[0].length == 11);
 }
 
 TEST_CASE("Parse abbreviated payload body", "[payload]")
@@ -135,8 +135,8 @@ TEST_CASE("Parse abbreviated payload body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.size() == 1);
-    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Hello World!\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -147,9 +147,9 @@ TEST_CASE("Parse abbreviated payload body", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].location == 2);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].length == 27);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 33);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 33);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
 }
 
 TEST_CASE("Parse abbreviated inline payload body", "[payload]")
@@ -167,8 +167,8 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "Hello World!\nB\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Hello World!\nB\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -176,11 +176,11 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 2);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 17);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].location == 36);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].length == 2);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 2);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 17);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.body.sourceMap[1].location == 36);
+    REQUIRE(payload.sourceMap.body.sourceMap[1].length == 2);
 }
 
 TEST_CASE("Parse payload description with list", "[payload]")
@@ -212,8 +212,8 @@ TEST_CASE("Parse payload description with list", "[payload]")
     REQUIRE(payload.node.description == "+ B\n");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "{}\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "{}\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 1);
@@ -221,9 +221,9 @@ TEST_CASE("Parse payload description with list", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap[0].length == 4);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 40);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 7);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 40);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 7);
 }
 
 TEST_CASE("Parse payload with foreign list item", "[payload]")
@@ -255,16 +255,16 @@ TEST_CASE("Parse payload with foreign list item", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "{}\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "{}\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 31);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 7);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 31);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 7);
 }
 
 TEST_CASE("Parse payload with dangling body", "[payload]")
@@ -295,18 +295,18 @@ TEST_CASE("Parse payload with dangling body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "Foo\nBar\n\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Foo\nBar\n\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 2);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 30);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 8);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].location == 43);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[1].length == 4);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 2);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 30);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 8);
+    REQUIRE(payload.sourceMap.body.sourceMap[1].location == 43);
+    REQUIRE(payload.sourceMap.body.sourceMap[1].length == 4);
 }
 
 TEST_CASE("Parse inline payload with symbol reference", "[payload]")
@@ -324,8 +324,8 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     REQUIRE(payload.node.description == "Foo");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "Bar");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Bar");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 1);
@@ -333,9 +333,9 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap[0].length == 1);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 0);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 0);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 1);
 }
 
 TEST_CASE("Parse inline payload with symbol reference with extra indentation", "[payload]")
@@ -358,16 +358,16 @@ TEST_CASE("Parse inline payload with symbol reference with extra indentation", "
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "[Symbol][]\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "[Symbol][]\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 15);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 15);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 15);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 15);
 }
 
 TEST_CASE("Parse inline payload with symbol reference with foreign content", "[payload]")
@@ -388,8 +388,8 @@ TEST_CASE("Parse inline payload with symbol reference with foreign content", "[p
     REQUIRE(payload.node.description == "Foo");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "Bar");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Bar");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 1);
@@ -397,9 +397,9 @@ TEST_CASE("Parse inline payload with symbol reference with foreign content", "[p
     REQUIRE(payload.sourceMap.description.sourceMap[0].length == 1);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 0);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 0);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 1);
 }
 
 TEST_CASE("Parse named model", "[payload]")
@@ -426,8 +426,8 @@ TEST_CASE("Parse named model", "[payload]")
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Content-Type");
     REQUIRE(payload.node.headers[0].second == "text/plain");
-    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Hello World!\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.name.sourceMap[0].location == 2);
@@ -438,9 +438,9 @@ TEST_CASE("Parse named model", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].location == 2);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].length == 26);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 32);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 32);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
 }
 
 TEST_CASE("Parse nameless model", "[payload]")
@@ -467,8 +467,8 @@ TEST_CASE("Parse nameless model", "[payload]")
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Content-Type");
     REQUIRE(payload.node.headers[0].second == "text/plain");
-    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Hello World!\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
@@ -477,10 +477,10 @@ TEST_CASE("Parse nameless model", "[payload]")
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap.size() == 1);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].location == 2);
     REQUIRE(payload.sourceMap.headers.collection[0].sourceMap[0].length == 20);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 26);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
-    REQUIRE(payload.sourceMap.assets.schema.sourceMap.empty());
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 26);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.schema.sourceMap.empty());
 }
 
 TEST_CASE("Warn on malformed payload signature", "[payload]")
@@ -514,8 +514,8 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     REQUIRE(payload.node.description == "Description\n\nLine 2\n");
     REQUIRE(payload.node.parameters.empty());
     REQUIRE(payload.node.headers.empty());
-    REQUIRE(payload.node.assets.body.source == "Hello World!\n");
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body == "Hello World!\n");
+    REQUIRE(payload.node.schema.empty());
 
     REQUIRE(payload.sourceMap.name.sourceMap.empty());
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 3);
@@ -527,9 +527,9 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap[2].length == 7);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 82);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 17);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 82);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 17);
 }
 
 TEST_CASE("Give a warning of empty message body for requests with certain headers", "[payload]")
@@ -550,9 +550,9 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Content-Length");
     REQUIRE(payload.node.headers[0].second == "100");
-    REQUIRE(payload.node.assets.body.source.empty());
+    REQUIRE(payload.node.body.empty());
 
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.empty());
+    REQUIRE(payload.sourceMap.body.sourceMap.empty());
 }
 
 TEST_CASE("Do not report empty message body for requests", "[payload]")
@@ -572,7 +572,7 @@ TEST_CASE("Do not report empty message body for requests", "[payload]")
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Accept");
     REQUIRE(payload.node.headers[0].second == "application/json, application/javascript");
-    REQUIRE(payload.node.assets.body.source.empty());
+    REQUIRE(payload.node.body.empty());
 }
 
 TEST_CASE("Give a warning when 100 response has a body", "[payload]")
@@ -588,7 +588,7 @@ TEST_CASE("Give a warning when 100 response has a body", "[payload]")
     REQUIRE(payload.report.warnings.size() == 1);
     REQUIRE(payload.report.warnings[0].code == EmptyDefinitionWarning);
 
-    REQUIRE(payload.node.assets.body.source == "{}\n");
+    REQUIRE(payload.node.body == "{}\n");
 }
 
 TEST_CASE("Empty body section should shouldn't be parsed as description", "[payload]")
@@ -599,9 +599,9 @@ TEST_CASE("Empty body section should shouldn't be parsed as description", "[payl
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
 
-    REQUIRE(payload.node.assets.body.source == "");
+    REQUIRE(payload.node.body == "");
 
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.empty());
+    REQUIRE(payload.sourceMap.body.sourceMap.empty());
 }
 
 TEST_CASE("Parameters section should be taken as a description node", "[payload]")
@@ -620,7 +620,7 @@ TEST_CASE("Parameters section should be taken as a description node", "[payload]
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.description == "+ Parameters\n\n    + id (string)\n");
-    REQUIRE(payload.node.assets.body.source == "{}\n");
+    REQUIRE(payload.node.body == "{}\n");
 
     REQUIRE(payload.sourceMap.description.sourceMap.size() == 2);
     REQUIRE(payload.sourceMap.description.sourceMap[0].location == 20);
@@ -628,9 +628,9 @@ TEST_CASE("Parameters section should be taken as a description node", "[payload]
     REQUIRE(payload.sourceMap.description.sourceMap[1].location == 38);
     REQUIRE(payload.sourceMap.description.sourceMap[1].length == 18);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
-    REQUIRE(payload.sourceMap.assets.body.sourceMap.size() == 1);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].location == 77);
-    REQUIRE(payload.sourceMap.assets.body.sourceMap[0].length == 7);
+    REQUIRE(payload.sourceMap.body.sourceMap.size() == 1);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].location == 77);
+    REQUIRE(payload.sourceMap.body.sourceMap[0].length == 7);
 }
 
 TEST_CASE("Report ignoring nested request objects", "[payload][#163][#189]")
@@ -653,7 +653,7 @@ TEST_CASE("Report ignoring nested request objects", "[payload][#163][#189]")
     REQUIRE(payload.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(payload.node.headers.size() == 1);
-    REQUIRE(payload.node.assets.body.source.empty());
+    REQUIRE(payload.node.body.empty());
 }
 
 TEST_CASE("Parse a payload with attributes", "[payload]")
@@ -674,8 +674,8 @@ TEST_CASE("Parse a payload with attributes", "[payload]")
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.headers.size() == 1);
-    REQUIRE(payload.node.assets.body.source.empty());
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body.empty());
+    REQUIRE(payload.node.schema.empty());
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.attributes.name.empty());
     REQUIRE(payload.node.attributes.typeDefinition.attributes == 0);
@@ -700,8 +700,8 @@ TEST_CASE("Parse a request with attributes and no body", "[payload]")
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.headers.size() == 2);
-    REQUIRE(payload.node.assets.body.source.empty());
-    REQUIRE(payload.node.assets.schema.source.empty());
+    REQUIRE(payload.node.body.empty());
+    REQUIRE(payload.node.schema.empty());
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.attributes.name.empty());
     REQUIRE(payload.node.attributes.typeDefinition.attributes == 0);

--- a/test/test-ResourceGroupParser.cc
+++ b/test/test-ResourceGroupParser.cc
@@ -172,7 +172,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resource1.actions[0].examples[0].requests.size() == 1);
     REQUIRE(resource1.actions[0].examples[0].requests[0].name.empty());
     REQUIRE(resource1.actions[0].examples[0].requests[0].description.empty());
-    REQUIRE(resource1.actions[0].examples[0].requests[0].assets.body.source.empty());
+    REQUIRE(resource1.actions[0].examples[0].requests[0].body.empty());
     REQUIRE(resource1.actions[0].examples[0].responses.empty());
 
     Resource resource2 = resourceGroup.node.content.elements().at(1).content.resource;
@@ -184,7 +184,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resource2.actions[0].examples.size() == 1);
     REQUIRE(resource2.actions[0].examples[0].requests[0].name.empty());
     REQUIRE(resource2.actions[0].examples[0].requests[0].description.empty());
-    REQUIRE(resource2.actions[0].examples[0].requests[0].assets.body.source.empty());
+    REQUIRE(resource2.actions[0].examples[0].requests[0].body.empty());
     REQUIRE(resource2.actions[0].examples[0].responses.empty());
 
     REQUIRE(resourceGroup.sourceMap.attributes.name.sourceMap.empty());
@@ -336,7 +336,7 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.model.name.empty());
-    REQUIRE(resource.model.assets.body.source.empty());
+    REQUIRE(resource.model.body.empty());
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "GET");
 
@@ -371,7 +371,7 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.model.name.empty());
-    REQUIRE(resource.model.assets.body.source.empty());
+    REQUIRE(resource.model.body.empty());
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "GET");
 
@@ -379,7 +379,7 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/2");
     REQUIRE(resource.model.name.empty());
-    REQUIRE(resource.model.assets.body.source.empty());
+    REQUIRE(resource.model.body.empty());
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "POST");
 

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -72,7 +72,7 @@ TEST_CASE("Parse resource", "[resource]")
     REQUIRE(resource.node.headers.empty());
 
     REQUIRE(resource.node.model.name == "Resource");
-    REQUIRE(resource.node.model.assets.body.source == "X.O.\n");
+    REQUIRE(resource.node.model.body == "X.O.\n");
 
     REQUIRE(resource.node.parameters.size() == 2);
     REQUIRE(resource.node.parameters[0].name == "id");
@@ -102,9 +102,9 @@ TEST_CASE("Parse resource", "[resource]")
     REQUIRE(resource.sourceMap.model.name.sourceMap.size() == 1);
     REQUIRE(resource.sourceMap.model.name.sourceMap[0].location == 63);
     REQUIRE(resource.sourceMap.model.name.sourceMap[0].length == 29);
-    REQUIRE(resource.sourceMap.model.assets.body.sourceMap.size() == 1);
-    REQUIRE(resource.sourceMap.model.assets.body.sourceMap[0].location == 96);
-    REQUIRE(resource.sourceMap.model.assets.body.sourceMap[0].length == 9);
+    REQUIRE(resource.sourceMap.model.body.sourceMap.size() == 1);
+    REQUIRE(resource.sourceMap.model.body.sourceMap[0].location == 96);
+    REQUIRE(resource.sourceMap.model.body.sourceMap[0].length == 9);
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].method.sourceMap.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].method.sourceMap[0].location == 278);
@@ -131,7 +131,7 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description.empty());
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.assets.body.source.empty());
+    REQUIRE(resource.node.model.body.empty());
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions.front().method == "GET");
     REQUIRE(resource.node.actions.front().description.empty());
@@ -139,7 +139,7 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     REQUIRE(resource.node.actions.front().examples.front().requests.size() == 1);
     REQUIRE(resource.node.actions.front().examples.front().requests.front().name.empty());
     REQUIRE(resource.node.actions.front().examples.front().requests.front().description.empty());
-    REQUIRE(resource.node.actions.front().examples.front().requests.front().assets.body.source == "p1\n\n");
+    REQUIRE(resource.node.actions.front().examples.front().requests.front().body == "p1\n\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
@@ -170,7 +170,7 @@ TEST_CASE("Parse multiple method descriptions", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description.empty());
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.assets.body.source.empty());
+    REQUIRE(resource.node.model.body.empty());
     REQUIRE(resource.node.actions.size() == 2);
     REQUIRE(resource.node.actions[0].method == "GET");
     REQUIRE(resource.node.actions[0].description == "p1\n");
@@ -219,7 +219,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "A\n");
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.assets.body.source.empty());
+    REQUIRE(resource.node.model.body.empty());
     REQUIRE(resource.node.actions.size() == 3);
 
     REQUIRE(resource.node.actions[0].method == "GET");
@@ -229,7 +229,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
     REQUIRE(resource.node.actions[0].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "Code 1\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "Code 1\n");
 
     REQUIRE(resource.node.actions[1].method == "POST");
     REQUIRE(resource.node.actions[1].description == "C\n");
@@ -241,7 +241,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.actions[1].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[1].examples[0].responses[0].name == "200");
     REQUIRE(resource.node.actions[1].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[1].examples[0].responses[0].assets.body.source == "{}\n");
+    REQUIRE(resource.node.actions[1].examples[0].responses[0].body == "{}\n");
 
     REQUIRE(resource.node.actions[2].method == "PUT");
     REQUIRE(resource.node.actions[2].description == "E\n");
@@ -280,7 +280,7 @@ TEST_CASE("Parse description with list", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "+ A\n\n+ B\n\np1\n");
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.assets.body.source.empty());
+    REQUIRE(resource.node.model.body.empty());
     REQUIRE(resource.node.actions.empty());
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -310,7 +310,7 @@ TEST_CASE("Parse resource with a HR", "[resource][block]")
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "A\n---\n\nB\n");
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.assets.body.source.empty());
+    REQUIRE(resource.node.model.body.empty());
     REQUIRE(resource.node.actions.empty());
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -346,7 +346,7 @@ TEST_CASE("Parse resource method abbreviation", "[resource]")
 
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "{}\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "{}\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
@@ -372,7 +372,7 @@ TEST_CASE("Parse resource without name", "[resource]")
     REQUIRE(resource.node.uriTemplate == "/resource");
     REQUIRE(resource.node.name.empty());
     REQUIRE(resource.node.model.name.empty());
-    REQUIRE(resource.node.model.assets.body.source.empty());
+    REQUIRE(resource.node.model.body.empty());
     REQUIRE(resource.node.actions.size() == 0);
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -434,7 +434,7 @@ TEST_CASE("Parse nameless resource with named model", "[resource][model][source]
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.model.name == "Super");
-    REQUIRE(resource.node.model.assets.body.source == "AAA\n");
+    REQUIRE(resource.node.model.body == "AAA\n");
     REQUIRE(resource.node.actions.empty());
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
@@ -494,14 +494,14 @@ TEST_CASE("Parse named resource with nameless model", "[resource][model][source]
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.model.name == "Message");
-    REQUIRE(resource.node.model.assets.body.source == "AAA\n");
+    REQUIRE(resource.node.model.body == "AAA\n");
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].name == "Retrieve a message");
     REQUIRE(resource.node.actions[0].method == "GET");
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "AAA\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "AAA\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.size() == 1);
     REQUIRE(resource.sourceMap.name.sourceMap[0].location == 0);
@@ -538,14 +538,14 @@ TEST_CASE("Parse model with unrecognised resource", "[resource][model]")
     REQUIRE(resource.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(resource.node.model.name == "Resource");
-    REQUIRE(resource.node.model.assets.body.source == "AAA\n");
+    REQUIRE(resource.node.model.body == "AAA\n");
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].name == "Retrieve a resource");
     REQUIRE(resource.node.actions[0].method == "GET");
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "[Resource][]\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "[Resource][]\n");
     REQUIRE(resource.node.actions[0].examples[0].responses[0].description == "");
 }
 
@@ -586,7 +586,7 @@ TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source == "`resource model` 2\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body == "`resource model` 2\n");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first == "Content-Type");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second == "text/plain");
@@ -656,7 +656,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(resource.actions[0].examples[0].requests.size() == 1);
 
     REQUIRE(resource.actions[0].examples[0].requests[0].name == "");
-    REQUIRE(resource.actions[0].examples[0].requests[0].assets.body.source == "{ item }\n");
+    REQUIRE(resource.actions[0].examples[0].requests[0].body == "{ item }\n");
     REQUIRE(resource.actions[0].examples[0].requests[0].headers.size() == 1);
     REQUIRE(resource.actions[0].examples[0].requests[0].headers[0].first == "Content-Type");
     REQUIRE(resource.actions[0].examples[0].requests[0].headers[0].second == "application/json");
@@ -667,7 +667,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
 
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source == "[ { item 1 }, { item 2 } ]\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body == "[ { item 1 }, { item 2 } ]\n");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
 
     REQUIRE(resource.actions[0].examples[0].responses[0].reference.id == "Collection of Items");
@@ -869,7 +869,7 @@ TEST_CASE("Parse resource with multi-word named model", "[resource][model]")
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.model.name == "a really good name");
-    REQUIRE(resource.node.model.assets.body.source == "body of the `model`\n");
+    REQUIRE(resource.node.model.body == "body of the `model`\n");
     REQUIRE(resource.node.actions.empty());
 }
 
@@ -907,22 +907,22 @@ TEST_CASE("Dangling transaction example assets", "[resource]")
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].requests.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].requests[0].name == "A");
-    REQUIRE(resource.node.actions[0].examples[0].requests[0].assets.body.source == "dangling request body\n\n");
+    REQUIRE(resource.node.actions[0].examples[0].requests[0].body == "dangling request body\n\n");
 
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].assets.body.source == "dangling response body\n\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "dangling response body\n\n");
 
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].examples.collection.size() == 1);
     REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].assets.body.sourceMap.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].assets.body.sourceMap[0].location == 29);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].assets.body.sourceMap[0].length == 33);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap.size() == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap[0].location == 29);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap[0].length == 33);
     REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].assets.body.sourceMap.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].assets.body.sourceMap[0].location == 78);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].assets.body.sourceMap[0].length == 31);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap.size() == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap[0].location == 78);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap[0].length == 31);
 }
 
 TEST_CASE("Body list item in description", "[resource][regression][#190]")

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -68,7 +68,7 @@ TEST_CASE("Parse simple blueprint", "[parser]")
 
     Response& response = action.examples.front().responses[0];
     REQUIRE(response.name == "200");
-    REQUIRE(response.assets.body.source == "Text\n\n{ ... }\n");
+    REQUIRE(response.body == "Text\n\n{ ... }\n");
 }
 
 TEST_CASE("Parse blueprint with unsupported characters", "[parser]")
@@ -132,7 +132,7 @@ TEST_CASE("Support description ending with an list item", "[parser][#8]")
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source == "...\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body == "...\n");
 }
 
 TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[parser][#13]")
@@ -158,7 +158,7 @@ TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "304");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source.empty());
+    REQUIRE(resource.actions[0].examples[0].responses[0].body.empty());
 }
 
 TEST_CASE("SIGTERM parsing blueprint", "[parser][#45]")
@@ -218,9 +218,9 @@ TEST_CASE("Parse adjacent asset blocks", "[parser][#9]")
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 2);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source == "asset\n\npre\n\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body == "asset\n\npre\n\n");
     REQUIRE(resource.actions[0].examples[0].responses[1].name == "404");
-    REQUIRE(resource.actions[0].examples[0].responses[1].assets.body.source == "Not found\n");
+    REQUIRE(resource.actions[0].examples[0].responses[1].body == "Not found\n");
 }
 
 TEST_CASE("Parse adjacent asset list blocks", "[parser][#9]")
@@ -247,7 +247,7 @@ TEST_CASE("Parse adjacent asset list blocks", "[parser][#9]")
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source.empty());
+    REQUIRE(resource.actions[0].examples[0].responses[0].body.empty());
 }
 
 TEST_CASE("Parse adjacent nested asset blocks", "[parser][#9]")
@@ -280,7 +280,7 @@ TEST_CASE("Parse adjacent nested asset blocks", "[parser][#9]")
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source == "A\nB\nC\n\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body == "A\nB\nC\n\n");
 }
 
 TEST_CASE("Exception while parsing a blueprint with leading empty space", "[regression][parser]")
@@ -408,7 +408,7 @@ TEST_CASE("Dangling block not recognized", "[parser][regression][#186]")
     Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
     REQUIRE(resource.name == "A");
     REQUIRE(resource.uriTemplate == "/a");
-    REQUIRE(resource.model.assets.body.source == "    { ... }\n\n");
+    REQUIRE(resource.model.body == "    { ... }\n\n");
 }
 
 TEST_CASE("Ignoring block recovery", "[parser][regression][#188]")
@@ -477,7 +477,7 @@ TEST_CASE("Ignoring dangling model assets", "[parser][regression][#196]")
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].assets.body.source == "{ A }\n\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body == "{ A }\n\n");
 }
 
 TEST_CASE("Ignoring local media type", "[parser][regression][#195]")


### PR DESCRIPTION
This PR contains the following:

1. Reverted the previous commit where the `assets` key and `source` and `resolved` are introduced.
2. Serialisation of asset in AST in the new format.
3. Introduced `Element::Role` for the new format.

This PR does not contain the following:

1. Change the `Payload` structure and `PayloadParser` to be up to date with the latest spec.
2. Serialisation of asset source maps.

For @zdne to review and merge.