### PR TITLE
Implemented sourcemap serialization for asset & attributes

### DIFF
--- a/src/MSONSourcemap.cc
+++ b/src/MSONSourcemap.cc
@@ -10,6 +10,13 @@
 
 using namespace snowcrash;
 
+bool SourceMap<mson::NamedType>::empty() const
+{
+    return (name.sourceMap.empty() &&
+            typeDefinition.sourceMap.empty() &&
+            sections.collection.empty());
+}
+
 bool SourceMap<mson::ValueMember>::empty() const
 {
     return (description.sourceMap.empty() &&

--- a/src/MSONSourcemap.h
+++ b/src/MSONSourcemap.h
@@ -106,6 +106,9 @@ namespace snowcrash {
 
         /** Source Map of Type Sections */
         SourceMap<mson::TypeSections> sections;
+
+        /** Check if empty */
+        bool empty() const;
     };
 
     /** Source Map structure for Value Member */


### PR DESCRIPTION
To be rebased after #282. Contains the following:

1. Serialisation of asset source maps
2. Serialisation of attributes source maps

Based on the spec from apiaryio/api-blueprint-ast#28

For either @zdne or @klokane to review.