### PR TITLE
Fix link to App Veyor builds in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo](https://raw.github.com/apiaryio/api-blueprint/master/assets/logo_apiblueprint.png)
 
-# Snow Crash [![Build Status](https://travis-ci.org/apiaryio/snowcrash.svg?branch=master)](https://travis-ci.org/apiaryio/snowcrash) [![Build status](https://ci.appveyor.com/api/projects/status/gupp1f7ymifxh3yn/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/snowcrash/branch)
+# Snow Crash [![Build Status](https://travis-ci.org/apiaryio/snowcrash.svg?branch=master)](https://travis-ci.org/apiaryio/snowcrash) [![Build status](https://ci.appveyor.com/api/projects/status/gupp1f7ymifxh3yn/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/snowcrash)
 
 
 ### API Blueprint Parser


### PR DESCRIPTION
The previous link is a 404.

![screen shot 2015-08-04 at 14 41 39](https://cloud.githubusercontent.com/assets/44164/9060750/f167c752-3ab6-11e5-8f47-fc22c6607a01.png)
