### PR TITLE
Give error when we find a circular reference

### DIFF
--- a/src/BlueprintParser.h
+++ b/src/BlueprintParser.h
@@ -491,7 +491,7 @@ namespace snowcrash {
 
                 // ERR: A named type is circularly referenced
                 std::stringstream ss;
-                ss << "base type '" << subType << "' circularly referencing itself is not allowed";
+                ss << "base type '" << subType << "' circularly referencing itself";
 
                 mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(nodeSourceMap, pd.sourceData);
                 report.error = Error(ss.str(), MSONError, sourceMap);

--- a/src/MSON.h
+++ b/src/MSON.h
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <string>
+#include <set>
 #include <map>
 #include <stdexcept>
 
@@ -55,6 +56,9 @@ namespace mson {
 
     /** Named Types inheritance table */
     typedef std::map<Literal, std::pair<Literal, mdp::BytesRangeSet> > NamedTypeInheritanceTable;
+
+    /** Named Types dependency table */
+    typedef std::map<Literal, std::set<Literal> > NamedTypeDependencyTable;
 
     /** A simple or actual value */
     struct Value {

--- a/src/MSONMixinParser.h
+++ b/src/MSONMixinParser.h
@@ -65,8 +65,13 @@ namespace snowcrash {
                                                       sourceMap));
             }
 
-            // Add mixin type as dependency
-            mson::addDependency(node, pd, out.node.typeSpecification.name.symbol.literal, pd.namedTypeContext, out.report);
+            // Check circular references
+            if (out.node.typeSpecification.name.base == mson::UndefinedTypeName &&
+                !out.node.typeSpecification.name.symbol.literal.empty() &&
+                !out.node.typeSpecification.name.symbol.variable) {
+
+                mson::addDependency(node, pd, out.node.typeSpecification.name.symbol.literal, pd.namedTypeContext, out.report);
+            }
 
             return ++MarkdownNodeIterator(node);
         }

--- a/src/MSONMixinParser.h
+++ b/src/MSONMixinParser.h
@@ -65,6 +65,9 @@ namespace snowcrash {
                                                       sourceMap));
             }
 
+            // Add mixin type as dependency
+            mson::addDependency(node, pd, out.node.typeSpecification.name.symbol.literal, pd.namedTypeContext, out.report);
+
             return ++MarkdownNodeIterator(node);
         }
 

