### PR TITLE
Allow escaped MSON values

### DIFF
--- a/src/MSONUtility.h
+++ b/src/MSONUtility.h
@@ -85,7 +85,7 @@ namespace mson {
         }
 
         if (value.literal.empty()) {
-            value.literal = buffer;
+            value.literal = snowcrash::StripBackticks(buffer);
         }
 
         // When the value is a wildcard

--- a/src/SignatureSectionProcessor.h
+++ b/src/SignatureSectionProcessor.h
@@ -298,7 +298,7 @@ namespace scpl {
             snowcrash::TrimString(value);
 
             if (!value.empty()) {
-                out.values.push_back(snowcrash::StripBackticks(value));
+                out.values.push_back(value);
             }
 
             // If the subject ended with the values, strip the last value from the subject

--- a/test/test-MSONUtility.cc
+++ b/test/test-MSONUtility.cc
@@ -42,6 +42,16 @@ TEST_CASE("Parse canonical variable value with '_'", "[mson][utility]")
     REQUIRE(value.variable == true);
 }
 
+TEST_CASE("Parse escaped value", "[mson][utility]")
+{
+  std::string source = "`_rel_`";
+
+  Value value = parseValue(source);
+
+  REQUIRE(value.literal == "_rel_");
+  REQUIRE(value.variable == false);
+}
+
 TEST_CASE("Parse variable value with more than 1 level '*'", "[mson][utility]")
 {
     std::string source = "**r*e*l**";

--- a/test/test-Signature.cc
+++ b/test/test-Signature.cc
@@ -56,7 +56,7 @@ TEST_CASE("Escaped property signature parsing", "[signature]")
     REQUIRE(signature.identifier == "*id*(data):3");
     REQUIRE(signature.value == "42");
     REQUIRE(signature.values.size() == 1);
-    REQUIRE(signature.values[0] == "42");
+    REQUIRE(signature.values[0] == "`42`");
     REQUIRE(signature.attributes.size() == 2);
     REQUIRE(signature.attributes[0] == "yes");
     REQUIRE(signature.attributes[1] == "no");
@@ -277,7 +277,7 @@ TEST_CASE("Escaped element signature parsing", "[signature]")
     REQUIRE(signature.identifier.empty());
     REQUIRE(signature.value == "*42*(data):3");
     REQUIRE(signature.values.size() == 1);
-    REQUIRE(signature.values[0] == "*42*(data):3");
+    REQUIRE(signature.values[0] == "`*42*(data):3`");
     REQUIRE(signature.attributes.size() == 1);
     REQUIRE(signature.attributes[0] == "number");
     REQUIRE(signature.content == "a good number");


### PR DESCRIPTION
Fixes apiaryio/drafter#365

**NOTE:** I've test this from within Drafter and the tests still pass there.