### PR TITLE
[BlueprintParser] include missing iterator

### DIFF
--- a/src/BlueprintParser.h
+++ b/src/BlueprintParser.h
@@ -9,6 +9,7 @@
 #ifndef SNOWCRASH_BLUEPRINTPARSER_H
 #define SNOWCRASH_BLUEPRINTPARSER_H
 
+#include <iterator>
 #include <algorithm>
 #include "ResourceParser.h"
 #include "ResourceGroupParser.h"


### PR DESCRIPTION
This was causing failing builds in certain compilers/environments.