### PR TITLE
Fixing multiple small typos

### DIFF
--- a/src/HeadersParser.cc
+++ b/src/HeadersParser.cc
@@ -12,7 +12,7 @@ static HeaderIterator findHeader(const Headers& headers, const Header& header)
 
 typedef std::vector<std::string> HeadersKeyCollection;
 
-/** Get collection of allowed keywords - workarround due to C++98 restriction - static initialization of vector */
+/** Get collection of allowed keywords - workaround due to C++98 restriction - static initialization of vector */
 static const HeadersKeyCollection& getAllowedMultipleDefinitions()
 {
 

--- a/src/HeadersParser.h
+++ b/src/HeadersParser.h
@@ -30,7 +30,7 @@ namespace snowcrash
     /** Base class for functor to check validity of parsed header */
     struct ValidateFunctorBase {
 
-        /** intended to generate warning mesage */
+        /** intended to generate warning message */
         virtual std::string getMessage() const = 0;
 
         /**
@@ -97,7 +97,7 @@ namespace snowcrash
         virtual std::string getMessage() const;
     };
 
-    /** Functor receive and invoke individual Validators and conditionaly push reports  */
+    /** Functor receive and invoke individual Validators and conditionally push reports  */
     struct HeaderParserValidator {
 
         const ParseResultRef<Headers>& out;

--- a/src/MSON.h
+++ b/src/MSON.h
@@ -409,7 +409,7 @@ namespace mson
 
         void buildFromElements(const Elements& elements);
 
-        /** Desctructor */
+        /** Destructor */
         ~Element();
     };
 }

--- a/src/MSONValueMemberParser.cc
+++ b/src/MSONValueMemberParser.cc
@@ -196,7 +196,7 @@ namespace snowcrash
                 // WARN: Ignoring unrecognized block in mson nested members
                 mdp::CharactersRangeSet sourceMap
                     = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                sections.report.warnings.push_back(Warning("ignorning unrecognized block", IgnoringWarning, sourceMap));
+                sections.report.warnings.push_back(Warning("ignoring unrecognized block", IgnoringWarning, sourceMap));
 
                 cur = ++MarkdownNodeIterator(node);
             }

--- a/src/MSONValueMemberParser.cc
+++ b/src/MSONValueMemberParser.cc
@@ -59,7 +59,7 @@ namespace snowcrash
         }
 
         // If the nodes follow after some block description without member
-        // seperator, then they are treated as description
+        // separator, then they are treated as description
         if (!sections.node.empty() && sections.node.back().klass == mson::TypeSection::BlockDescriptionClass) {
             return SectionProcessor<mson::ValueMember>::blockDescription(node, pd, sections.node, sections.sourceMap);
         }

--- a/src/ParameterParser.h
+++ b/src/ParameterParser.h
@@ -42,10 +42,10 @@ namespace snowcrash
     /** Parameter Optional matching regex */
     const char* const ParameterOptionalRegex = "^[[:blank:]]*[Oo]ptional[[:blank:]]*$";
 
-    /** Additonal Parameter Traits Example matching regex */
+    /** Additional Parameter Traits Example matching regex */
     const char* const AdditionalTraitsExampleRegex = "`([^`]*)`";
 
-    /** Additonal Parameter Traits Use matching regex */
+    /** Additional Parameter Traits Use matching regex */
     const char* const AdditionalTraitsUseRegex = "([Oo]ptional|[Rr]equired)";
 
     /** Parameter Values matching regex */

--- a/src/ParametersParser.h
+++ b/src/ParametersParser.h
@@ -172,7 +172,7 @@ namespace snowcrash
      * \brief Check Parameter validity in URI template
      */
 
-    // It must either be in path "{param" or at the begining
+    // It must either be in path "{param" or at the beginning
     // "?param" or in the list ",param". And any of the params
     // must end either with "}" or ",".
 

--- a/src/SectionParserData.h
+++ b/src/SectionParserData.h
@@ -68,7 +68,7 @@ namespace snowcrash
         /** Source Data */
         const mdp::ByteBuffer& sourceData;
 
-        /** Source - map of bytes to character position - performance optimalization */
+        /** Source - map of bytes to character position - performance optimization */
         mdp::ByteBufferCharacterIndex sourceCharacterIndex;
 
         /** AST being parsed **/

--- a/src/SectionProcessor.h
+++ b/src/SectionProcessor.h
@@ -125,7 +125,7 @@ namespace snowcrash
     /**
      *  \brief  Section Processor Base
      *
-     *  Defines section processor interface alongised with its default
+     *  Defines section processor interface alongside with its default
      *  behavior.
      */
     template <typename T>

