### PR TITLE
Locate error when unable to find a named type used as super type

### DIFF
--- a/snowcrash.xcodeproj/project.pbxproj
+++ b/snowcrash.xcodeproj/project.pbxproj
@@ -73,7 +73,6 @@
 		BBCC856519542E5600B99E90 /* test-PayloadParser.cc in Sources */ = {isa = PBXBuildFile; fileRef = BBE5705C173922B70086CE22 /* test-PayloadParser.cc */; };
 		BBCC856719543A4D00B99E90 /* test-SectionParser.cc in Sources */ = {isa = PBXBuildFile; fileRef = BBCC856619543A4D00B99E90 /* test-SectionParser.cc */; };
 		BBCC856919545FCE00B99E90 /* Signature.cc in Sources */ = {isa = PBXBuildFile; fileRef = BBCC856819545FCE00B99E90 /* Signature.cc */; };
-		BBCEF19218FBF7B000A0FA24 /* Version.h in Headers */ = {isa = PBXBuildFile; fileRef = BBCEF19118FBF7B000A0FA24 /* Version.h */; };
 		BBD5F9C917353C310049BBEE /* ResourceGroupParser.h in Headers */ = {isa = PBXBuildFile; fileRef = BBD5F9C717353C300049BBEE /* ResourceGroupParser.h */; };
 		BBD5F9CE17353CE00049BBEE /* ResourceParser.h in Headers */ = {isa = PBXBuildFile; fileRef = BBD5F9CC17353CE00049BBEE /* ResourceParser.h */; };
 		BBD73564192ED417009FE09E /* HeadersParser.h in Headers */ = {isa = PBXBuildFile; fileRef = BBD73563192ED417009FE09E /* HeadersParser.h */; };
@@ -208,7 +207,6 @@
 		BBCC856119542DB300B99E90 /* test-ValuesParser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "test-ValuesParser.cc"; path = "test/test-ValuesParser.cc"; sourceTree = "<group>"; };
 		BBCC856619543A4D00B99E90 /* test-SectionParser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "test-SectionParser.cc"; path = "test/test-SectionParser.cc"; sourceTree = "<group>"; };
 		BBCC856819545FCE00B99E90 /* Signature.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Signature.cc; path = src/Signature.cc; sourceTree = "<group>"; };
-		BBCEF19118FBF7B000A0FA24 /* Version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Version.h; path = src/Version.h; sourceTree = "<group>"; };
 		BBD5F9C717353C300049BBEE /* ResourceGroupParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = ResourceGroupParser.h; path = src/ResourceGroupParser.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		BBD5F9CC17353CE00049BBEE /* ResourceParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = ResourceParser.h; path = src/ResourceParser.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		BBD5F9DD173578210049BBEE /* test-ResourceParser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = "test-ResourceParser.cc"; path = "test/test-ResourceParser.cc"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -387,7 +385,6 @@
 				BBFC8416196C0C0F001A236A /* UriTemplateParser.cc */,
 				BBFC8417196C0C0F001A236A /* UriTemplateParser.h */,
 				BBCC855D19542DA100B99E90 /* ValuesParser.h */,
-				BBCEF19118FBF7B000A0FA24 /* Version.h */,
 			);
 			name = libsnowcrash;
 			sourceTree = "<group>";
@@ -405,7 +402,6 @@
 				BBD73564192ED417009FE09E /* HeadersParser.h in Headers */,
 				BBCC855F19542DA100B99E90 /* ValuesParser.h in Headers */,
 				BBA91DC2171D402600649B05 /* BlueprintParser.h in Headers */,
-				BBCEF19218FBF7B000A0FA24 /* Version.h in Headers */,
 				BBB0F42A1731CE0D00C92465 /* RegexMatch.h in Headers */,
 				BBD5F9C917353C310049BBEE /* ResourceGroupParser.h in Headers */,
 				402612201A7779F600354E69 /* DataStructureGroupParser.h in Headers */,

--- a/src/MSON.h
+++ b/src/MSON.h
@@ -54,7 +54,7 @@ namespace mson {
     typedef std::map<Literal, BaseType> NamedTypeBaseTable;
 
     /** Named Types inheritance table */
-    typedef std::map<Literal, Literal> NamedTypeInheritanceTable;
+    typedef std::map<Literal, std::pair<Literal, mdp::BytesRangeSet> > NamedTypeInheritanceTable;
 
     /** A simple or actual value */
     struct Value {

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -584,7 +584,7 @@ TEST_CASE("Parsing blueprint with mson data structures", "[blueprint]")
 
     inheritanceIt = pd.namedTypeInheritanceTable.find("Plan");
     REQUIRE(inheritanceIt != pd.namedTypeInheritanceTable.end());
-    REQUIRE(inheritanceIt->second == "Plan Base");
+    REQUIRE(inheritanceIt->second.first == "Plan Base");
 
     REQUIRE(blueprint.node.content.elements().size() == 3);
     REQUIRE(blueprint.node.content.elements().at(2).element == Element::CategoryElement);
@@ -681,4 +681,5 @@ TEST_CASE("Report error when coming across a super type reference to non existen
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code != Error::OK);
+    SourceMapHelper::check(blueprint.report.error.location, 62, 27);
 }


### PR DESCRIPTION
During the preprocess stage of the Blueprint parsing where we get information about the named types and the inheritance graphs, if we are unable to find a named type, we give out an error. But that error doesn't use to have a source annotation to it. This PR fixes that bug.

/cc @Almad 