### PR TITLE
Bugfix: handle crash for undisclosed item list

### DIFF
--- a/src/SectionParser.h
+++ b/src/SectionParser.h
@@ -196,7 +196,8 @@ namespace snowcrash {
                 }
             }
 
-            return seed->children().end();
+            // there are no parseable items, let it pass in old manner
+            return seed->children().begin(); 
         }
 
         static const MarkdownNodes& startingNodeSiblings(const MarkdownNodeIterator& seed,

--- a/test/test-MSONValueMemberParser.cc
+++ b/test/test-MSONValueMemberParser.cc
@@ -247,3 +247,13 @@ TEST_CASE("Check warnings for object with defined value", "[mson][value_member]"
     REQUIRE(valueMember.report.warnings.size() == 1);
 
 }
+
+TEST_CASE("Parse undisclosed item list", "[mson][value_member]")
+{
+    mdp::ByteBuffer source = \
+    "- item\n"\
+    "    -\n";
+
+    ParseResult<mson::ValueMember> valueMember;
+    REQUIRE_NOTHROW( (SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption)) );
+}


### PR DESCRIPTION
Changes in parsing sundown leads to crash for parsing following MSON definition:

```
+ a
+
```
This fix restore original behavior if there is empty item in list
