### PR TITLE
Allow `(` and `)` characters as action identifier

### DIFF
--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -16,16 +16,19 @@
 #include "RelationParser.h"
 #include "RegexMatch.h"
 
+// Similiar to SYMBOL_IDENTIFIER, except `(` and `)` are allowed
+#define ACTION_SYMBOL_IDENTIFIER "([^][]+)"
+
 namespace snowcrash {
 
     /** Nameless action matching regex */
     const char* const ActionHeaderRegex = "^[[:blank:]]*" HTTP_REQUEST_METHOD "[[:blank:]]*" URI_TEMPLATE "?$";
 
     /** Named action matching regex */
-    const char* const NamedActionHeaderRegex = "^[[:blank:]]*" SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD "[[:blank:]]*" URI_TEMPLATE "?]$";
+    const char* const NamedActionHeaderRegex = "^[[:blank:]]*" ACTION_SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD "[[:blank:]]*" URI_TEMPLATE "?]$";
 
     /** Miss leading slash in URI */
-    const char* const NamedActionNonAbsoluteURIRegex = "^[[:blank:]]*" SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD "[[:blank:]]+[^/]+]$";
+    const char* const NamedActionNonAbsoluteURIRegex = "^[[:blank:]]*" ACTION_SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD "[[:blank:]]+[^/]+]$";
 
     /** Internal type alias for Collection iterator of Action */
     typedef Collection<Action>::const_iterator ActionIterator;

--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -16,8 +16,7 @@
 #include "RelationParser.h"
 #include "RegexMatch.h"
 
-// Similiar to SYMBOL_IDENTIFIER, except `(` and `)` are allowed
-#define ACTION_SYMBOL_IDENTIFIER "([^][]+)"
+#define ACTION_SYMBOL_IDENTIFIER "(.+)"
 
 namespace snowcrash {
 

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -72,6 +72,39 @@ TEST_CASE("Parsing action", "[action]")
     SourceMapHelper::check(action.sourceMap.examples.collection[0].responses.collection[0].headers.collection[0].sourceMap, 41, 27);
 }
 
+TEST_CASE("Parse named action with () in title", "[action]")
+{
+    mdp::ByteBuffer source = \
+    "# My Action (Deprecated) [GET]\n"\
+    "+ Response 204\n";
+
+    ParseResult<Action> action;
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+
+    REQUIRE(action.report.error.code == Error::OK);
+    CHECK(action.report.warnings.empty());
+
+    REQUIRE(action.node.name == "My Action (Deprecated)");
+    REQUIRE(action.node.method == "GET");
+}
+
+TEST_CASE("Parse named action with path including () in title", "[action]")
+{
+    mdp::ByteBuffer source = \
+    "# My Action (Deprecated) [GET /test]\n"\
+    "+ Response 204\n";
+
+    ParseResult<Action> action;
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+
+    REQUIRE(action.report.error.code == Error::OK);
+    CHECK(action.report.warnings.empty());
+
+    REQUIRE(action.node.name == "My Action (Deprecated)");
+    REQUIRE(action.node.method == "GET");
+    REQUIRE(action.node.uriTemplate == "/test");
+}
+
 TEST_CASE("Parse Action description with list", "[action]")
 {
     mdp::ByteBuffer source = \

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -105,6 +105,22 @@ TEST_CASE("Parse named action with path including () in title", "[action]")
     REQUIRE(action.node.uriTemplate == "/test");
 }
 
+TEST_CASE("Parse named action with [] in title", "[action]")
+{
+    mdp::ByteBuffer source = \
+    "# My Action [DEPRECATED] [GET]\n"\
+    "+ Response 204\n";
+
+    ParseResult<Action> action;
+    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+
+    REQUIRE(action.report.error.code == Error::OK);
+    CHECK(action.report.warnings.empty());
+
+    REQUIRE(action.node.name == "My Action [DEPRECATED]");
+    REQUIRE(action.node.method == "GET");
+}
+
 TEST_CASE("Parse Action description with list", "[action]")
 {
     mdp::ByteBuffer source = \


### PR DESCRIPTION
Excluding `(` and `)` in action identifiers leads to confusing behaviour for users of API Blueprint since adding `()` to an action name results in the action being treated as a description of the previous block (resource). API Blueprint tools such as Apiary will discard resources that don't have any actions and therefore the entire resource and action will not be present in rendered documentation. Since the user is now given any warnings about this they are left in a confused state.

It does appear that excluding `(` and `)` is unnecessary at the current time, especially since other formats such as Swagger allow these characters in the equivalent names and subsequent tooling such as Apiary and API Blueprint support using these characters in action names.

In API Blueprint, it does make sense to disallow these characters in some places to prevent ambiguity and parsing problems such as with Data Structures and Resource names. The following case would break:

```apib
# Resource (x) [/]

+ Attributes
    + a: b

## Data Structures
### X

+ `my_resource` (Resource (x))
```

It's not possible to reference an action and therefore it isn't necessary to exclude these characters. If a user does need to reference an action in future such as with affordances, they should use relation identifiers.

These changes do add a special case to the rules for identifiers which may not be ideal in the long run. No identifiers can contain `(` `)` unless they are action identifiers.

### Alternatives

Alternatively we can instead detect uses of `(` or `)` in an identifier and expose a warning to the user.