### PR TITLE
Addition of `nullable` type attribute

### DIFF
--- a/src/MSON.h
+++ b/src/MSON.h
@@ -134,7 +134,8 @@ namespace mson {
         OptionalTypeAttribute = (1 << 1),  // The type is optional
         FixedTypeAttribute    = (1 << 2),  // The type is fixed
         SampleTypeAttribute   = (1 << 3),  // The type is a sample
-        DefaultTypeAttribute  = (1 << 4)   // The type is default
+        DefaultTypeAttribute  = (1 << 4),  // The type is default
+        NullableTypeAttribute = (1 << 5)   // The type is nullable
     };
 
     /** List of type attributes */

--- a/src/MSONUtility.h
+++ b/src/MSONUtility.h
@@ -178,6 +178,9 @@ namespace mson {
         else if (attribute == "default") {
             typeAttributes |= DefaultTypeAttribute;
         }
+        else if (attribute == "nullable") {
+            typeAttributes |= NullableTypeAttribute;
+        }
         else {
             isAttribute = false;
         }

--- a/test/test-MSONUtility.cc
+++ b/test/test-MSONUtility.cc
@@ -187,6 +187,7 @@ TEST_CASE("Parse required type attribute", "[mson][utility]")
     REQUIRE((typeAttributes & FixedTypeAttribute) == 0);
     REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
     REQUIRE(isAttributeParsed);
 }
 
@@ -203,6 +204,7 @@ TEST_CASE("Parse optional type attribute", "[mson][utility]")
     REQUIRE((typeAttributes & FixedTypeAttribute) == 0);
     REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
     REQUIRE(isAttributeParsed);
 }
 
@@ -219,6 +221,7 @@ TEST_CASE("Parse fixed type attribute", "[mson][utility]")
     REQUIRE((typeAttributes & FixedTypeAttribute) == FixedTypeAttribute);
     REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
     REQUIRE(isAttributeParsed);
 }
 
@@ -235,6 +238,7 @@ TEST_CASE("Parse sample type attribute", "[mson][utility]")
     REQUIRE((typeAttributes & FixedTypeAttribute) == 0);
     REQUIRE((typeAttributes & SampleTypeAttribute) == SampleTypeAttribute);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
     REQUIRE(isAttributeParsed);
 }
 
@@ -251,6 +255,24 @@ TEST_CASE("Parse default type attribute", "[mson][utility]")
     REQUIRE((typeAttributes & FixedTypeAttribute) == 0);
     REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == DefaultTypeAttribute);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
+    REQUIRE(isAttributeParsed);
+}
+
+TEST_CASE("Parse nullable type attribute", "[mson][utility]")
+{
+    std::string source = "nullable";
+    TypeAttributes typeAttributes = 0;
+    
+    bool isAttributeParsed;
+    isAttributeParsed = parseTypeAttribute(source, typeAttributes);
+    
+    REQUIRE((typeAttributes & RequiredTypeAttribute) == 0);
+    REQUIRE((typeAttributes & OptionalTypeAttribute) == 0);
+    REQUIRE((typeAttributes & FixedTypeAttribute) == 0);
+    REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
+    REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == NullableTypeAttribute);
     REQUIRE(isAttributeParsed);
 }
 
@@ -267,6 +289,7 @@ TEST_CASE("Parse required type attribute enclosed in backticks", "[mson][utility
     REQUIRE((typeAttributes & FixedTypeAttribute) == 0);
     REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
+    REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
     REQUIRE(isAttributeParsed == false);
 }
 


### PR DESCRIPTION
+ This resolves #347 - based on apiaryio/mson#38 MSON now supports a `nullable` type attribute