### PR TITLE
Add warning for named object as array member

### DIFF
--- a/src/MSONValueMemberParser.cc
+++ b/src/MSONValueMemberParser.cc
@@ -138,6 +138,19 @@ namespace snowcrash {
 
                 element.build(valueMember.node);
 
+                if ((valueMember.node.valueDefinition.typeDefinition.baseType ==  mson::ImplicitObjectBaseType ||
+                     valueMember.node.valueDefinition.typeDefinition.baseType ==  mson::ObjectBaseType) &&
+                    !valueMember.node.valueDefinition.values.empty()) {
+                    // WARN: object definition contain value 
+                    // e.g
+                    // - a (array)
+                    //   - key (object)
+                    mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    sections.report.warnings.push_back(Warning("array member definition of type 'object' contains value. You should use type definition without value eg. '- (object)'",
+                                                               LogicalErrorWarning,
+                                                               sourceMap));
+                }
+
                 if (pd.exportSourceMap()) {
                     elementSM.value = valueMember.sourceMap;
                 }

--- a/test/test-MSONValueMemberParser.cc
+++ b/test/test-MSONValueMemberParser.cc
@@ -217,3 +217,19 @@ TEST_CASE("Parse mson value member array with items", "[mson][value_member]")
     valueMemberSM = valueMember.sourceMap.sections.collection[0].elements().collection[1].value;
     SourceMapHelper::check(valueMemberSM.valueDefinition.sourceMap, 50, 17);
 }
+
+TEST_CASE("Check warnings for object in array with defined value", "[mson][value_member]")
+{
+    mdp::ByteBuffer source = \
+    "- (array)\n"\
+    "    - explicit (object)\n"\
+    "    - implicit\n"\
+    "        - k: v\n";
+
+    ParseResult<mson::ValueMember> valueMember;
+    SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption);
+
+    REQUIRE(valueMember.report.error.code == Error::OK);
+    REQUIRE(valueMember.report.warnings.size() == 2);
+
+}


### PR DESCRIPTION
eg:
 # A (array)
 - obj (object)

tests are attached in `drafter` patch (will follow)