--- a/src/MSONNamedTypeParser.h
+++ b/src/MSONNamedTypeParser.h
@@ -34,7 +34,7 @@ namespace snowcrash {
                                                       const Signature& signature,
                                                       const ParseResultRef<mson::NamedType>& out) {
 
-            mson::parseTypeName(signature.identifier, out.node.name);
+            mson::parseTypeName(signature.identifier, out.node.name, true);
             mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.typeDefinition);
 
             if (pd.exportSourceMap()) {
@@ -52,6 +52,9 @@ namespace snowcrash {
             if (out.node.typeDefinition.baseType == mson::UndefinedBaseType) {
                 out.node.typeDefinition.baseType = mson::ImplicitObjectBaseType;
             }
+
+            // Setup named type context
+            pd.namedTypeContext = out.node.name.symbol.literal;
 
             return ++MarkdownNodeIterator(node);
         }

--- a/src/MSONNamedTypeParser.h
+++ b/src/MSONNamedTypeParser.h
@@ -34,7 +34,7 @@ namespace snowcrash {
                                                       const Signature& signature,
                                                       const ParseResultRef<mson::NamedType>& out) {
 
-            mson::parseTypeName(signature.identifier, out.node.name, true);
+            mson::parseTypeName(signature.identifier, out.node.name, false);
             mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.typeDefinition);
 
             if (pd.exportSourceMap()) {

--- a/src/MSONUtility.h
+++ b/src/MSONUtility.h
@@ -121,28 +121,28 @@ namespace mson {
      *
      * \param subject String which represents the type name
      * \param typeName MSON Type Name
-     * \param notBaseType If true, will be parsed as a symbol
+     * \param isBaseType If false, will be parsed as a symbol
      */
     inline void parseTypeName(const std::string& subject,
                               TypeName& typeName,
-                              bool notBaseType = false) {
+                              bool isBaseType = true) {
 
-        if (!notBaseType && subject == "boolean") {
+        if (isBaseType && subject == "boolean") {
             typeName.base = BooleanTypeName;
         }
-        else if (!notBaseType && subject == "string") {
+        else if (isBaseType && subject == "string") {
             typeName.base = StringTypeName;
         }
-        else if (!notBaseType && subject == "number") {
+        else if (isBaseType && subject == "number") {
             typeName.base = NumberTypeName;
         }
-        else if (!notBaseType && subject == "array") {
+        else if (isBaseType && subject == "array") {
             typeName.base = ArrayTypeName;
         }
-        else if (!notBaseType && subject == "enum") {
+        else if (isBaseType && subject == "enum") {
             typeName.base = EnumTypeName;
         }
-        else if (!notBaseType && subject == "object") {
+        else if (isBaseType && subject == "object") {
             typeName.base = ObjectTypeName;
         }
         else {
@@ -444,7 +444,7 @@ namespace mson {
 
             // ERR: Dependency named type circular references itself
             std::stringstream ss;
-            ss << "base type '" << dependent << "' circularly referencing itself is not allowed";
+            ss << "base type '" << dependent << "' circularly referencing itself";
 
             mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceData);
             report.error = snowcrash::Error(ss.str(), snowcrash::MSONError, sourceMap);

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -105,6 +105,11 @@ namespace snowcrash {
 
                 case AttributesSectionType:
                 {
+                    // Set up named type context
+                    if (!out.node.name.empty()) {
+                        pd.namedTypeContext = out.node.name;
+                    }
+
                     ParseResultRef<Attributes> attributes(out.report, out.node.attributes, out.sourceMap.attributes);
                     MarkdownNodeIterator cur = AttributesParser::parse(node, siblings, pd, attributes);
 

--- a/src/SectionParserData.h
+++ b/src/SectionParserData.h
@@ -51,6 +51,9 @@ namespace snowcrash {
         /** Table mapping named type to sub types */
         mson::NamedTypeInheritanceTable namedTypeInheritanceTable;
 
+        /** Table mapping named types to their dependent named types */
+        mson::NamedTypeDependencyTable namedTypeDependencyTable;
+
         /** Model Table */
         ModelTable modelTable;
 

--- a/src/SectionParserData.h
+++ b/src/SectionParserData.h
@@ -54,6 +54,9 @@ namespace snowcrash {
         /** Table mapping named types to their dependent named types */
         mson::NamedTypeDependencyTable namedTypeDependencyTable;
 
+        /** Variable to store the current named type */
+        mson::Literal namedTypeContext;
+
         /** Model Table */
         ModelTable modelTable;
 

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -699,6 +699,21 @@ TEST_CASE("Report error when a Data Structure inherits from itself", "[blueprint
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
 }
 
+TEST_CASE("Report error when named type inherits a sub type in array", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## A (array[B])\n"\
+    "## B (A)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
 TEST_CASE("Report error when data Structure inheritance graph contains a cycle", "[blueprint]")
 {
     mdp::ByteBuffer source = \
@@ -707,6 +722,104 @@ TEST_CASE("Report error when data Structure inheritance graph contains a cycle",
     "## A (B)\n"\
     "## B (C)\n"\
     "## C (A)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 19, 9);
+}
+
+TEST_CASE("Report error when data Structure inheritance graph with only a few of them forming a cycle", "[blueprint]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## A (B)\n"\
+    "## B (C)\n"\
+    "## C (D)\n"\
+    "## D (E)\n"\
+    "## E (C)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 37, 9);
+}
+
+TEST_CASE("Report error when named sub type is referenced in nested members", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## A (B)\n"\
+    "## B\n"\
+    "+ person (A)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
+TEST_CASE("Report error when named sub type is referenced in nested members when reference happens first", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## B\n"\
+    "+ person (A)\n"\
+    "## A (B)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
+TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## A (B)\n"\
+    "## B\n"\
+    "+ Include A\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
+TEST_CASE("Report error when named sub type is referenced as mixin when reference happens first", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## B\n"\
+    "+ Include A\n"\
+    "## A (B)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
+TEST_CASE("Report error when named type references itself in array", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## Comment\n"\
+    "+ user (string)\n"\
+    "+ children (array[Comment])\n";
 
     ParseResult<Blueprint> blueprint;
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -764,6 +764,25 @@ TEST_CASE("Report error when named sub type is referenced in nested members", "[
     SourceMapHelper::check(blueprint.report.error.location, 28, 9);
 }
 
+TEST_CASE("Report error when there are circular references in nested members", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Data Structures\n"\
+    "\n"\
+    "## B (C)\n"\
+    "## C\n"\
+    "+ id (A)\n"
+    "\n"\
+    "## A\n"\
+    "+ id (B)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
 TEST_CASE("Report error when named sub type is referenced in nested members when reference happens first", "[blueprint][now]")
 {
     mdp::ByteBuffer source = \
@@ -771,6 +790,7 @@ TEST_CASE("Report error when named sub type is referenced in nested members when
     "\n"\
     "## B\n"\
     "+ person (A)\n"\
+    "\n"\
     "## A (B)\n";
 
     ParseResult<Blueprint> blueprint;
@@ -780,7 +800,27 @@ TEST_CASE("Report error when named sub type is referenced in nested members when
     SourceMapHelper::check(blueprint.report.error.location, 28, 9);
 }
 
-TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint][now]")
+TEST_CASE("Report error when a resource attributes type is circularly referenced in nested members", "[blueprint][now]")
+{
+    mdp::ByteBuffer source = \
+    "# Post [/]\n"\
+    "\n"\
+    "+ Attributes (B)\n"\
+    "    + id\n"\
+    "\n"\
+    "# Data Structures\n"\
+    "\n"\
+    "## B\n"\
+    "+ posts (Post)\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code == MSONError);
+    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+}
+
+TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
@@ -793,23 +833,24 @@ TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 35, 10);
 }
 
-TEST_CASE("Report error when named sub type is referenced as mixin when reference happens first", "[blueprint][now]")
+TEST_CASE("Report error when named sub type is referenced as mixin when reference happens first", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
     "\n"\
     "## B\n"\
     "+ Include A\n"\
+    "\n"\
     "## A (B)\n";
 
     ParseResult<Blueprint> blueprint;
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 26, 10);
 }
 
 TEST_CASE("Report error when named type references itself in array", "[blueprint][now]")

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -748,7 +748,7 @@ TEST_CASE("Report error when data Structure inheritance graph with only a few of
     SourceMapHelper::check(blueprint.report.error.location, 37, 9);
 }
 
-TEST_CASE("Report error when named sub type is referenced in nested members", "[blueprint][now]")
+TEST_CASE("Report error when named sub type is referenced in nested members", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
@@ -761,10 +761,10 @@ TEST_CASE("Report error when named sub type is referenced in nested members", "[
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 35, 11);
 }
 
-TEST_CASE("Report error when there are circular references in nested members", "[blueprint][now]")
+TEST_CASE("Report error when there are circular references in nested members", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
@@ -780,10 +780,10 @@ TEST_CASE("Report error when there are circular references in nested members", "
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 50, 7);
 }
 
-TEST_CASE("Report error when named sub type is referenced in nested members when reference happens first", "[blueprint][now]")
+TEST_CASE("Report error when named sub type is referenced in nested members when reference happens first", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
@@ -797,10 +797,10 @@ TEST_CASE("Report error when named sub type is referenced in nested members when
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 26, 11);
 }
 
-TEST_CASE("Report error when a resource attributes type is circularly referenced in nested members", "[blueprint][now]")
+TEST_CASE("Report error when a resource attributes type is circularly referenced in nested members", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Post [/]\n"\
@@ -817,7 +817,7 @@ TEST_CASE("Report error when a resource attributes type is circularly referenced
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 65, 13);
 }
 
 TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint]")
@@ -853,7 +853,7 @@ TEST_CASE("Report error when named sub type is referenced as mixin when referenc
     SourceMapHelper::check(blueprint.report.error.location, 26, 10);
 }
 
-TEST_CASE("Report error when named type references itself in array", "[blueprint][now]")
+TEST_CASE("Report error when named type references itself in array", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
@@ -866,7 +866,7 @@ TEST_CASE("Report error when named type references itself in array", "[blueprint
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 48, 26);
 }
 
 TEST_CASE("Report error when a named type is defined twice with inheritance", "[blueprint]")

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -699,7 +699,7 @@ TEST_CASE("Report error when a Data Structure inherits from itself", "[blueprint
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
 }
 
-TEST_CASE("Report error when named type inherits a sub type in array", "[blueprint][now]")
+TEST_CASE("Report error when named type inherits a sub type in array", "[blueprint]")
 {
     mdp::ByteBuffer source = \
     "# Data Structures\n"\
@@ -711,7 +711,7 @@ TEST_CASE("Report error when named type inherits a sub type in array", "[bluepri
     SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    SourceMapHelper::check(blueprint.report.error.location, 28, 9);
+    SourceMapHelper::check(blueprint.report.error.location, 35, 9);
 }
 
 TEST_CASE("Report error when data Structure inheritance graph contains a cycle", "[blueprint]")


### PR DESCRIPTION
This PR gives a parser error when the parser finds a circular reference among the named types. The old #315 only takes care of circular *inheritance*.

Note: It was a bit tricky to think about how to do this which is why it took me a bit of time.

@zdne @klokane Please review and merge.