### PR TITLE
Handle escaped legacy parameters

### DIFF
--- a/src/ParameterParser.h
+++ b/src/ParameterParser.h
@@ -19,7 +19,7 @@
 #define PARAMETER_VALUE "`([^`]+)`"
 
 /** Parameter Identifier */
-#define PARAMETER_IDENTIFIER "(([[:alnum:]_.-])*|(%[A-Fa-f0-9]{2})*)+"
+#define PARAMETER_IDENTIFIER "`?(([[:alnum:]_.-])*|(%[A-Fa-f0-9]{2})*)+`?"
 
 /** Lead in and out for comma separated values regex */
 #define CSV_LEADINOUT "[[:blank:]]*,?[[:blank:]]*"
@@ -415,11 +415,6 @@ namespace snowcrash {
 
             if (innerSignature.empty()) {
                 return NotParameterType; // Empty string, invalid
-            }
-
-            // If first character is backtick, then new parameter syntax
-            if (innerSignature.substr(0, 1) == "`") {
-                return NewParameterType;
             }
 
             if (RegexCapture(innerSignature, "^" PARAMETER_IDENTIFIER "[[:blank:]]*", captureGroups) &&

--- a/src/ParametersParser.h
+++ b/src/ParametersParser.h
@@ -67,12 +67,12 @@ namespace snowcrash {
                                                          const ParseResultRef<Parameters>& out) {
 
             IntermediateParseResult<Parameter> parameter(out.report);
-            IntermediateParseResult<MSONParameter> msonParameter(out.report);
 
             if (pd.sectionContext() == ParameterSectionType) {
                 ParameterParser::parse(node, siblings, pd, parameter);
             }
             else if (pd.sectionContext() == MSONParameterSectionType) {
+                IntermediateParseResult<MSONParameter> msonParameter(out.report);
                 MSONParameterParser::parse(node, siblings, pd, msonParameter);
 
                 // Copy values from MSON Parameter to normal parameter

--- a/test/test-ParameterParser.cc
+++ b/test/test-ParameterParser.cc
@@ -141,6 +141,17 @@ TEST_CASE("Recognize parameter with brackets in old syntax example value", "[par
     REQUIRE(sectionType == ParameterSectionType);
 }
 
+TEST_CASE("Recognize escaped parameter with brackets in old syntax example value", "[parameter]")
+{
+    mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ `id` (optional, oData, `example`)", markdownAST);
+
+    REQUIRE(!markdownAST.children().empty());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    REQUIRE(sectionType == ParameterSectionType);
+}
+
 TEST_CASE("Recognize parameter with old syntax description after attributes", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;


### PR DESCRIPTION
A parameter list item such as ``+ `u_u` (required, string, `a_a`)`` was being treated as an MSON aligned parameter when it wasn't.

Fixes https://github.com/apiaryio/drafter/issues/391