### PR TITLE
[sundown] Don't include unindented lines in list items

### DIFF
--- a/test/test-MSONTypeSectionParser.cc
+++ b/test/test-MSONTypeSectionParser.cc
@@ -246,8 +246,7 @@ TEST_CASE("Parse multi-line mson sample list type section with newline", "[mson]
     mdp::ByteBuffer source = \
     "- Sample\n\n"\
     "     red\n"\
-    "       green\n"\
-    "yellow";
+    "       green";
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
@@ -257,13 +256,13 @@ TEST_CASE("Parse multi-line mson sample list type section with newline", "[mson]
     REQUIRE(typeSection.report.warnings.empty());
 
     REQUIRE(typeSection.node.klass == mson::TypeSection::SampleClass);
-    REQUIRE(typeSection.node.content.value == " red\n   green\nyellow");
+    REQUIRE(typeSection.node.content.value == " red\n   green");
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().empty());
 
     REQUIRE(typeSection.sourceMap.value.sourceMap.size() == 2);
     SourceMapHelper::check(typeSection.sourceMap.value.sourceMap, 14, 5, 1);
-    SourceMapHelper::check(typeSection.sourceMap.value.sourceMap, 23, 15, 2);
+    SourceMapHelper::check(typeSection.sourceMap.value.sourceMap, 23, 8, 2);
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -725,3 +725,24 @@ TEST_CASE("Don't mess up sourcemaps when there are references", "[parser][#213]"
     REQUIRE(resourceSM.actions.collection[0].method.sourceMap[0].location == 111);
     REQUIRE(resourceSM.actions.collection[0].method.sourceMap[0].length == 8);
 }
+
+TEST_CASE("doesn't crash while parsing response followed by a block quote", "[parser][#322]")
+{
+    mdp::ByteBuffer source = \
+    "# GET /a\n\n"\
+    "+ Response 200\n\n"\
+    "        a\n"\
+    ">       b\n"\
+    "        e\n"\
+    "# B";
+
+    ParseResult<Blueprint> blueprint;
+    parse(source, ExportSourcemapOption, blueprint);
+
+    REQUIRE(blueprint.report.error.code == Error::OK);
+
+    SourceMap<Resource> resourceSM = blueprint.sourceMap.content.elements().collection[0].content.elements().collection[0].content.resource;
+    SourceMap<Action> actionSM = resourceSM.actions.collection[0];
+    SourceMap<Payload> payloadSM = actionSM.examples.collection[0].responses.collection[0];
+    SourceMapHelper::check(payloadSM.body.sourceMap, 30, 6);
+}


### PR DESCRIPTION
#### :warning: NOT READY FOR MERGE :warning:

Fixes #322 

There was some behaviour introduced in https://github.com/apiaryio/snowcrash/issues/9, which means that unindented list items are included in the list item which in this case, causes this crash.

I believe that in sundown the behaviour from https://github.com/apiaryio/sundown/pull/8 would be correct. However due to how #9 implements this breaks the behaviour where we assume that unindented content should be part of the list item. I've opened this pull request for discussion on how we should proceed. How should this be handled, since unindented content shouldn't be part of a list item but we've allowed this so far.

#### :warning: NOT READY FOR MERGE :warning: - also will needs rebase after dependent PR is merged.

/c @zdne