### PR TITLE
Improve syntax matching of request keyword

### DIFF
--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -35,7 +35,7 @@ namespace snowcrash {
     };
 
     /** Request matching regex */
-    const char* const RequestRegex = "^[[:blank:]]*[Rr]equest" SYMBOL_IDENTIFIER "?" MEDIA_TYPE "?[[:blank:]]*";
+    const char* const RequestRegex = "^[[:blank:]]*[Rr]equest([[:blank:]]" SYMBOL_IDENTIFIER ")?" MEDIA_TYPE "?[[:blank:]]*";
 
     /** Response matching regex */
     const char* const ResponseRegex = "^[[:blank:]]*[Rr]esponse([[:blank:][:digit:]]+)?" MEDIA_TYPE "?[[:blank:]]*";
@@ -466,6 +466,9 @@ namespace snowcrash {
                     pd.sectionContext() == ModelBodySectionType) {
 
                     out.node.name = captureGroups[2];
+                    mediaType = captureGroups[4];
+                } else if (pd.sectionContext() == RequestSectionType) {
+                    out.node.name = captureGroups[1];
                     mediaType = captureGroups[4];
                 } else {
                     out.node.name = captureGroups[1];

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -473,6 +473,20 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 82, 17);
 }
 
+TEST_CASE("Warn on malformed request payload signature", "[payload]")
+{
+  mdp::ByteBuffer source = "+ Requestz\n";
+  source += "    + Body\n\n";
+  source += "            Hello World!\n";
+
+  ParseResult<Payload> payload;
+  SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+
+  REQUIRE(payload.report.error.code == Error::OK);
+  REQUIRE(payload.report.warnings.size() == 1);
+  REQUIRE(payload.report.warnings[0].code == FormattingWarning);
+}
+
 TEST_CASE("Give a warning of empty message body for requests with certain headers", "[payload]")
 {
     mdp::ByteBuffer source = \


### PR DESCRIPTION
We should ensure there is a space or end of line after `Request`. Currently the following is handled:

```apib
+ Requestindsfgdfghdg
```