### PR TITLE
Improved resource relation and inline action

### DIFF
--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -527,6 +527,15 @@ namespace snowcrash {
                                 actions.end(),
                                 std::bind2nd(MatchAction(), action));
         }
+
+        /** Finds a relation identifier inside an actions collection */
+        static ActionIterator findRelation(const Actions& actions,
+                                           const Relation& relation) {
+
+            return std::find_if(actions.begin(),
+                                actions.end(),
+                                std::bind2nd(MatchRelation(), relation));
+        }
     };
 
     /** Action Section Parser */

--- a/src/BlueprintUtility.h
+++ b/src/BlueprintUtility.h
@@ -99,6 +99,13 @@ namespace snowcrash {
             return first.uriTemplate == second.uriTemplate && first.method == second.method;
         }
     };
+
+    /** Relation matching predicate. */
+    struct MatchRelation : std::binary_function<Action, Relation, bool> {
+        bool operator()(const first_argument_type& first, const second_argument_type& second) const {
+            return !first.relation.str.empty() && !second.str.empty() && first.relation.str == second.str;
+        }
+    };
 }
 
 #endif

--- a/src/RelationParser.h
+++ b/src/RelationParser.h
@@ -15,7 +15,7 @@
 namespace snowcrash {
 
     /** Link Relation matching regex */
-    const char* const RelationRegex = "^[[:blank:]]*[Rr]elation[[:blank:]]*:" SYMBOL_IDENTIFIER "?$";
+    const char* const RelationRegex = "^[[:blank:]]*[Rr]elation[[:blank:]]*:[[:blank:]]*([a-z][a-z0-9.-]*)?[[:blank:]]*$";
 
     /**
      *  Relation Section Processor
@@ -33,8 +33,9 @@ namespace snowcrash {
             CaptureGroups captureGroups;
 
             signature = GetFirstLine(node->text, remainingContent);
+            TrimString(signature);
 
-            if (RegexCapture(node->text, RelationRegex, captureGroups, 3)) {
+            if (RegexCapture(signature, RelationRegex, captureGroups, 3)) {
                 out.node.str = captureGroups[1];
                 TrimString(out.node.str);
             }

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -354,7 +354,12 @@ namespace snowcrash {
 
             if (!action.node.parameters.empty()) {
 
-                checkParametersEligibility(node, pd, action.node.parameters, out);
+                if (!action.node.uriTemplate.empty()) {
+                    checkParametersEligibility<Action>(node, pd, action.node.parameters, action);
+                }
+                else {
+                    checkParametersEligibility<Resource>(node, pd, action.node.parameters, out);
+                }
             }
 
             out.node.actions.push_back(action.node);
@@ -378,7 +383,7 @@ namespace snowcrash {
 
             if (!parameters.node.empty()) {
 
-                checkParametersEligibility(node, pd, parameters.node, out);
+                checkParametersEligibility<Resource>(node, pd, parameters.node, out);
                 out.node.parameters.insert(out.node.parameters.end(), parameters.node.begin(), parameters.node.end());
 
                 if (pd.exportSourceMap()) {
@@ -474,11 +479,16 @@ namespace snowcrash {
             return cur;
         }
 
-        /** Check Parameters eligibility in URI template */
+        /**
+         * \brief Check Parameters eligibility in URI template
+         *
+         * \warning Do not specialise this.
+         */
+        template<typename T>
         static void checkParametersEligibility(const MarkdownNodeIterator& node,
                                                const SectionParserData& pd,
                                                Parameters& parameters,
-                                               const ParseResultRef<Resource>& out) {
+                                               const ParseResultRef<T>& out) {
 
             for (ParameterIterator it = parameters.begin();
                  it != parameters.end();

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -352,6 +352,20 @@ namespace snowcrash {
                                                       sourceMap));
             }
 
+            ActionIterator relationDuplicate = SectionProcessor<Action>::findRelation(out.node.actions, action.node.relation);
+
+            if (relationDuplicate != out.node.actions.end()) {
+
+                // WARN: duplicate relation identifier
+                std::stringstream ss;
+                ss << "relation identifier '" << action.node.relation.str << "' already defined for resource '" << out.node.uriTemplate << "'";
+
+                mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceData);
+                out.report.warnings.push_back(Warning(ss.str(),
+                                                      DuplicateWarning,
+                                                      sourceMap));
+            }
+
             if (!action.node.parameters.empty()) {
 
                 if (!action.node.uriTemplate.empty()) {

--- a/test/test-RelationParser.cc
+++ b/test/test-RelationParser.cc
@@ -40,6 +40,62 @@ TEST_CASE("Relation signature without colon", "[relation]")
     REQUIRE(sectionType != RelationSectionType);
 }
 
+TEST_CASE("Relation identifier starting with non lower alphabet", "[relation]")
+{
+    mdp::ByteBuffer source = "+ Relation: 9delete";
+
+    mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
+    SectionType sectionType;
+    markdownParser.parse(source, markdownAST);
+
+    REQUIRE(!markdownAST.children().empty());
+    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    REQUIRE(sectionType != RelationSectionType);
+}
+
+TEST_CASE("Relation identifier containing capital letters", "[relation]")
+{
+    mdp::ByteBuffer source = "+ Relation: deLete";
+
+    mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
+    SectionType sectionType;
+    markdownParser.parse(source, markdownAST);
+
+    REQUIRE(!markdownAST.children().empty());
+    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    REQUIRE(sectionType != RelationSectionType);
+}
+
+TEST_CASE("Relation identifier containing special characters", "[relation]")
+{
+    mdp::ByteBuffer source = "+ Relation: del*et_e";
+
+    mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
+    SectionType sectionType;
+    markdownParser.parse(source, markdownAST);
+
+    REQUIRE(!markdownAST.children().empty());
+    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    REQUIRE(sectionType != RelationSectionType);
+}
+
+TEST_CASE("Relation identifier consisting of dots and dashes", "[relation]")
+{
+    mdp::ByteBuffer source = "+ Relation: delete-task.2";
+
+    mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
+    SectionType sectionType;
+    markdownParser.parse(source, markdownAST);
+
+    REQUIRE(!markdownAST.children().empty());
+    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    REQUIRE(sectionType == RelationSectionType);
+}
+
 TEST_CASE("Parse canonical link relation", "[relation]")
 {
     ParseResult<Relation> relation;

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -1072,3 +1072,28 @@ TEST_CASE("Parameters for action should consider action's uri template", "[resou
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
 }
+
+TEST_CASE("Relation identifiers should be unique for a resource", "[resource]")
+{
+    mdp::ByteBuffer source = \
+    "## Users [/users]\n"\
+    "\n"\
+    "### Create [POST]\n"\
+    "+ Relation: create\n"\
+    "+ Response 204\n"\
+    "\n"\
+    "### Delte [DELETE]\n"\
+    "+ Relation: create\n"\
+    "+ Response 204";
+
+    ParseResult<Resource> resource;
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+
+    REQUIRE(resource.report.error.code == Error::OK);
+    REQUIRE(resource.report.warnings.size() == 1);
+    REQUIRE(resource.report.warnings[0].code == DuplicateWarning);
+
+    REQUIRE(resource.node.actions.size() == 2);
+    REQUIRE(resource.node.actions[0].relation.str == "create");
+    REQUIRE(resource.node.actions[1].relation.str == "create");
+}

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -1011,7 +1011,7 @@ TEST_CASE("Parse unnamed resource attributes", "[resource]")
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
 }
 
-TEST_CASE("Parse inline action", "[resource][now]")
+TEST_CASE("Parse inline action", "[resource]")
 {
     mdp::ByteBuffer source = \
     "# Task [/task/{id}]\n"\
@@ -1047,4 +1047,28 @@ TEST_CASE("Parse inline action", "[resource][now]")
     REQUIRE(resource.sourceMap.actions.collection[0].uriTemplate.sourceMap.empty());
     SourceMapHelper::check(resource.sourceMap.actions.collection[1].method.sourceMap, 117, 31);
     SourceMapHelper::check(resource.sourceMap.actions.collection[1].uriTemplate.sourceMap, 117, 31);
+}
+
+TEST_CASE("Parameters for action should consider action's uri template", "[resource]")
+{
+    mdp::ByteBuffer source = \
+    "## Users [/users]\n"\
+    "\n"\
+    "### Create [POST]\n"\
+    "\n"\
+    "+ Response 204\n"\
+    "\n"\
+    "### Add a friend [POST /users/{username}/friends/{friend}]\n"\
+    "\n"\
+    "+ Parameters\n"\
+    "    + username\n"\
+    "    + friend\n"\
+    "\n"\
+    "+ Response 204";
+
+    ParseResult<Resource> resource;
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+
+    REQUIRE(resource.report.error.code == Error::OK);
+    REQUIRE(resource.report.warnings.empty());
 }


### PR DESCRIPTION
* Parameters for action will now consider action's uri template if it is defined instead of resource's uri template
* Parser will now give a warning if the relation identifiers are not unique for a resource
* Relation identifier will now use the regex defined in [RFC 5988](https://tools.ietf.org/html/rfc5988)