--- a/src/Signature.cc
+++ b/src/Signature.cc
@@ -42,7 +42,7 @@ SectionType snowcrash::SectionKeywordSignature(const mdp::MarkdownNodeIterator& 
     TYPECHECK(Relation)
 
     /*
-     *  NOTE: Order is important. Resource MUST preced the Action.
+     *  NOTE: Order is important. Resource MUST preceed the Action.
      *
      *  This is because an HTTP Request Method + URI is recognized as both %ActionSectionType and %ResourceSectionType.
      *  This is not optimal and should be addressed in the future.

--- a/src/Signature.cc
+++ b/src/Signature.cc
@@ -42,7 +42,7 @@ SectionType snowcrash::SectionKeywordSignature(const mdp::MarkdownNodeIterator& 
     TYPECHECK(Relation)
 
     /*
-     *  NOTE: Order is important. Resource MUST preceed the Action.
+     *  NOTE: Order is important. Resource MUST preced the Action.
      *
      *  This is because an HTTP Request Method + URI is recognized as both %ActionSectionType and %ResourceSectionType.
      *  This is not optimal and should be addressed in the future.

--- a/src/StringUtility.h
+++ b/src/StringUtility.h
@@ -52,7 +52,7 @@ namespace snowcrash
         return TrimStringStart(TrimStringEnd(s));
     }
 
-    // <position form begin, lenght of string>
+    // <position form begin, length of string>
     typedef std::tuple<std::string::const_iterator::difference_type, std::string::const_iterator::difference_type>
         TrimRange;
 
@@ -153,7 +153,7 @@ namespace snowcrash
     }
 
     /**
-     *  \brief  compare equality  - allow compare diferent types
+     *  \brief  compare equality  - allow compare different types
      *
      *  \return true if args era equal
      */
@@ -265,7 +265,7 @@ namespace snowcrash
     /**
      * \brief Strip the enclosing backticks and return the string in the middle.
      *
-     *        If there are no matching enclosing bacticks, return the whole string.
+     *        If there are no matching enclosing backticks, return the whole string.
      *
      * \param subject String that needs to be stripped of enclosing backticks
      *

--- a/src/snowcrash.cc
+++ b/src/snowcrash.cc
@@ -79,8 +79,9 @@ int snowcrash::parse(
         std::stringstream ss;
         ss << "parser exception: '" << e.what() << "'";
         out.report.error = Error(ss.str(), ApplicationError);
-    } catch (...) {
-        out.report.error = Error("parser exception has occured", ApplicationError);
+    }
+    catch (...) {
+        out.report.error = Error("parser exception has occurred", ApplicationError);
     }
 
     return out.report.error.code;

--- a/src/snowcrash.cc
+++ b/src/snowcrash.cc
@@ -79,8 +79,7 @@ int snowcrash::parse(
         std::stringstream ss;
         ss << "parser exception: '" << e.what() << "'";
         out.report.error = Error(ss.str(), ApplicationError);
-    }
-    catch (...) {
+    } catch (...) {
         out.report.error = Error("parser exception has occurred", ApplicationError);
     }
 

--- a/test/performance/perf-snowcrash.cc
+++ b/test/performance/perf-snowcrash.cc
@@ -126,7 +126,7 @@ bool helpRequest(const std::string& arg)
 
 int main(int argc, const char* argv[])
 {
-    // FIXME: Intstrumetns helper
+    // FIXME: Instruments helper
     //::sleep(20);
 
     if (argc != 2) {
@@ -158,7 +158,7 @@ int main(int argc, const char* argv[])
 
     std::cout << "parsing '" << inputFileName << "' " << TestRunCount << "-times (" << result << "):\n";
     std::cout << "total: " << total << "s mean: " << mean << " +/- " << stddev << "s\n";
-
-    // FIXME: Intstrumetns helper
+    
+    // FIXME: Instruments helper
     //::sleep(20);
 }

--- a/test/performance/perf-snowcrash.cc
+++ b/test/performance/perf-snowcrash.cc
@@ -158,7 +158,6 @@ int main(int argc, const char* argv[])
 
     std::cout << "parsing '" << inputFileName << "' " << TestRunCount << "-times (" << result << "):\n";
     std::cout << "total: " << total << "s mean: " << mean << " +/- " << stddev << "s\n";
-    
     // FIXME: Instruments helper
     //::sleep(20);
 }

--- a/test/performance/perf-snowcrash.cc
+++ b/test/performance/perf-snowcrash.cc
@@ -158,6 +158,7 @@ int main(int argc, const char* argv[])
 
     std::cout << "parsing '" << inputFileName << "' " << TestRunCount << "-times (" << result << "):\n";
     std::cout << "total: " << total << "s mean: " << mean << " +/- " << stddev << "s\n";
+
     // FIXME: Instruments helper
     //::sleep(20);
 }

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -358,7 +358,7 @@ TEST_CASE("Parse method without name", "[action]")
 TEST_CASE("Parse action with parameters", "[action]")
 {
     mdp::ByteBuffer source
-        = "# GET /resrouce/{id}\n"
+        = "# GET /resource/{id}\n"
           "+ Parameters\n"
           "    + id (required, number, `42`) ... Resource Id\n"
           "\n"

--- a/test/test-Blueprint.cc
+++ b/test/test-Blueprint.cc
@@ -11,7 +11,7 @@
 
 using namespace snowcrash;
 
-TEST_CASE("blueprint/blueprint-init", "Blueprint initializaton")
+TEST_CASE("blueprint/blueprint-init", "Blueprint initialization")
 {
     Blueprint blueprint;
     REQUIRE(blueprint.name.length() == 0);
@@ -20,7 +20,7 @@ TEST_CASE("blueprint/blueprint-init", "Blueprint initializaton")
     REQUIRE(blueprint.content.elements().size() == 0);
 }
 
-TEST_CASE("blueprint/init", "Blueprint initializaton")
+TEST_CASE("blueprint/init", "Blueprint initialization")
 {
     Blueprint blueprint;
     REQUIRE(blueprint.name.length() == 0);

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -1427,7 +1427,7 @@ TEST_CASE("Report error when not finding a super type of the attributes", "[blue
     REQUIRE(blueprint.report.warnings.empty());
 }
 
-TEST_CASE("Parse blueprint with escaped datastructure", "[blueprint]")
+TEST_CASE("Parse blueprint with escaped data structure", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1454,7 +1454,7 @@ TEST_CASE("Parse blueprint with escaped datastructure", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
 }
 
-TEST_CASE("Parse blueprint with escaped datastructure reference", "[blueprint]")
+TEST_CASE("Parse blueprint with escaped data structure reference", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"

--- a/test/test-HeadersParser.cc
+++ b/test/test-HeadersParser.cc
@@ -297,7 +297,8 @@ TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue
     }
 }
 
-TEST_CASE("Allow parse nonvalid headers, provide appropriate warning", "[headers][issue][158]") {
+TEST_CASE("Allow parse nonvalid headers, provide appropriate warning", "[headers][issue][158]")
+{
 
     SECTION("Strange but valid token")
     {

--- a/test/test-HeadersParser.cc
+++ b/test/test-HeadersParser.cc
@@ -56,7 +56,7 @@ TEST_CASE("parse headers fixture", "[headers]")
 
 // This test is commented out because, in real parsing it is never parsed is "one block sourcemap"
 // Just in context of HeaderParser testing.
-// This test is not completly removed, instead it is placed in context of ResourceParser (as in real world)
+// This test is not completely removed, instead it is placed in context of ResourceParser (as in real world)
 
 TEST_CASE("parse headers fixture with no empty line between signature and content", "[headers]")
 {
@@ -220,7 +220,7 @@ TEST_CASE("Headers Filed Name should be case insensitive", "[headers][issue][230
     REQUIRE(headers.node[1].second == "application/json");
 }
 
-TEST_CASE("Aditional test for Header name insenstivity combined with allowed multiple headers", "[headers][issue][230]")
+TEST_CASE("Additional test for Header name insensitivity combined with allowed multiple headers", "[headers][issue][230]")
 {
     const mdp::ByteBuffer source
         = "+ Headers\n"
@@ -297,8 +297,7 @@ TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue
     }
 }
 
-TEST_CASE("Allow parse nonvalid headers, provide apropriate warning", "[headers][issue][158]")
-{
+TEST_CASE("Allow parse nonvalid headers, provide appropriate warning", "[headers][issue][158]") {
 
     SECTION("Strange but valid token")
     {

--- a/test/test-MSONParameterParser.cc
+++ b/test/test-MSONParameterParser.cc
@@ -185,7 +185,7 @@ TEST_CASE("Parentheses in parameter description with new syntax", "[parameter]")
     REQUIRE(parameter.node.description == "lorem (ipsum) dolor");
 }
 
-TEST_CASE("Parse parameter including backtics for escaping, issue drafter#445", "[mson_parameter]")
+TEST_CASE("Parse parameter including backticks for escaping, issue drafter#445", "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ `start_time`: `recorded_at` (enum[string], optional)\n"

--- a/test/test-MSONUtility.cc
+++ b/test/test-MSONUtility.cc
@@ -440,9 +440,9 @@ TEST_CASE("Parse type definition with non recognized type attribute", "[mson][ut
     snowcrash::Blueprint blueprint;
 
     attributes.push_back("[Person][]");
-    attributes.push_back("optional");
+    attributes.push_back("optinal");
 
-    mdp::ByteBuffer source = "+ ([Person][], optional)";
+    mdp::ByteBuffer source = "+ ([Person][], optinal)";
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
 

--- a/test/test-MSONUtility.cc
+++ b/test/test-MSONUtility.cc
@@ -440,9 +440,9 @@ TEST_CASE("Parse type definition with non recognized type attribute", "[mson][ut
     snowcrash::Blueprint blueprint;
 
     attributes.push_back("[Person][]");
-    attributes.push_back("optinal");
+    attributes.push_back("optional");
 
-    mdp::ByteBuffer source = "+ ([Person][], optinal)";
+    mdp::ByteBuffer source = "+ ([Person][], optional)";
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
 
@@ -523,7 +523,7 @@ TEST_CASE("Build member type from value member", "[mson][utility]")
     REQUIRE(element.klass == Element::ValueClass);
 }
 
-TEST_CASE("Build member type from property memeber", "[mson][utility]")
+TEST_CASE("Build member type from property member", "[mson][utility]")
 {
     PropertyMember propertyMember;
     Element element;
@@ -533,7 +533,7 @@ TEST_CASE("Build member type from property memeber", "[mson][utility]")
     REQUIRE(element.klass == Element::PropertyClass);
 }
 
-TEST_CASE("Build memebr type from members collection", "[mson][utility]")
+TEST_CASE("Build member type from members collection", "[mson][utility]")
 {
     Element element;
     TypeSection typeSection;

--- a/test/test-ParametersParser.cc
+++ b/test/test-ParametersParser.cc
@@ -54,7 +54,7 @@ TEST_CASE("Parse canonical parameters", "[parameters]")
     SourceMapHelper::check(parameters.sourceMap.collection[1].name.sourceMap, 165, 5);
 }
 
-TEST_CASE("Parse ilegal parameter", "[parameters]")
+TEST_CASE("Parse illegal parameter", "[parameters]")
 {
     mdp::ByteBuffer source
         = "+ Parameters\n"

--- a/test/test-RelationParser.cc
+++ b/test/test-RelationParser.cc
@@ -77,7 +77,7 @@ TEST_CASE("Relation identifier starting with non lower alphabet", "[relation]")
 
 TEST_CASE("Relation identifier containing capital letters", "[relation]")
 {
-    mdp::ByteBuffer source = "+ Relation: deLete";
+    mdp::ByteBuffer source = "+ Relation: delete";
 
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;

--- a/test/test-RelationParser.cc
+++ b/test/test-RelationParser.cc
@@ -77,7 +77,7 @@ TEST_CASE("Relation identifier starting with non lower alphabet", "[relation]")
 
 TEST_CASE("Relation identifier containing capital letters", "[relation]")
 {
-    mdp::ByteBuffer source = "+ Relation: delete";
+    mdp::ByteBuffer source = "+ Relation: deLete";
 
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -189,7 +189,7 @@ TEST_CASE("Parse multiple methods", "[resource]")
     SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
-    REQUIRE(resource.report.warnings.size() == 2); // empty reuqest asset & no response
+    REQUIRE(resource.report.warnings.size() == 2); // empty request asset & no response
 
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "A");
@@ -616,7 +616,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(resource.actions[0].examples[0].responses[0].reference.meta.state == Reference::StateResolved);
 }
 
-TEST_CASE("Expect to have a warning when 100 responce's reference has a body", "[resource][model]")
+TEST_CASE("Expect to have a warning when 100 response's reference has a body", "[resource][model]")
 {
     mdp::ByteBuffer source
         = "# API\n"
@@ -688,7 +688,7 @@ TEST_CASE("Parse root resource", "[resource]")
     REQUIRE(resource.sourceMap.actions.collection.empty());
 }
 
-TEST_CASE("Parse resource with invalid URI Tempalte", "[resource]")
+TEST_CASE("Parse resource with invalid URI Template", "[resource]")
 {
     mdp::ByteBuffer source = "# Resource [/id{? limit}]\n";
 
@@ -1020,7 +1020,7 @@ TEST_CASE("Relation identifiers should be unique for a resource", "[resource]")
           "+ Relation: create\n"
           "+ Response 204\n"
           "\n"
-          "### Delte [DELETE]\n"
+          "### Delete [DELETE]\n"
           "+ Relation: create\n"
           "+ Response 204";
 

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -616,7 +616,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(resource.actions[0].examples[0].responses[0].reference.meta.state == Reference::StateResolved);
 }
 
-TEST_CASE("Expect to have a warning when 100 response's reference has a body", "[resource][model]")
+TEST_CASE("Expect to have a warning when 100 responses reference has a body", "[resource][model]")
 {
     mdp::ByteBuffer source
         = "# API\n"

--- a/test/test-StringUtility.cc
+++ b/test/test-StringUtility.cc
@@ -34,14 +34,14 @@ TEST_CASE("Templates for compare equality", "[utility]")
         REQUIRE_FALSE(IsIEqual()('a', 'b'));
     }
 
-    SECTION("Both version should not throw while testing diferent types")
+    SECTION("Both version should not throw while testing different types")
     {
-        REQUIRE_NOTHROW(IsEqual()('a', 1));  // allow compare diferent types - not throw
-        REQUIRE_NOTHROW(IsIEqual()('a', 1)); // allow compare diferent types - not throw
+        REQUIRE_NOTHROW(IsEqual()('a',1)); // allow compare different types - not throw
+        REQUIRE_NOTHROW(IsIEqual()('a',1)); // allow compare different types - not throw
     }
 }
 
-TEST_CASE("Container comparation", "[utility]")
+TEST_CASE("Container comparison", "[utility]")
 {
     REQUIRE(MatchContainers(std::string("abc"), std::string("abc"), IsEqual()));
 
@@ -53,7 +53,7 @@ TEST_CASE("Container comparation", "[utility]")
     REQUIRE_FALSE(MatchContainers(std::string("def"), std::string("ABC"), IsIEqual()));
 }
 
-TEST_CASE("Comapare string", "[utility]")
+TEST_CASE("Compare string", "[utility]")
 {
     REQUIRE(Equal<std::string>()(std::string("abc"), std::string("abc")));
     REQUIRE_FALSE(Equal<std::string>()(std::string("abcd"), std::string("abc")));

--- a/test/test-StringUtility.cc
+++ b/test/test-StringUtility.cc
@@ -36,8 +36,8 @@ TEST_CASE("Templates for compare equality", "[utility]")
 
     SECTION("Both version should not throw while testing different types")
     {
-        REQUIRE_NOTHROW(IsEqual()('a',1)); // allow compare different types - not throw
-        REQUIRE_NOTHROW(IsIEqual()('a',1)); // allow compare different types - not throw
+        REQUIRE_NOTHROW(IsEqual()('a', 1));  // allow compare different types - not throw
+        REQUIRE_NOTHROW(IsIEqual()('a', 1)); // allow compare different types - not throw
     }
 }
 

--- a/test/test-UriTemplateParser.cc
+++ b/test/test-UriTemplateParser.cc
@@ -11,7 +11,7 @@
 
 using namespace snowcrash;
 
-TEST_CASE("Parse a valid uri into seperate parts", "[validuriparser][issue][79]")
+TEST_CASE("Parse a valid uri into separate parts", "[validuriparser][issue][79]")
 {
 
     const snowcrash::URI uri = "http://www.test.com/other/{id}";
@@ -27,7 +27,7 @@ TEST_CASE("Parse a valid uri into seperate parts", "[validuriparser][issue][79]"
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE("Parse an invalid uri into seperate parts", "[invaliduriparser][issue][79]")
+TEST_CASE("Parse an invalid uri into separate parts", "[invaliduriparser][issue][79]")
 {
 
     const snowcrash::URI uri = "http://www.test.com/other/{id}[2]";

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -572,7 +572,7 @@ TEST_CASE("Using local media type", "[parser][regression][195]")
         18);
 }
 
-TEST_CASE("Parse ill-formated header", "[parser][198][regression]")
+TEST_CASE("Parse ill-formatted header", "[parser][198][regression]")
 {
     mdp::ByteBuffer source
         = "# GET /A\n"


### PR DESCRIPTION
Hi! This is my first contribution here :D

I was using [Apiary](apiary.io) when I found a small typo in the "unrecognized block" warning message. I tracked down the typo to the parser and fixed it. Afterwards, I ran [scspell](https://github.com/myint/scspell), a lightweight spell checking tool and fixed some other typos.

I did not proofread the comments and strings where no typo was found and I tried my best not to fall in small differences between US and UK English.