### PR TITLE
Remove export source map option

### DIFF
--- a/src/SectionParserData.h
+++ b/src/SectionParserData.h
@@ -23,7 +23,6 @@ namespace snowcrash {
     enum BlueprintParserOption {
         RenderDescriptionsOption = (1 << 0),    /// < Render Markdown in description.
         RequireBlueprintNameOption = (1 << 1),  /// < Treat missing blueprint name as error
-        ExportSourcemapOption = (1 << 2)        /// < Export source maps AST
     };
 
     typedef unsigned int BlueprintParserOptions;
@@ -96,7 +95,7 @@ namespace snowcrash {
 
         /** \returns True if exporting source maps */
         bool exportSourceMap() const {
-            return options & ExportSourcemapOption;
+            return true;
         }
 
     private:

--- a/test/snowcrashtest.h
+++ b/test/snowcrashtest.h
@@ -172,8 +172,8 @@ namespace snowcrashtest {
                 REQUIRE(sourceMap.size() == 1);
             }
 
-            REQUIRE(sourceMap[nth - 1].location == loc);
-            REQUIRE(sourceMap[nth - 1].length == len);
+            REQUIRE(sourceMap[nth - 1].location == (size_t) loc);
+            REQUIRE(sourceMap[nth - 1].length == (size_t) len);
         }
     };
 }

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -40,7 +40,7 @@ TEST_CASE("Method block classifier", "[action]")
 TEST_CASE("Parsing action", "[action]")
 {
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(ActionFixture, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(ActionFixture, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -94,7 +94,7 @@ TEST_CASE("Parse Action description with list", "[action]")
     "+ Response 204\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -140,7 +140,7 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
     "            J\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // warn responses with the same name
@@ -203,7 +203,7 @@ TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
     "+ Response 200\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 2); // empty asset & preformatted asset
@@ -252,7 +252,7 @@ TEST_CASE("Parse method with foreign item", "[action]")
     "+ Response 200\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -291,7 +291,7 @@ TEST_CASE("Parse method with a HR", "[action]")
     "B\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // no response
@@ -316,7 +316,7 @@ TEST_CASE("Parse method without name", "[action]")
     mdp::ByteBuffer source = "# GET";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // no response
@@ -344,7 +344,7 @@ TEST_CASE("Parse action with parameters", "[action]")
     "\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -379,7 +379,7 @@ TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
     "        {}\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -407,7 +407,7 @@ TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
     "        {}\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -435,7 +435,7 @@ TEST_CASE("Missing 'LINK' HTTP request method", "[action]")
     "+ Response 204\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -467,7 +467,7 @@ TEST_CASE("Warn when request is not followed by a response", "[action]")
     "        A\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -507,7 +507,7 @@ TEST_CASE("Warn when request is not followed by a response", "[action]")
 //    NamedTypes namedTypes;
 //
 //    NamedTypeHelper::build("Coupon", mson::ObjectBaseType, namedTypes);
-//    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption, Models(), NULL, namedTypes);
+//    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, 0, Models(), NULL, namedTypes);
 //
 //    REQUIRE(action.report.error.code == Error::OK);
 //    REQUIRE(action.report.warnings.empty());

--- a/test/test-AssetParser.cc
+++ b/test/test-AssetParser.cc
@@ -62,7 +62,7 @@ TEST_CASE("Recognize schema signature", "[asset]")
 TEST_CASE("Parse body asset", "[asset]")
 {
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(BodyAssetFixture, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(BodyAssetFixture, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -76,7 +76,7 @@ TEST_CASE("Parse body asset", "[asset]")
 TEST_CASE("Parse schema asset", "[asset]")
 {
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(SchemaAssetFixture, SchemaSectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(SchemaAssetFixture, SchemaSectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -95,7 +95,7 @@ TEST_CASE("Foreign block inside", "[asset]")
     "    Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -117,7 +117,7 @@ TEST_CASE("Nested list block inside", "[asset]")
     "    + Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -140,7 +140,7 @@ TEST_CASE("Multiline signature", "[asset]")
     "        Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -168,7 +168,7 @@ TEST_CASE("Multiple blocks", "[asset]")
     "    Block 3\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 2);
@@ -193,7 +193,7 @@ TEST_CASE("Extra spaces before signature", "[asset]")
     "        Lorem Ipsum\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -212,7 +212,7 @@ TEST_CASE("Asset parser greediness", "[asset]")
     "+ Another Block\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());

--- a/test/test-AttributesParser.cc
+++ b/test/test-AttributesParser.cc
@@ -30,7 +30,7 @@ TEST_CASE("Recognize explicit attributes signature", "[attributes]")
 TEST_CASE("Parse canonical attributes", "[attributes]")
 {
     ParseResult<Attributes> attributes;
-    SectionParserHelper<Attributes, AttributesParser>::parse(AttributesFixture, AttributesSectionType, attributes, ExportSourcemapOption);
+    SectionParserHelper<Attributes, AttributesParser>::parse(AttributesFixture, AttributesSectionType, attributes);
 
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());
@@ -56,7 +56,7 @@ TEST_CASE("Parse attributes with nested members", "[attributes]")
     "    + author: john@appleseed.com (string) - Author of the blog post";
 
     ParseResult<Attributes> attributes;
-    SectionParserHelper<Attributes, AttributesParser>::parse(source, AttributesSectionType, attributes, ExportSourcemapOption);
+    SectionParserHelper<Attributes, AttributesParser>::parse(source, AttributesSectionType, attributes);
 
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());
@@ -109,7 +109,7 @@ TEST_CASE("Parse attributes with block description", "[attributes]")
     "        + message (string)";
 
     ParseResult<Attributes> attributes;
-    SectionParserHelper<Attributes, AttributesParser>::parse(source, AttributesSectionType, attributes, ExportSourcemapOption);
+    SectionParserHelper<Attributes, AttributesParser>::parse(source, AttributesSectionType, attributes);
 
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -52,7 +52,7 @@ TEST_CASE("Blueprint block classifier", "[blueprint]")
 TEST_CASE("Parse canonical blueprint", "[blueprint]")
 {
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(BlueprintFixture, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(BlueprintFixture, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -96,7 +96,7 @@ TEST_CASE("Parse blueprint with multiple metadata sections", "[blueprint]")
     source += BlueprintFixture;
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -150,7 +150,7 @@ TEST_CASE("Parse API with Name and abbreviated resource", "[blueprint]")
     "        {}";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -188,7 +188,7 @@ TEST_CASE("Parse nameless blueprint description", "[blueprint]")
     "# B\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -211,7 +211,7 @@ TEST_CASE("Parse nameless blueprint with a list description", "[blueprint]")
     mdp::ByteBuffer source = "+ List\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -241,7 +241,7 @@ TEST_CASE("Parse two groups with the same name", "[blueprint]")
     "# Group Name\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 2); // groups with same name & no response
@@ -299,7 +299,7 @@ TEST_CASE("Should parse nested lists in description", "[blueprint]")
     "   + Nested Item\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -342,7 +342,7 @@ TEST_CASE("Blueprint starting with Resource Group should be parsed", "[blueprint
     "## /posts";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -366,7 +366,7 @@ TEST_CASE("Blueprint starting with Resource should be parsed", "[blueprint]")
     mdp::ByteBuffer source = "# /posts";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -395,7 +395,7 @@ TEST_CASE("Checking a resource with global resources for duplicates", "[blueprin
     "### List posts [GET]\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 3); // 2x no response & duplicate resource
@@ -441,7 +441,7 @@ TEST_CASE("Parsing unexpected blocks", "[blueprint]")
     "# GET /\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1); // no response
@@ -558,7 +558,7 @@ TEST_CASE("Parsing blueprint with mson data structures", "[blueprint]")
     markdownParser.parse(source, markdownAST);
     REQUIRE(!markdownAST.children().empty());
 
-    snowcrash::SectionParserData pd(ExportSourcemapOption, source, blueprint.node);
+    snowcrash::SectionParserData pd(0, source, blueprint.node);
     pd.sectionsContext.push_back(BlueprintSectionType);
 
     BlueprintParser::parse(markdownAST.children().begin(), markdownAST.children(), pd, blueprint);
@@ -606,7 +606,7 @@ TEST_CASE("Parse blueprint with two named types having the same name", "[bluepri
     "    - name - Coupon name";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -641,7 +641,7 @@ TEST_CASE("Parser blueprint correctly when having a big chain of inheritance in 
     "Clone\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -678,7 +678,7 @@ TEST_CASE("Report error when coming across a super type reference to non existen
     "+ id: 25OFF (string)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 62, 27);
@@ -693,7 +693,7 @@ TEST_CASE("Report error when a Data Structure inherits from itself", "[blueprint
     "+ id (string)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
@@ -708,7 +708,7 @@ TEST_CASE("Report error when named type inherits a sub type in array", "[bluepri
     "## B (A)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 35, 9);
@@ -724,7 +724,7 @@ TEST_CASE("Report error when data Structure inheritance graph contains a cycle",
     "## C (A)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
@@ -742,7 +742,7 @@ TEST_CASE("Report error when data Structure inheritance graph with only a few of
     "## E (C)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 37, 9);
@@ -758,7 +758,7 @@ TEST_CASE("Do not report error when named sub type is referenced in nested membe
     "+ person (A)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -801,7 +801,7 @@ TEST_CASE("Do not report error when there are circular references in nested memb
     "+ id (B)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -857,7 +857,7 @@ TEST_CASE("Do not report error when named sub type is referenced in nested membe
     "## A (B)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -901,7 +901,7 @@ TEST_CASE("Do not report error when a resource attributes type is circularly ref
     "+ posts (Post)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -952,7 +952,7 @@ TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint
     "+ Include A\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 35, 10);
@@ -969,7 +969,7 @@ TEST_CASE("Report error when named sub type is referenced as mixin when referenc
     "## A (B)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 26, 10);
@@ -987,7 +987,7 @@ TEST_CASE("Report error when circular reference in mixins", "[blueprint]")
     "+ Include A\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 45, 10);
@@ -1003,7 +1003,7 @@ TEST_CASE("Do not report error when named type references itself in array", "[bl
     "+ children (array[Comment])\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -1043,7 +1043,7 @@ TEST_CASE("Report error when a named type is defined twice with inheritance", "[
     "## C (object)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
@@ -1058,7 +1058,7 @@ TEST_CASE("Report error when a named type is defined twice with base type", "[bl
     "## A (object)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 33, 14);
@@ -1074,7 +1074,7 @@ TEST_CASE("Report error when a named type is defined twice, once with base type 
     "## B (object)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     SourceMapHelper::check(blueprint.report.error.location, 28, 14);
@@ -1087,7 +1087,7 @@ TEST_CASE("Parse mson signature attributes with mismatched square brackets", "[b
     "+ Attributes (array[Note)";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
 }
@@ -1099,7 +1099,7 @@ TEST_CASE("Parse named type mson signature attributes with no closing bracket", 
     "## B (A(";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     REQUIRE(blueprint.report.error.message == "base type 'A(' is not defined in the document");
@@ -1118,7 +1118,7 @@ TEST_CASE("Parse correctly when a resource named type is non-circularly referenc
     "    + bla (Question)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
 }
@@ -1131,7 +1131,7 @@ TEST_CASE("Report error when not finding a super type of the nested member", "[b
     "+ choice (B)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     REQUIRE(blueprint.report.error.message == "base type 'B' is not defined in the document");
@@ -1145,7 +1145,7 @@ TEST_CASE("Report error when not finding a nested super type of the nested membe
     "+ choice (array[B])\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     REQUIRE(blueprint.report.error.message == "base type 'B' is not defined in the document");
@@ -1159,7 +1159,7 @@ TEST_CASE("Report error when not finding a mixin type", "[blueprint]")
     "+ Include B\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     REQUIRE(blueprint.report.error.message == "base type 'B' is not defined in the document");
@@ -1180,7 +1180,7 @@ TEST_CASE("When an object contains a mixin of array type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint, namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1203,7 +1203,7 @@ TEST_CASE("When an array contains a mixin of object type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint, namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1226,7 +1226,7 @@ TEST_CASE("When an object member contains a mixin of array type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint, namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1249,7 +1249,7 @@ TEST_CASE("When an array member contains a mixin of object type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint, namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1275,7 +1275,7 @@ TEST_CASE("Any named type data structure should be able to be overridden when re
     "                    + relation: family\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint, 0, Models(), &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());

--- a/test/test-DataStructureGroupParser.cc
+++ b/test/test-DataStructureGroupParser.cc
@@ -36,7 +36,7 @@ TEST_CASE("Parse canonical data structures", "[data_structure_group]")
     "## Email (array[string])";
 
     ParseResult<DataStructureGroup> dataStructureGroup;
-    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup, ExportSourcemapOption);
+    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup);
 
     REQUIRE(dataStructureGroup.report.error.code == Error::OK);
     REQUIRE(dataStructureGroup.report.warnings.empty());
@@ -86,7 +86,7 @@ TEST_CASE("Parse multiple data structures with type sections", "[data_structure_
     "## Email (array[string])";
 
     ParseResult<DataStructureGroup> dataStructureGroup;
-    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup, ExportSourcemapOption);
+    SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(source, DataStructureGroupSectionType, dataStructureGroup);
 
     REQUIRE(dataStructureGroup.report.error.code == Error::OK);
     REQUIRE(dataStructureGroup.report.warnings.empty());

--- a/test/test-HeadersParser.cc
+++ b/test/test-HeadersParser.cc
@@ -37,7 +37,7 @@ TEST_CASE("recognize headers signature", "[headers]")
 TEST_CASE("parse headers fixture", "[headers]")
 {
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(HeadersFixture, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(HeadersFixture, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.empty());
@@ -64,7 +64,7 @@ TEST_CASE("parse headers fixture", "[headers]")
 TEST_CASE("parse headers fixture with no empty line between signature and content", "[headers]")
 {
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(HeadersSignatureContentFixture, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(HeadersSignatureContentFixture, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // content in signature
@@ -90,7 +90,7 @@ TEST_CASE("parse malformed headers fixture", "[headers]")
     source += "        X-Custom-Header:\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // malformed header
@@ -148,7 +148,7 @@ TEST_CASE("Parse header section composed of multiple blocks", "[headers]")
     source += "        X-My-Header: 42\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // not a code block
@@ -178,7 +178,7 @@ TEST_CASE("Parse header section with missing headers", "[headers]")
     mdp::ByteBuffer source = "+ Headers\n\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // no headers

--- a/test/test-MSONMixinParser.cc
+++ b/test/test-MSONMixinParser.cc
@@ -41,7 +41,7 @@ TEST_CASE("Parse canonical mson mixin", "[mson][mixin]")
     NamedTypeHelper::build("Person", mson::ObjectBaseType, namedTypes);
 
     ParseResult<mson::Mixin> mixin;
-    SectionParserHelper<mson::Mixin, MSONMixinParser>::parseMSON(source, MSONMixinSectionType, mixin, ExportSourcemapOption, namedTypes);
+    SectionParserHelper<mson::Mixin, MSONMixinParser>::parseMSON(source, MSONMixinSectionType, mixin, 0, namedTypes);
 
     REQUIRE(mixin.report.error.code == Error::OK);
     REQUIRE(mixin.report.warnings.empty());
@@ -63,7 +63,7 @@ TEST_CASE("Parse mson mixin with canonical type definition", "[mson][mixin]")
     NamedTypeHelper::build("Person", mson::ObjectBaseType, namedTypes);
 
     ParseResult<mson::Mixin> mixin;
-    SectionParserHelper<mson::Mixin, MSONMixinParser>::parseMSON(source, MSONMixinSectionType, mixin, ExportSourcemapOption, namedTypes);
+    SectionParserHelper<mson::Mixin, MSONMixinParser>::parseMSON(source, MSONMixinSectionType, mixin, 0, namedTypes);
 
     REQUIRE(mixin.report.error.code == Error::OK);
     REQUIRE(mixin.report.warnings.empty());
@@ -82,7 +82,7 @@ TEST_CASE("Parse mson mixin with base type definition", "[mson][mixin]")
     mdp::ByteBuffer source = "- Include (string)";
 
     ParseResult<mson::Mixin> mixin;
-    SectionParserHelper<mson::Mixin, MSONMixinParser>::parse(source, MSONMixinSectionType, mixin, ExportSourcemapOption);
+    SectionParserHelper<mson::Mixin, MSONMixinParser>::parse(source, MSONMixinSectionType, mixin);
 
     REQUIRE(mixin.report.error.code == Error::OK);
     REQUIRE(mixin.report.warnings.size() == 1);
@@ -104,7 +104,7 @@ TEST_CASE("Parse mson mixin with nested type definition", "[mson][mixin]")
     NamedTypeHelper::build("Person", mson::ValueBaseType, namedTypes);
 
     ParseResult<mson::Mixin> mixin;
-    SectionParserHelper<mson::Mixin, MSONMixinParser>::parseMSON(source, MSONMixinSectionType, mixin, ExportSourcemapOption, namedTypes);
+    SectionParserHelper<mson::Mixin, MSONMixinParser>::parseMSON(source, MSONMixinSectionType, mixin, 0, namedTypes);
 
     REQUIRE(mixin.report.error.code == Error::OK);
     REQUIRE(mixin.report.warnings.empty());

--- a/test/test-MSONNamedTypeParser.cc
+++ b/test/test-MSONNamedTypeParser.cc
@@ -27,7 +27,7 @@ TEST_CASE("Parse canonical mson named type", "[mson][named_type]")
     "        - name: Medium (string)\n";
 
     ParseResult<mson::NamedType> namedType;
-    SectionParserHelper<mson::NamedType, MSONNamedTypeParser>::parse(source, MSONNamedTypeSectionType, namedType, ExportSourcemapOption);
+    SectionParserHelper<mson::NamedType, MSONNamedTypeParser>::parse(source, MSONNamedTypeSectionType, namedType);
 
     mson::Element element, subelement;
     SourceMap<mson::Element> elementSM, subelementSM;
@@ -158,7 +158,7 @@ TEST_CASE("Parse named type with a type section", "[mson][named_type]")
     "## Sample: pksunkara";
 
     ParseResult<mson::NamedType> namedType;
-    SectionParserHelper<mson::NamedType, MSONNamedTypeParser>::parse(source, MSONNamedTypeSectionType, namedType, ExportSourcemapOption);
+    SectionParserHelper<mson::NamedType, MSONNamedTypeParser>::parse(source, MSONNamedTypeSectionType, namedType);
 
     REQUIRE(namedType.report.error.code == Error::OK);
     REQUIRE(namedType.report.warnings.empty());
@@ -186,7 +186,7 @@ TEST_CASE("Parse named type without type specification", "[mson][named_type]")
     "## Sample: pksunkara";
 
     ParseResult<mson::NamedType> namedType;
-    SectionParserHelper<mson::NamedType, MSONNamedTypeParser>::parse(source, MSONNamedTypeSectionType, namedType, ExportSourcemapOption);
+    SectionParserHelper<mson::NamedType, MSONNamedTypeParser>::parse(source, MSONNamedTypeSectionType, namedType);
 
     REQUIRE(namedType.report.error.code == Error::OK);
     REQUIRE(namedType.report.warnings.size() == 1);

--- a/test/test-MSONOneOfParser.cc
+++ b/test/test-MSONOneOfParser.cc
@@ -56,7 +56,7 @@ TEST_CASE("Parse canonical mson one of", "[mson][one_of]")
     "  - province: Madras";
 
     ParseResult<mson::OneOf> oneOf;
-    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf, ExportSourcemapOption);
+    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf);
 
     REQUIRE(oneOf.report.error.code == Error::OK);
     REQUIRE(oneOf.report.warnings.empty());
@@ -96,7 +96,7 @@ TEST_CASE("Parse mson one of without any nested members", "[mson][one_of]")
     mdp::ByteBuffer source = "- One of\n";
 
     ParseResult<mson::OneOf> oneOf;
-    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf, ExportSourcemapOption);
+    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf);
 
     REQUIRE(oneOf.report.error.code == Error::OK);
     REQUIRE(oneOf.report.warnings.size() == 1);
@@ -116,7 +116,7 @@ TEST_CASE("Parse mson one of with one of", "[mson][one_of]")
     "        - suffixed_name";
 
     ParseResult<mson::OneOf> oneOf;
-    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf, ExportSourcemapOption);
+    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf);
 
     REQUIRE(oneOf.report.error.code == Error::OK);
     REQUIRE(oneOf.report.warnings.empty());
@@ -158,7 +158,7 @@ TEST_CASE("Parse mson one of with member group", "[mson][one_of]")
     "        - last_name";
 
     ParseResult<mson::OneOf> oneOf;
-    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf, ExportSourcemapOption);
+    SectionParserHelper<mson::OneOf, MSONOneOfParser>::parseMSON(source, MSONOneOfSectionType, oneOf);
 
     REQUIRE(oneOf.report.error.code == Error::OK);
     REQUIRE(oneOf.report.warnings.empty());

--- a/test/test-MSONParameterParser.cc
+++ b/test/test-MSONParameterParser.cc
@@ -23,7 +23,7 @@ const mdp::ByteBuffer ParameterFixture = \
 TEST_CASE("Parse canonical parameter definition with new syntax", "[mson_parameter]")
 {
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(ParameterFixture, MSONParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(ParameterFixture, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -59,7 +59,7 @@ TEST_CASE("Parse parameter description when it occurs in different cases", "[mso
     "    Double newline\n";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -78,7 +78,7 @@ TEST_CASE("Parse parameter when it has more than 2 traits", "[mson_parameter]")
     mdp::ByteBuffer source = "+ id: 100 (optional, number, tagging)";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);

--- a/test/test-MSONPropertyMemberParser.cc
+++ b/test/test-MSONPropertyMemberParser.cc
@@ -18,7 +18,7 @@ TEST_CASE("Parse canonical mson property member", "[mson][property_member]")
     "- color: red (string, required) - A color";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -45,7 +45,7 @@ TEST_CASE("Parse mson property member with description not on new line", "[mson]
     "  Which is also very nice\n\n";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -77,7 +77,7 @@ TEST_CASE("Parse mson property member with block description", "[mson][property_
     "and really really nice\n\n";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -112,7 +112,7 @@ TEST_CASE("Parse mson property member with block description, default and sample
     "        green\n";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -150,7 +150,7 @@ TEST_CASE("Parse mson property member object with nested members", "[mson][prope
     "    - last_name: Sunkara (string)";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -197,7 +197,7 @@ TEST_CASE("Parse mson array property member with nested properties type section"
     "        - last_name";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.size() == 1);
@@ -220,7 +220,7 @@ TEST_CASE("Parse mson property member when it has a member group in nested membe
     "    - first_name (string)";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -255,7 +255,7 @@ TEST_CASE("Parse mson property member when it has multiple member groups", "[mso
     "        - first_name";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -292,7 +292,7 @@ TEST_CASE("Parse mson property member when it has the wrong member group", "[mso
     "        - last_name";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.size() == 1);
@@ -315,7 +315,7 @@ TEST_CASE("Parse mson property member when it is an object and has no sub-type s
     "        - last_name: sunkara (string)";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -354,7 +354,7 @@ TEST_CASE("Parse mson property member when it is an object and has no sub-type s
     "    - first_name: pavan (string)";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.size() == 1);
@@ -402,7 +402,7 @@ TEST_CASE("Parse mson property member when it is a string and has no sub-type sp
     "    - Sample: Pavan, Sunkara";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -434,7 +434,7 @@ TEST_CASE("Parse mson property member when no sub-type specified and no nested s
     "    Some block description";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -466,7 +466,7 @@ TEST_CASE("Parse mson property member when containing a mixin", "[mson][property
     NamedTypeHelper::build("Person", mson::ObjectBaseType, namedTypes);
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption, Models(), NULL, namedTypes);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, 0, Models(), NULL, namedTypes);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -500,7 +500,7 @@ TEST_CASE("Parse mson property member when containing an oneOf", "[mson][propert
     "        - given_name: Smith";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -539,7 +539,7 @@ TEST_CASE("Parse mson property member containing a list of values and no type sp
     "- list: 1, 2, 3";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -563,7 +563,7 @@ TEST_CASE("Parse mson property containing list of value with string type specifi
     "- list: 1, 2, 3 (string)";
 
     ParseResult<mson::PropertyMember> propertyMember;
-    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+    SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(source, MSONPropertyMemberSectionType, propertyMember);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());

--- a/test/test-MSONTypeSectionParser.cc
+++ b/test/test-MSONTypeSectionParser.cc
@@ -90,7 +90,7 @@ TEST_CASE("Parse canonical mson sample list type section", "[mson][type_section]
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -112,7 +112,7 @@ TEST_CASE("Parse array mson sample list type section", "[mson][type_section]")
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -142,7 +142,7 @@ TEST_CASE("Parse mson sample list type section for a string but having values", 
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -164,7 +164,7 @@ TEST_CASE("Parse mson sample list type section for an object with a value", "[ms
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ObjectBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.size() == 1);
@@ -189,7 +189,7 @@ TEST_CASE("Parse mson sample list type section with values as list items", "[mso
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -222,7 +222,7 @@ TEST_CASE("Parse multi-line mson sample list type section without newline", "[ms
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -251,7 +251,7 @@ TEST_CASE("Parse multi-line mson sample list type section with newline", "[mson]
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -277,7 +277,7 @@ TEST_CASE("Parse mson sample list type section with values as para for values ba
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -301,7 +301,7 @@ TEST_CASE("Parse markdown multi-line mson sample list type section", "[mson][typ
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -327,7 +327,7 @@ TEST_CASE("Parse mson sample header type section with values as list items", "[m
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -360,7 +360,7 @@ TEST_CASE("Parse multi-line mson sample header type section", "[mson][type_secti
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -385,7 +385,7 @@ TEST_CASE("Parse multi-line mson sample header type section with multiple nested
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -409,7 +409,7 @@ TEST_CASE("Parse markdown multi-line mson sample header type section", "[mson][t
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -434,7 +434,7 @@ TEST_CASE("Parse mson items list type section for values base type containing on
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.size() == 1);
@@ -456,7 +456,7 @@ TEST_CASE("Parse mson properties list type section for values base type", "[mson
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.size() == 1);
@@ -481,7 +481,7 @@ TEST_CASE("Parse mson sample type section for a simple object", "[mson][type_sec
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ObjectBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -541,7 +541,7 @@ TEST_CASE("Parse mson sample type section for a complex object", "[mson][type_se
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ObjectBaseType;
-    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+    SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(source, MSONSampleDefaultSectionType, typeSection);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());

--- a/test/test-MSONValueMemberParser.cc
+++ b/test/test-MSONValueMemberParser.cc
@@ -18,7 +18,7 @@ TEST_CASE("Parse canonical mson value member", "[mson][value_member]")
     "- red (string, required) - A color";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());
@@ -42,7 +42,7 @@ TEST_CASE("Parse mson value member with description not on new line", "[mson][va
     "  Which is also very nice\n\n";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());
@@ -69,7 +69,7 @@ TEST_CASE("Parse mson value member with block description", "[mson][value_member
     "and really really nice\n\n";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());
@@ -100,7 +100,7 @@ TEST_CASE("Parse mson value member with block description, default and sample", 
     "        green\n";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());
@@ -138,7 +138,7 @@ TEST_CASE("Parse mson value member array with sample", "[mson][value_member]")
     "        - yellow\n";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());
@@ -164,7 +164,7 @@ TEST_CASE("Parse mson value member with multiple values", "[mson][value_member]"
     "- 1, yellow, true";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());
@@ -189,7 +189,7 @@ TEST_CASE("Parse mson value member array with items", "[mson][value_member]")
     "    - green (string)";
 
     ParseResult<mson::ValueMember> valueMember;
-    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember);
 
     REQUIRE(valueMember.report.error.code == Error::OK);
     REQUIRE(valueMember.report.warnings.empty());

--- a/test/test-ParameterParser.cc
+++ b/test/test-ParameterParser.cc
@@ -259,7 +259,7 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses old syntax for 
 TEST_CASE("Parse canonical parameter definition", "[parameter]")
 {
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(ParameterFixture, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(ParameterFixture, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     CHECK(parameter.report.warnings.empty());
@@ -315,7 +315,7 @@ TEST_CASE("Warn when re-setting the values attribute", "[parameter]")
     "        + `Hello`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -358,7 +358,7 @@ TEST_CASE("Parse full abbreviated syntax", "[parameter]")
     mdp::ByteBuffer source = "+ limit = `20` (optional, number, `42`) ... This is a limit\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     CHECK(parameter.report.warnings.empty());
@@ -397,7 +397,7 @@ TEST_CASE("Warn on error in abbreviated syntax attribute bracket", "[parameter]"
     mdp::ByteBuffer source = "+ limit (string1, string2, string3) ... This is a limit\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -429,7 +429,7 @@ TEST_CASE("Warn about required vs default clash", "[parameter]")
     mdp::ByteBuffer source = "+ id = `42` (required)\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -459,7 +459,7 @@ TEST_CASE("Warn about implicit required vs default clash", "[parameter_definitio
     mdp::ByteBuffer source = "+ id = `42`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -490,7 +490,7 @@ TEST_CASE("Unrecognized 'values' keyword", "[parameter]")
     "        + `lorem`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -523,7 +523,7 @@ TEST_CASE("Warn missing example item in values", "[parameter]")
     "        + `Value2`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -547,7 +547,7 @@ TEST_CASE("Warn missing default value in values", "[parameter]")
     "        + `Value2`\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -568,7 +568,7 @@ TEST_CASE("Parse parameters with dot in its name", "[parameter]")
     mdp::ByteBuffer source = "+ product.id ... Hello\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -594,7 +594,7 @@ TEST_CASE("Parentheses in parameter description", "[parameter]")
     mdp::ByteBuffer source = "+ id (string) ... lorem (ipsum)\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -625,7 +625,7 @@ TEST_CASE("Parameter with additional description", "[parameter]")
     "  Additional description";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -658,7 +658,7 @@ TEST_CASE("Parameter with additional description as continuation of signature", 
     "  Additional description\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -691,7 +691,7 @@ TEST_CASE("Parameter with list in description", "[parameter]")
     "  + Mauris condimentum\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());

--- a/test/test-ParametersParser.cc
+++ b/test/test-ParametersParser.cc
@@ -39,8 +39,7 @@ TEST_CASE("Parse canonical parameters", "[parameters]")
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(ParametersFixture,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());
@@ -89,8 +88,7 @@ TEST_CASE("Parse illegal parameter among legal ones", "[parameters]")
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -123,8 +121,7 @@ TEST_CASE("Warn about additional content in parameters section", "[parameters]")
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -151,8 +148,7 @@ TEST_CASE("Warn about additional content block in parameters section", "[paramet
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -179,8 +175,7 @@ TEST_CASE("Warn about multiple parameters with the same name", "[parameters]")
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -219,8 +214,7 @@ TEST_CASE("Recognize parameter when there is no description on its signature and
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());
@@ -389,8 +383,7 @@ TEST_CASE("Parse old style parameter in parameters with non-complete default val
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 1);
@@ -409,8 +402,7 @@ TEST_CASE("Parse old style parameter in parameters with non-complete example val
     ParseResult<Parameters> parameters;
     SectionParserHelper<Parameters, ParametersParser>::parse(source,
                                                              ParametersSectionType,
-                                                             parameters,
-                                                             ExportSourcemapOption);
+                                                             parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 2);

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -85,7 +85,7 @@ TEST_CASE("recognize empty body response signature as non-abbreviated", "[payloa
 TEST_CASE("Parse request payload", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(RequestFixture, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(RequestFixture, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -126,7 +126,7 @@ TEST_CASE("Parse request payload", "[payload]")
 TEST_CASE("Parse abbreviated payload body", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(ResponseBodyFixture, ResponseBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(ResponseBodyFixture, ResponseBodySectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -158,7 +158,7 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     source += "  B\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.size() == 1); // preformatted code block
@@ -203,7 +203,7 @@ TEST_CASE("Parse payload description with list", "[payload]")
     "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -246,7 +246,7 @@ TEST_CASE("Parse payload with foreign list item", "[payload]")
     "    + Bar\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.size() == 1); // dangling block
@@ -285,7 +285,7 @@ TEST_CASE("Parse payload with dangling body", "[payload]")
     source += "    Bar\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1); // dangling block
@@ -315,7 +315,7 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     ModelHelper::build("Symbol", models);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(ModelFixture, RequestBodySectionType, payload, ExportSourcemapOption, models);
+    SectionParserHelper<Payload, PayloadParser>::parse(ModelFixture, RequestBodySectionType, payload, 0, models);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 0);
@@ -348,7 +348,7 @@ TEST_CASE("Parse inline payload with symbol reference with extra indentation", "
     ModelHelper::build("Symbol", models);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption, models);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, 0, models);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -379,7 +379,7 @@ TEST_CASE("Parse inline payload with symbol reference with foreign content", "[p
     ModelHelper::build("Symbol", models);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption, models);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, 0, models);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1); // ignoring foreign entry
@@ -415,7 +415,7 @@ TEST_CASE("Parse named model", "[payload]")
     source += "        Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -456,7 +456,7 @@ TEST_CASE("Parse nameless model", "[payload]")
     source += "        Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -504,7 +504,7 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     source += "            Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -541,7 +541,7 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     "            Content-Length: 100\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -567,7 +567,7 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     "            Content-Length: 100\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -648,7 +648,7 @@ TEST_CASE("Give a warning when 100 response has a body", "[payload]")
 TEST_CASE("Empty body section should shouldn't be parsed as description", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(EmptyBodyFixture, ResponseSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(EmptyBodyFixture, ResponseSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -694,7 +694,7 @@ TEST_CASE("Values section should be taken as a description node", "[payload]")
     "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -723,7 +723,7 @@ TEST_CASE("Parameters section in response section should give a warning", "[payl
     "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);

--- a/test/test-RelationParser.cc
+++ b/test/test-RelationParser.cc
@@ -43,7 +43,7 @@ TEST_CASE("Relation signature without colon", "[relation]")
 TEST_CASE("Parse canonical link relation", "[relation]")
 {
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(RelationFixture, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(RelationFixture, RelationSectionType, relation);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.empty());
@@ -66,7 +66,7 @@ TEST_CASE("Relation identifier starting with non lower alphabet", "[relation]")
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.size() == 1);
@@ -88,7 +88,7 @@ TEST_CASE("Relation identifier containing capital letters", "[relation]")
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.size() == 1);
@@ -110,7 +110,7 @@ TEST_CASE("Relation identifier containing special characters", "[relation]")
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.size() == 1);
@@ -132,7 +132,7 @@ TEST_CASE("Relation identifier consisting of dots and dashes", "[relation]")
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.empty());

--- a/test/test-ResourceGroupParser.cc
+++ b/test/test-ResourceGroupParser.cc
@@ -49,8 +49,7 @@ TEST_CASE("Parse canonical resource group", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(ResourceGroupFixture,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -81,8 +80,7 @@ TEST_CASE("Parse resource group with empty resource", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -114,8 +112,7 @@ TEST_CASE("Parse multiple resource in anonymous group", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -150,8 +147,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 4);
@@ -201,8 +197,7 @@ TEST_CASE("Parse multiple resources with the same name", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 1);
@@ -229,8 +224,7 @@ TEST_CASE("Parse resource with list in its description", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 3);   // preformatted asset & ignoring unrecognized node & no response
@@ -262,8 +256,7 @@ TEST_CASE("Parse resource groups with hr in description", "[resource_group]")
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -289,8 +282,7 @@ TEST_CASE("Make sure method followed by a group does not eat the group", "[resou
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 1); // no response
@@ -319,8 +311,7 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 2); // no response && unexpected action POST
@@ -353,8 +344,7 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.size() == 2); // 2x no response
@@ -397,8 +387,7 @@ TEST_CASE("Resource followed by a complete action", "[resource_group][regression
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -446,8 +435,7 @@ TEST_CASE("Too eager complete action processing", "[resource_group][regression][
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(source,
                                                                    ResourceGroupSectionType,
-                                                                   resourceGroup,
-                                                                   ExportSourcemapOption);
+                                                                   resourceGroup);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -61,7 +61,7 @@ TEST_CASE("Resource block classifier", "[resource]")
 TEST_CASE("Parse resource", "[resource]")
 {
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(ResourceFixture, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(ResourceFixture, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -120,7 +120,7 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     "p1\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // no response & preformatted asset
@@ -162,7 +162,7 @@ TEST_CASE("Parse multiple method descriptions", "[resource]")
     "p2\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // 2x no response
@@ -211,7 +211,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     "E\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // empty reuqest asset & no response
@@ -272,7 +272,7 @@ TEST_CASE("Parse description with list", "[resource]")
     "p1\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -302,7 +302,7 @@ TEST_CASE("Parse resource with a HR", "[resource][block]")
     "B\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -333,7 +333,7 @@ TEST_CASE("Parse resource method abbreviation", "[resource]")
     "            {}\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -364,7 +364,7 @@ TEST_CASE("Parse resource without name", "[resource]")
     mdp::ByteBuffer source = "# /resource\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -396,7 +396,7 @@ TEST_CASE("Warn about parameters not in URI template", "[resource][source]")
     "+ Response 204\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2);
@@ -428,7 +428,7 @@ TEST_CASE("Parse nameless resource with named model", "[resource][model][source]
     "\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -459,7 +459,7 @@ TEST_CASE("Parse nameless resource with nameless model", "[resource][model][sour
     "\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == ModelError);
     REQUIRE(resource.report.warnings.empty());
@@ -488,7 +488,7 @@ TEST_CASE("Parse named resource with nameless model", "[resource][model][source]
     "    [Message][]\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -562,7 +562,7 @@ TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue
     "        `resource model` 2\n";
 
     ParseResult<Blueprint> blueprint;
-    parse(source, ExportSourcemapOption, blueprint);
+    parse(source, 0, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -731,7 +731,7 @@ TEST_CASE("Parse root resource", "[resource]")
     mdp::ByteBuffer source = "# API Root [/]\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -756,7 +756,7 @@ TEST_CASE("Parse resource with invalid URI Tempalte", "[resource]")
     mdp::ByteBuffer source = "# Resource [/id{? limit}]\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1);
@@ -791,7 +791,7 @@ TEST_CASE("Deprecated resource and action headers", "[resource]")
     "            header3: value3\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2);
@@ -891,7 +891,7 @@ TEST_CASE("Dangling transaction example assets", "[resource]")
     "```\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 3);
@@ -938,7 +938,7 @@ TEST_CASE("Body list item in description", "[resource][regression][#190]")
     "+ Response 200\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -966,7 +966,7 @@ TEST_CASE("Parse resource attributes", "[resource]")
 
     NamedTypeHelper::build("Coupon", mson::ObjectBaseType, namedTypes);
     NamedTypeHelper::build("Coupons", mson::ValueBaseType, namedTypes);
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption, Models(), NULL, namedTypes);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, 0, Models(), NULL, namedTypes);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -995,7 +995,7 @@ TEST_CASE("Parse unnamed resource attributes", "[resource]")
     NamedTypes namedTypes;
 
     NamedTypeHelper::build("Coupon", mson::ObjectBaseType, namedTypes);
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption, Models(), NULL, namedTypes);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, 0, Models(), NULL, namedTypes);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1); // Unknown type 'Coupons'
@@ -1029,7 +1029,7 @@ TEST_CASE("Parse inline action", "[resource]")
     "        {}";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -1067,7 +1067,7 @@ TEST_CASE("Parameters for action should consider action's uri template", "[resou
     "+ Response 204";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -1087,7 +1087,7 @@ TEST_CASE("Relation identifiers should be unique for a resource", "[resource]")
     "+ Response 204";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1);

--- a/test/test-ValuesParser.cc
+++ b/test/test-ValuesParser.cc
@@ -33,7 +33,7 @@ TEST_CASE("Recognize values signature", "[values]")
 TEST_CASE("Parse canonical values", "[values]")
 {
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(ValuesFixture, ValuesSectionType, values, ExportSourcemapOption);
+    SectionParserHelper<Values, ValuesParser>::parse(ValuesFixture, ValuesSectionType, values);
 
     REQUIRE(values.report.error.code == Error::OK);
     CHECK(values.report.warnings.empty());
@@ -63,7 +63,7 @@ TEST_CASE("Warn superfluous content in values attribute", "[values]")
     "    + `Hello`\n";
 
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values, ExportSourcemapOption);
+    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values);
 
     REQUIRE(values.report.error.code == Error::OK);
     REQUIRE(values.report.warnings.size() == 1);
@@ -87,7 +87,7 @@ TEST_CASE("Warn about illegal entities in values attribute", "[values]")
     "    + `Hi`\n";
 
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values, ExportSourcemapOption);
+    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values);
 
     REQUIRE(values.report.error.code == Error::OK);
     REQUIRE(values.report.warnings.size() == 1);

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -494,7 +494,7 @@ TEST_CASE("Ignoring local media type", "[parser][regression][#195]")
     "    [A][]\n";
 
     ParseResult<Blueprint> blueprint;
-    parse(source, ExportSourcemapOption, blueprint);
+    parse(source, 0, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -541,7 +541,7 @@ TEST_CASE("Using local media type", "[parser][regression][#195]")
     "    [A][]\n";
 
     ParseResult<Blueprint> blueprint;
-    parse(source, ExportSourcemapOption, blueprint);
+    parse(source, 0, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -710,7 +710,7 @@ TEST_CASE("Don't mess up sourcemaps when there are references", "[parser][#213]"
     "# GET /1";
 
     ParseResult<Blueprint> blueprint;
-    parse(source, ExportSourcemapOption, blueprint);
+    parse(source, 0, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -737,7 +737,7 @@ TEST_CASE("doesn't crash while parsing response followed by a block quote and he
     "# B";
 
     ParseResult<Blueprint> blueprint;
-    parse(source, ExportSourcemapOption, blueprint);
+    parse(source, 0, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
 
@@ -759,7 +759,7 @@ TEST_CASE("doesn't crash while parsing response followed by a block quote settex
     "-------\n";
 
     ParseResult<Blueprint> blueprint;
-    parse(source, ExportSourcemapOption, blueprint);
+    parse(source, 0, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
 


### PR DESCRIPTION
Removing `pd.exportSourceMap()` will be done in another PR. Until then, the function returns true.