### PR TITLE
Improve parameter missing warning wording

### DIFF
--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -532,13 +532,11 @@ namespace snowcrash {
 
                     // WARN: parameter name not present
                     std::stringstream ss;
-                    ss << "parameter '" << it->name << "' not specified in ";
+                    ss << "parameter '" << it->name << "' is not found within the URI template '" << out.node.uriTemplate << "'";
 
                     if (!out.node.name.empty()) {
-                        ss << "'" << out.node.name << "' ";
+                        ss << " for '" << out.node.name << "' ";
                     }
-
-                    ss << "its '" << out.node.uriTemplate << "' URI template";
 
                     mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
                     out.report.warnings.push_back(Warning(ss.str(),


### PR DESCRIPTION
@honzajavorek How does the following wording sound?

```
warning: (8)  parameter 'beekeeper' is not found within the URI template '/honey' for 'Honey' ; line 4, column 1 - line 4, column 20
```

Closes https://github.com/apiaryio/drafter/issues/319