### PR TITLE
Remove integration tests command from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,7 @@
 version: 1.0.{build}
 
 install:
-  - git submodule update --init --recursive  
+  - git submodule update --init --recursive
 
 build_script:
-  - vcbuild.bat MSVC2013
-  
-before_test:
-  - gem install cucumber
-  - gem install bundle
-
-test_script:
-  - vcbuild.bat MSVC2013 inttest
-
+  - vcbuild.bat MSVC2013 test


### PR DESCRIPTION
The integration tests were remove in shared/mson branch, but the appveyor file in that branch still contains the commands to perform those tests. This happened because #300 was merged before @XVincentX has a chance to fix it. This PR fixes it.