### PR TITLE
Remove error for circular reference in members.

### DIFF
--- a/src/MSONMixinParser.h
+++ b/src/MSONMixinParser.h
@@ -70,7 +70,7 @@ namespace snowcrash {
                 !out.node.typeSpecification.name.symbol.literal.empty() &&
                 !out.node.typeSpecification.name.symbol.variable) {
 
-                mson::addDependency(node, pd, out.node.typeSpecification.name.symbol.literal, pd.namedTypeContext, out.report);
+                mson::addDependency(node, pd, out.node.typeSpecification.name.symbol.literal, pd.namedTypeContext, out.report, true);
             }
 
             return ++MarkdownNodeIterator(node);

--- a/src/MSONUtility.h
+++ b/src/MSONUtility.h
@@ -437,7 +437,8 @@ namespace mson {
                               snowcrash::SectionParserData& pd,
                               const mson::Literal dependency,
                               const mson::Literal dependent,
-                              snowcrash::Report& report) {
+                              snowcrash::Report& report,
+                              bool circularCheck = false) {
 
         // First, check if the type exists
         if (pd.namedTypeDependencyTable.find(dependency) == pd.namedTypeDependencyTable.end()) {
@@ -454,8 +455,8 @@ namespace mson {
         std::set<mson::Literal> dependencyDeps = pd.namedTypeDependencyTable[dependency];
 
         // Second, check if it is circular reference between them
-        if (dependent == dependency ||
-            dependencyDeps.find(dependent) != dependencyDeps.end()) {
+        if (circularCheck && (dependent == dependency ||
+                              dependencyDeps.find(dependent) != dependencyDeps.end())) {
 
             // ERR: Dependency named type circular references itself
             std::stringstream ss;


### PR DESCRIPTION
Keeps the error in inheritance references.
Tests are very basic, just checking that it does not produce an error,
the resulting ast is not validated in any way. Possible FIXME.
