### PR TITLE
adding null primitive type

### DIFF
--- a/src/MSON.h
+++ b/src/MSON.h
@@ -101,6 +101,7 @@ namespace mson {
     enum BaseTypeName {
         UndefinedTypeName = 0, // Not a base type name
         BooleanTypeName,       // `boolean` type name
+        NullTypeName,          // `null` type name
         StringTypeName,        // `string` type name
         NumberTypeName,        // `number` type name
         ArrayTypeName,         // `array` type name

--- a/src/MSONUtility.h
+++ b/src/MSONUtility.h
@@ -46,7 +46,8 @@ namespace mson {
 
         if ((type == StringTypeName) ||
             (type == NumberTypeName) ||
-            (type == BooleanTypeName)) {
+            (type == BooleanTypeName) ||
+            (type == NullTypeName)) {
 
             return PrimitiveBaseType;
         }
@@ -141,6 +142,9 @@ namespace mson {
         }
         else if (isBaseType && subject == "enum") {
             typeName.base = EnumTypeName;
+        }
+        else if (isBaseType && subject == "null") {
+            typeName.base = NullTypeName;
         }
         else if (isBaseType && subject == "object") {
             typeName.base = ObjectTypeName;


### PR DESCRIPTION
Based on the pull request apiaryio/mson/pull/35 adding the `null` primitive type I have additionally added support for this in snowcrash.

#### 2.1.1 Primitive Types
Applies to basic data structure and type definitions. _[Types][]_ that are sub-typed from _Primitive Types_ MUST NOT
contain a _[Member Type Group][]_ or _[Nested Member Types][]_.

- `null`

    Specifies a null type.

- `boolean`

    Specifies a type with allowed values of `true` or `false`.

- `string`

    Specifies any string.

- `number`

    Specifies any number.
