### PR TITLE
Don't register duplicate params

### DIFF
--- a/src/ParametersParser.h
+++ b/src/ParametersParser.h
@@ -89,6 +89,7 @@ namespace snowcrash {
                 ParameterIterator duplicate = findParameter(out.node, parameter.node);
 
                 if (duplicate != out.node.end()) {
+                    removeParameter(duplicate, pd, out);
 
                     // WARN: Parameter already defined
                     std::stringstream ss;
@@ -154,6 +155,18 @@ namespace snowcrash {
             return std::find_if(parameters.begin(),
                                 parameters.end(),
                                 std::bind2nd(MatchName<Parameter>(), parameter));
+        }
+
+        static void removeParameter(ParameterIterator &parameter,
+                                    SectionParserData &pd,
+                                    const ParseResultRef<Parameters>& out) {
+
+            out.node.erase(parameter);
+
+            if (pd.exportSourceMap()) {
+                size_t parameterIndex = parameter - out.node.begin();
+                out.sourceMap.collection.erase(out.sourceMap.collection.begin() + parameterIndex);
+            }
         }
     };
 

--- a/test/test-ParametersParser.cc
+++ b/test/test-ParametersParser.cc
@@ -174,17 +174,13 @@ TEST_CASE("Warn about multiple parameters with the same name", "[parameters]")
     REQUIRE(parameters.report.warnings.size() == 1);
     REQUIRE(parameters.report.warnings[0].code == RedefinitionWarning);
 
-    REQUIRE(parameters.node.size() == 2);
+    REQUIRE(parameters.node.size() == 1);
 
     REQUIRE(parameters.node[0].name == "id");
-    REQUIRE(parameters.node[0].exampleValue == "42");
+    REQUIRE(parameters.node[0].exampleValue == "43");
 
-    REQUIRE(parameters.node[1].name == "id");
-    REQUIRE(parameters.node[1].exampleValue == "43");
-
-    REQUIRE(parameters.sourceMap.collection.size() == 2);
-    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 19, 10);
-    SourceMapHelper::check(parameters.sourceMap.collection[1].name.sourceMap, 35, 10);
+    REQUIRE(parameters.sourceMap.collection.size() == 1);
+    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 35, 10);
 }
 
 TEST_CASE("Recognize parameter when there is no description on its signature and remaining description is not a new node", "[parameters]")

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -623,19 +623,16 @@ TEST_CASE("Overshadow parameters", "[parser][201][regression][parameters]")
 
     Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
-    REQUIRE(resource.actions[0].parameters.size() == 4);
+    REQUIRE(resource.actions[0].parameters.size() == 3);
 
-    REQUIRE(resource.actions[0].parameters[0].name == "a");
-    REQUIRE(resource.actions[0].parameters[0].description == "1");
+    REQUIRE(resource.actions[0].parameters[0].name == "b");
+    REQUIRE(resource.actions[0].parameters[0].description == "2");
 
-    REQUIRE(resource.actions[0].parameters[1].name == "b");
-    REQUIRE(resource.actions[0].parameters[1].description == "2");
+    REQUIRE(resource.actions[0].parameters[1].name == "c");
+    REQUIRE(resource.actions[0].parameters[1].description == "3");
 
-    REQUIRE(resource.actions[0].parameters[2].name == "c");
-    REQUIRE(resource.actions[0].parameters[2].description == "3");
-
-    REQUIRE(resource.actions[0].parameters[3].name == "a");
-    REQUIRE(resource.actions[0].parameters[3].description == "4");
+    REQUIRE(resource.actions[0].parameters[2].name == "a");
+    REQUIRE(resource.actions[0].parameters[2].description == "4");
 }
 
 TEST_CASE("Segfault parsing metadata only", "[parser][205][regression]")


### PR DESCRIPTION
We shouldn't store additional parameters when overshadowing because we don't want to serialise duplicate parameters. I think it makes sense to do this here.