### PR TITLE
Impose column limit of 80

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ BraceWrapping:
   IndentBraces: false
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: true
-ColumnLimit:     120
+ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4

--- a/src/ActionParser.h
+++ b/src/ActionParser.h
@@ -22,15 +22,18 @@ namespace snowcrash
 {
 
     /** Nameless action matching regex */
-    const char* const ActionHeaderRegex = "^[[:blank:]]*" HTTP_REQUEST_METHOD "[[:blank:]]*" URI_TEMPLATE "?$";
+    const char* const ActionHeaderRegex
+        = "^[[:blank:]]*" HTTP_REQUEST_METHOD "[[:blank:]]*" URI_TEMPLATE "?$";
 
     /** Named action matching regex */
     const char* const NamedActionHeaderRegex
-        = "^[[:blank:]]*" ACTION_SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD "[[:blank:]]*" URI_TEMPLATE "?]$";
+        = "^[[:blank:]]*" ACTION_SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD
+          "[[:blank:]]*" URI_TEMPLATE "?]$";
 
     /** Miss leading slash in URI */
     const char* const NamedActionNonAbsoluteURIRegex
-        = "^[[:blank:]]*" ACTION_SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD "[[:blank:]]+[^/]+]$";
+        = "^[[:blank:]]*" ACTION_SYMBOL_IDENTIFIER "\\[" HTTP_REQUEST_METHOD
+          "[[:blank:]]+[^/]+]$";
 
     /** Internal type alias for Collection iterator of Action */
     typedef Collection<Action>::const_iterator ActionIterator;
@@ -39,7 +42,8 @@ namespace snowcrash
     enum ActionType
     {
         NotActionType = 0,
-        DependentActionType, /// Action isn't fully defined, depends on parents resource URI
+        DependentActionType, /// Action isn't fully defined, depends on parents
+                             /// resource URI
         CompleteActionType,  /// Action is fully defined including its URI
         UndefinedActionType = -1
     };
@@ -50,14 +54,16 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Action> : public SectionProcessorBase<Action> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
             const ParseResultRef<Action>& out)
         {
 
-            actionHTTPMethodAndName(node, out.node.method, out.node.name, out.node.uriTemplate);
+            actionHTTPMethodAndName(
+                node, out.node.method, out.node.name, out.node.uriTemplate);
             TrimString(out.node.name);
 
             mdp::ByteBuffer remainingContent;
@@ -88,7 +94,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Action>& out)
@@ -99,17 +106,22 @@ namespace snowcrash
             std::stringstream ss;
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
 
             switch (sectionType) {
                 case RelationSectionType: {
-                    ParseResultRef<Relation> relation(out.report, out.node.relation, out.sourceMap.relation);
+                    ParseResultRef<Relation> relation(
+                        out.report, out.node.relation, out.sourceMap.relation);
                     return RelationParser::parse(node, siblings, pd, relation);
                 }
 
                 case ParametersSectionType: {
-                    ParseResultRef<Parameters> parameters(out.report, out.node.parameters, out.sourceMap.parameters);
-                    return ParametersParser::parse(node, siblings, pd, parameters);
+                    ParseResultRef<Parameters> parameters(out.report,
+                        out.node.parameters,
+                        out.sourceMap.parameters);
+                    return ParametersParser::parse(
+                        node, siblings, pd, parameters);
                 }
 
                 case RequestSectionType:
@@ -118,14 +130,16 @@ namespace snowcrash
 
                     cur = PayloadParser::parse(node, siblings, pd, payload);
 
-                    if (out.node.examples.empty() || !out.node.examples.back().responses.empty()) {
+                    if (out.node.examples.empty()
+                        || !out.node.examples.back().responses.empty()) {
                         TransactionExample transaction;
                         SourceMap<TransactionExample> transactionSM;
 
                         out.node.examples.push_back(transaction);
 
                         if (pd.exportSourceMap()) {
-                            out.sourceMap.examples.collection.push_back(transactionSM);
+                            out.sourceMap.examples.collection.push_back(
+                                transactionSM);
                         }
                     }
 
@@ -134,7 +148,8 @@ namespace snowcrash
                     out.node.examples.back().requests.push_back(payload.node);
 
                     if (pd.exportSourceMap()) {
-                        out.sourceMap.examples.collection.back().requests.collection.push_back(payload.sourceMap);
+                        out.sourceMap.examples.collection.back()
+                            .requests.collection.push_back(payload.sourceMap);
                     }
 
                     break;
@@ -153,7 +168,8 @@ namespace snowcrash
                         out.node.examples.push_back(transaction);
 
                         if (pd.exportSourceMap()) {
-                            out.sourceMap.examples.collection.push_back(transactionSM);
+                            out.sourceMap.examples.collection.push_back(
+                                transactionSM);
                         }
                     }
 
@@ -162,20 +178,26 @@ namespace snowcrash
                     out.node.examples.back().responses.push_back(payload.node);
 
                     if (pd.exportSourceMap()) {
-                        out.sourceMap.examples.collection.back().responses.collection.push_back(payload.sourceMap);
+                        out.sourceMap.examples.collection.back()
+                            .responses.collection.push_back(payload.sourceMap);
                     }
 
                     break;
                 }
 
                 case HeadersSectionType: {
-                    ParseResultRef<Headers> headers(out.report, out.node.headers, out.sourceMap.headers);
-                    return SectionProcessor<Action>::handleDeprecatedHeaders(node, siblings, pd, headers);
+                    ParseResultRef<Headers> headers(
+                        out.report, out.node.headers, out.sourceMap.headers);
+                    return SectionProcessor<Action>::handleDeprecatedHeaders(
+                        node, siblings, pd, headers);
                 }
 
                 case AttributesSectionType: {
-                    ParseResultRef<Attributes> attributes(out.report, out.node.attributes, out.sourceMap.attributes);
-                    return AttributesParser::parse(node, siblings, pd, attributes);
+                    ParseResultRef<Attributes> attributes(out.report,
+                        out.node.attributes,
+                        out.sourceMap.attributes);
+                    return AttributesParser::parse(
+                        node, siblings, pd, attributes);
                 }
 
                 default:
@@ -185,50 +207,68 @@ namespace snowcrash
             return cur;
         }
 
-        static bool isUnexpectedNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isUnexpectedNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            if (SectionProcessor<Asset>::sectionType(node) != UndefinedSectionType) {
+            if (SectionProcessor<Asset>::sectionType(node)
+                != UndefinedSectionType) {
                 return true;
             }
 
-            return SectionProcessorBase<Action>::isUnexpectedNode(node, sectionType);
+            return SectionProcessorBase<Action>::isUnexpectedNode(
+                node, sectionType);
         }
 
-        static MarkdownNodeIterator processUnexpectedNode(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processUnexpectedNode(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionType& sectionType,
             const ParseResultRef<Action>& out)
         {
 
-            if ((node->type == mdp::ParagraphMarkdownNodeType || node->type == mdp::CodeMarkdownNodeType)
-                && (sectionType == ResponseBodySectionType || sectionType == ResponseSectionType)
+            if ((node->type == mdp::ParagraphMarkdownNodeType
+                    || node->type == mdp::CodeMarkdownNodeType)
+                && (sectionType == ResponseBodySectionType
+                       || sectionType == ResponseSectionType)
                 && !out.node.examples.empty()
                 && !out.node.examples.back().responses.empty()) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(
-                    node, pd, sectionType, out.report, out.node.examples.back().responses.back().body);
+                mdp::ByteBuffer content
+                    = CodeBlockUtility::addDanglingAsset(node,
+                        pd,
+                        sectionType,
+                        out.report,
+                        out.node.examples.back().responses.back().body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.examples.collection.back().responses.collection.back().body.sourceMap.append(
-                        node->sourceMap);
+                    out.sourceMap.examples.collection.back()
+                        .responses.collection.back()
+                        .body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
             }
 
-            if ((node->type == mdp::ParagraphMarkdownNodeType || node->type == mdp::CodeMarkdownNodeType)
-                && (sectionType == RequestBodySectionType || sectionType == RequestSectionType)
+            if ((node->type == mdp::ParagraphMarkdownNodeType
+                    || node->type == mdp::CodeMarkdownNodeType)
+                && (sectionType == RequestBodySectionType
+                       || sectionType == RequestSectionType)
                 && !out.node.examples.empty()
                 && !out.node.examples.back().requests.empty()) {
 
-                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(
-                    node, pd, sectionType, out.report, out.node.examples.back().requests.back().body);
+                mdp::ByteBuffer content
+                    = CodeBlockUtility::addDanglingAsset(node,
+                        pd,
+                        sectionType,
+                        out.report,
+                        out.node.examples.back().requests.back().body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    out.sourceMap.examples.collection.back().requests.collection.back().body.sourceMap.append(
-                        node->sourceMap);
+                    out.sourceMap.examples.collection.back()
+                        .requests.collection.back()
+                        .body.sourceMap.append(node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -241,28 +281,34 @@ namespace snowcrash
                 // WARN: Ignoring section
                 std::stringstream ss;
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
 
                 ss << "Ignoring " << SectionName(assetType) << " list item, ";
-                ss << SectionName(assetType) << " list item is expected to be indented by 4 spaces or 1 tab";
+                ss << SectionName(assetType) << " list item is expected to be "
+                                                "indented by 4 spaces or 1 tab";
 
-                out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                out.report.warnings.push_back(
+                    Warning(ss.str(), IgnoringWarning, sourceMap));
 
                 return ++MarkdownNodeIterator(node);
             }
 
-            return SectionProcessorBase<Action>::processUnexpectedNode(node, siblings, pd, sectionType, out);
+            return SectionProcessorBase<Action>::processUnexpectedNode(
+                node, siblings, pd, sectionType, out);
         }
 
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::HeaderMarkdownNodeType && !node->text.empty()) {
+            if (node->type == mdp::HeaderMarkdownNodeType
+                && !node->text.empty()) {
 
                 mdp::ByteBuffer subject = node->text;
                 TrimString(subject);
 
-                if (RegexMatch(subject, ActionHeaderRegex) || RegexMatch(subject, NamedActionHeaderRegex)) {
+                if (RegexMatch(subject, ActionHeaderRegex)
+                    || RegexMatch(subject, NamedActionHeaderRegex)) {
 
                     return ActionSectionType;
                 }
@@ -316,20 +362,29 @@ namespace snowcrash
 
         static SectionTypes upperSectionTypes()
         {
-            return { ActionSectionType, ResourceSectionType, ResourceGroupSectionType, DataStructureGroupSectionType };
+            return { ActionSectionType,
+                ResourceSectionType,
+                ResourceGroupSectionType,
+                DataStructureGroupSectionType };
         }
 
-        static void finalize(const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Action>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Action>& out)
         {
 
             if (!out.node.uriTemplate.empty()) {
-                checkParametersEligibility<Action>(node, pd, out.node.parameters, out);
+                checkParametersEligibility<Action>(
+                    node, pd, out.node.parameters, out);
             }
 
             if (!out.node.headers.empty()) {
 
-                SectionProcessor<Headers>::injectDeprecatedHeaders(
-                    pd, out.node.headers, out.sourceMap.headers, out.node.examples, out.sourceMap.examples);
+                SectionProcessor<Headers>::injectDeprecatedHeaders(pd,
+                    out.node.headers,
+                    out.sourceMap.headers,
+                    out.node.examples,
+                    out.sourceMap.examples);
                 out.node.headers.clear();
 
                 if (pd.exportSourceMap()) {
@@ -341,10 +396,14 @@ namespace snowcrash
 
                 // WARN: No response for action
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 out.report.warnings.push_back(
-                    Warning("action is missing a response", EmptyDefinitionWarning, sourceMap));
-            } else if (!out.node.examples.empty() && !out.node.examples.back().requests.empty()
+                    Warning("action is missing a response",
+                        EmptyDefinitionWarning,
+                        sourceMap));
+            } else if (!out.node.examples.empty()
+                && !out.node.examples.back().requests.empty()
                 && out.node.examples.back().responses.empty()) {
 
                 // WARN: No response for request
@@ -354,12 +413,16 @@ namespace snowcrash
                 if (out.node.examples.back().requests.back().name.empty()) {
                     ss << "a request";
                 } else {
-                    ss << "the '" << out.node.examples.back().requests.back().name << "' request";
+                    ss << "the '"
+                       << out.node.examples.back().requests.back().name
+                       << "' request";
                 }
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
             }
         }
 
@@ -377,17 +440,21 @@ namespace snowcrash
             const ParseResultRef<Action>& out)
         {
 
-            if (isPayloadDuplicate(sectionType, payload, out.node.examples.back())) {
+            if (isPayloadDuplicate(
+                    sectionType, payload, out.node.examples.back())) {
 
                 // WARN: Duplicate payload
                 std::stringstream ss;
-                ss << SectionName(sectionType) << " payload `" << payload.name << "`";
+                ss << SectionName(sectionType) << " payload `" << payload.name
+                   << "`";
                 ss << " already defined for `" << out.node.method << "` method";
 
-                out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                out.report.warnings.push_back(
+                    Warning(ss.str(), DuplicateWarning, sourceMap));
             }
 
-            if (sectionType == ResponseSectionType || sectionType == ResponseBodySectionType) {
+            if (sectionType == ResponseSectionType
+                || sectionType == ResponseBodySectionType) {
 
                 HTTPStatusCode code;
 
@@ -400,20 +467,26 @@ namespace snowcrash
                 if (!methodTraits.allowBody && !payload.body.empty()) {
 
                     // WARN: Edge case for 2xx CONNECT
-                    if (out.node.method == HTTPMethodName::Connect && code / 100 == 2) {
+                    if (out.node.method == HTTPMethodName::Connect
+                        && code / 100 == 2) {
 
                         std::stringstream ss;
-                        ss << "the response for " << code << " " << out.node.method << " request MUST NOT include a "
+                        ss << "the response for " << code << " "
+                           << out.node.method << " request MUST NOT include a "
                            << SectionName(BodySectionType);
 
-                        out.report.warnings.push_back(Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
-                    } else if (out.node.method != HTTPMethodName::Connect && !methodTraits.allowBody) {
+                        out.report.warnings.push_back(Warning(
+                            ss.str(), EmptyDefinitionWarning, sourceMap));
+                    } else if (out.node.method != HTTPMethodName::Connect
+                        && !methodTraits.allowBody) {
 
                         std::stringstream ss;
-                        ss << "the response for " << out.node.method << " request MUST NOT include a "
+                        ss << "the response for " << out.node.method
+                           << " request MUST NOT include a "
                            << SectionName(BodySectionType);
 
-                        out.report.warnings.push_back(Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
+                        out.report.warnings.push_back(Warning(
+                            ss.str(), EmptyDefinitionWarning, sourceMap));
                     }
 
                     return;
@@ -422,20 +495,24 @@ namespace snowcrash
         }
 
         /**
-         *  Checks whether given section payload has duplicate within its transaction examples
+         *  Checks whether given section payload has duplicate within its
+         * transaction examples
          *  \return True when a duplicate is found, false otherwise.
          */
-        static bool isPayloadDuplicate(
-            SectionType& sectionType, const Payload& payload, const TransactionExample& example)
+        static bool isPayloadDuplicate(SectionType& sectionType,
+            const Payload& payload,
+            const TransactionExample& example)
         {
 
             if (sectionType == RequestSectionType) {
 
-                RequestIterator duplicate = SectionProcessor<Payload>::findRequest(example, payload);
+                RequestIterator duplicate
+                    = SectionProcessor<Payload>::findRequest(example, payload);
                 return duplicate != example.requests.end();
             } else if (sectionType == ResponseSectionType) {
 
-                ResponseIterator duplicate = SectionProcessor<Payload>::findResponse(example, payload);
+                ResponseIterator duplicate
+                    = SectionProcessor<Payload>::findResponse(example, payload);
                 return duplicate != example.responses.end();
             }
 
@@ -443,22 +520,27 @@ namespace snowcrash
         }
 
         /** Warn about deprecated headers */
-        static MarkdownNodeIterator handleDeprecatedHeaders(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator handleDeprecatedHeaders(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Headers>& out)
         {
 
-            MarkdownNodeIterator cur = HeadersParser::parse(node, siblings, pd, out);
+            MarkdownNodeIterator cur
+                = HeadersParser::parse(node, siblings, pd, out);
 
             // WARN: Deprecated header sections
             std::stringstream ss;
-            ss << "the 'headers' section at this level is deprecated and will be removed in a future, use respective "
+            ss << "the 'headers' section at this level is deprecated and will "
+                  "be removed in a future, use respective "
                   "payload header section(s) instead";
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-            out.report.warnings.push_back(Warning(ss.str(), DeprecatedWarning, sourceMap));
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
+            out.report.warnings.push_back(
+                Warning(ss.str(), DeprecatedWarning, sourceMap));
 
             return cur;
         }
@@ -506,7 +588,8 @@ namespace snowcrash
 
             if (RegexCapture(subject, ActionHeaderRegex, captureGroups, 3)) {
                 method = captureGroups[1];
-            } else if (RegexCapture(subject, NamedActionHeaderRegex, captureGroups, 4)) {
+            } else if (RegexCapture(
+                           subject, NamedActionHeaderRegex, captureGroups, 4)) {
                 name = captureGroups[1];
                 method = captureGroups[2];
                 uriTemplate = captureGroups[3];
@@ -516,20 +599,28 @@ namespace snowcrash
         }
 
         /** Finds an action inside an actions collection */
-        static ActionIterator findAction(const Actions& actions, const Action& action)
+        static ActionIterator findAction(
+            const Actions& actions, const Action& action)
         {
 
-            return std::find_if(actions.begin(), actions.end(), std::bind2nd(MatchAction(), action));
+            return std::find_if(actions.begin(),
+                actions.end(),
+                std::bind2nd(MatchAction(), action));
         }
 
         /** Finds a relation identifier inside an actions collection */
-        static ActionIterator findRelation(const Actions& actions, const Relation& relation)
+        static ActionIterator findRelation(
+            const Actions& actions, const Relation& relation)
         {
 
-            return std::find_if(actions.begin(), actions.end(), std::bind2nd(MatchRelation(), relation));
+            return std::find_if(actions.begin(),
+                actions.end(),
+                std::bind2nd(MatchRelation(), relation));
         }
 
-        static void checkForTypoMistake(const MarkdownNodeIterator& node, SectionParserData& pd, Report& report)
+        static void checkForTypoMistake(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            Report& report)
         {
 
             if (node->type != mdp::HeaderMarkdownNodeType) {
@@ -539,11 +630,15 @@ namespace snowcrash
             if (RegexMatch(node->text, NamedActionNonAbsoluteURIRegex)) {
                 std::stringstream ss;
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
 
-                ss << "URI path in '" << node->text << "' is not absolute, it should have a leading forward slash";
+                ss << "URI path in '" << node->text << "' is not absolute, it "
+                                                       "should have a leading "
+                                                       "forward slash";
 
-                report.warnings.push_back(Warning(ss.str(), URIWarning, sourceMap));
+                report.warnings.push_back(
+                    Warning(ss.str(), URIWarning, sourceMap));
             }
         }
     };

--- a/src/AssetParser.h
+++ b/src/AssetParser.h
@@ -38,7 +38,8 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Asset> : public SectionProcessorBase<Asset> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -46,7 +47,8 @@ namespace snowcrash
         {
 
             out.node = "";
-            CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node);
+            CodeBlockUtility::signatureContentAsCodeBlock(
+                node, pd, out.report, out.node);
 
             if (pd.exportSourceMap() && !out.node.empty()) {
                 out.sourceMap.sourceMap.append(node->sourceMap);
@@ -57,7 +59,8 @@ namespace snowcrash
 
         NO_SECTION_DESCRIPTION(Asset)
 
-        static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processContent(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Asset>& out)
@@ -75,7 +78,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static bool isContentNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isContentNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
             return (SectionKeywordSignature(node) == UndefinedSectionType);
@@ -83,7 +87,8 @@ namespace snowcrash
 
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 AssetSignature signature = assetSignature(node);
 

--- a/src/AttributesParser.h
+++ b/src/AttributesParser.h
@@ -18,23 +18,27 @@ namespace snowcrash
 {
 
     /** Attributes matching regex */
-    const char* const AttributesRegex = "^[[:blank:]]*[Aa]ttributes?[[:blank:]]*(\\(.*\\))?$";
+    const char* const AttributesRegex
+        = "^[[:blank:]]*[Aa]ttributes?[[:blank:]]*(\\(.*\\))?$";
 
     /**
      * Attributes section processor
      */
     template <>
-    struct SectionProcessor<Attributes> : public SignatureSectionProcessorBase<Attributes> {
+    struct SectionProcessor<Attributes>
+        : public SignatureSectionProcessorBase<Attributes> {
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::AttributesTrait);
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::AttributesTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<Attributes>& out)
@@ -46,7 +50,11 @@ namespace snowcrash
                 return node;
             }
 
-            mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.typeDefinition);
+            mson::parseTypeDefinition(node,
+                pd,
+                signature.attributes,
+                out.report,
+                out.node.typeDefinition);
 
             if (pd.exportSourceMap()) {
 
@@ -62,13 +70,17 @@ namespace snowcrash
                 out.node.typeDefinition.baseType = mson::ImplicitObjectBaseType;
             }
 
-            SectionProcessor<mson::ValueMember>::parseRemainingContent(
-                node, pd, signature.remainingContent, out.node.sections, out.sourceMap.sections);
+            SectionProcessor<mson::ValueMember>::parseRemainingContent(node,
+                pd,
+                signature.remainingContent,
+                out.node.sections,
+                out.sourceMap.sections);
 
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processDescription(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Attributes>& out)
@@ -78,30 +90,40 @@ namespace snowcrash
                 node, pd, out.node.sections, out.sourceMap.sections);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Attributes>& out)
         {
 
-            ParseResultRef<mson::TypeSections> typeSections(out.report, out.node.sections, out.sourceMap.sections);
+            ParseResultRef<mson::TypeSections> typeSections(
+                out.report, out.node.sections, out.sourceMap.sections);
 
-            return SectionProcessor<mson::ValueMember>::processNestedMembers<MSONTypeSectionListParser>(
-                node, siblings, pd, typeSections, out.node.typeDefinition.baseType);
+            return SectionProcessor<mson::ValueMember>::
+                processNestedMembers<MSONTypeSectionListParser>(node,
+                    siblings,
+                    pd,
+                    typeSections,
+                    out.node.typeDefinition.baseType);
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            return SectionProcessor<mson::ValueMember>::isDescriptionNode(node, sectionType);
+            return SectionProcessor<mson::ValueMember>::isDescriptionNode(
+                node, sectionType);
         }
 
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
-                mdp::ByteBuffer remaining, subject = node->children().front().text;
+                mdp::ByteBuffer remaining,
+                    subject = node->children().front().text;
 
                 subject = GetFirstLine(subject, remaining);
                 TrimString(subject);

--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -478,7 +478,8 @@ namespace snowcrash
     /**
      *  \brief API Blueprint AST
      *
-     *  This is top-level (or root if you prefer) of API Blueprint abstract syntax tree.
+     *  This is top-level (or root if you prefer) of API Blueprint abstract
+     * syntax tree.
      *  Start reading a parsed API here.
      */
     struct Blueprint : public Element {

--- a/src/BlueprintParser.h
+++ b/src/BlueprintParser.h
@@ -21,7 +21,8 @@
 namespace snowcrash
 {
 
-    const char* const ExpectedAPINameMessage = "expected API name, e.g. '# <API Name>'";
+    const char* const ExpectedAPINameMessage
+        = "expected API name, e.g. '# <API Name>'";
 
     /** Internal type alias for Collection iterator of Metadata */
     typedef Collection<Metadata>::iterator MetadataCollectionIterator;
@@ -30,9 +31,11 @@ namespace snowcrash
      * Blueprint processor
      */
     template <>
-    struct SectionProcessor<Blueprint> : public SectionProcessorBase<Blueprint> {
+    struct SectionProcessor<Blueprint>
+        : public SectionProcessorBase<Blueprint> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -41,9 +44,11 @@ namespace snowcrash
 
             MarkdownNodeIterator cur = node;
 
-            while (cur != siblings.end() && cur->type == mdp::ParagraphMarkdownNodeType) {
+            while (cur != siblings.end()
+                && cur->type == mdp::ParagraphMarkdownNodeType) {
 
-                IntermediateParseResult<MetadataCollection> metadata(out.report);
+                IntermediateParseResult<MetadataCollection> metadata(
+                    out.report);
 
                 parseMetadata(cur, pd, metadata);
 
@@ -51,10 +56,13 @@ namespace snowcrash
                 if (metadata.node.empty()) {
                     return processDescription(cur, siblings, pd, out);
                 } else {
-                    out.node.metadata.insert(out.node.metadata.end(), metadata.node.begin(), metadata.node.end());
+                    out.node.metadata.insert(out.node.metadata.end(),
+                        metadata.node.begin(),
+                        metadata.node.end());
 
                     if (pd.exportSourceMap()) {
-                        out.sourceMap.metadata.collection.insert(out.sourceMap.metadata.collection.end(),
+                        out.sourceMap.metadata.collection.insert(
+                            out.sourceMap.metadata.collection.end(),
                             metadata.sourceMap.collection.begin(),
                             metadata.sourceMap.collection.end());
                     }
@@ -63,8 +71,10 @@ namespace snowcrash
                 cur++;
             }
 
-            // Ideally this parsing metadata should be handled by separate parser
-            // that way the following check would be covered in SectionParser::parse()
+            // Ideally this parsing metadata should be handled by separate
+            // parser
+            // that way the following check would be covered in
+            // SectionParser::parse()
             if (cur == siblings.end())
                 return cur;
 
@@ -93,7 +103,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(cur);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Blueprint>& out)
@@ -101,12 +112,16 @@ namespace snowcrash
 
             MarkdownNodeIterator cur = node;
 
-            if (pd.sectionContext() == ResourceGroupSectionType || pd.sectionContext() == ResourceSectionType) {
+            if (pd.sectionContext() == ResourceGroupSectionType
+                || pd.sectionContext() == ResourceSectionType) {
 
-                IntermediateParseResult<ResourceGroup> resourceGroup(out.report);
-                cur = ResourceGroupParser::parse(node, siblings, pd, resourceGroup);
+                IntermediateParseResult<ResourceGroup> resourceGroup(
+                    out.report);
+                cur = ResourceGroupParser::parse(
+                    node, siblings, pd, resourceGroup);
 
-                if (isResourceGroupDuplicate(out.node, resourceGroup.node.attributes.name)) {
+                if (isResourceGroupDuplicate(
+                        out.node, resourceGroup.node.attributes.name)) {
 
                     // WARN: duplicate resource group
                     std::stringstream ss;
@@ -114,30 +129,37 @@ namespace snowcrash
                     if (resourceGroup.node.attributes.name.empty()) {
                         ss << "anonymous group";
                     } else {
-                        ss << "group '" << resourceGroup.node.attributes.name << "'";
+                        ss << "group '" << resourceGroup.node.attributes.name
+                           << "'";
                     }
 
                     ss << " is already defined";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), DuplicateWarning, sourceMap));
                 }
 
                 out.node.content.elements().push_back(resourceGroup.node);
 
                 if (pd.exportSourceMap()) {
-                    out.sourceMap.content.elements().collection.push_back(resourceGroup.sourceMap);
+                    out.sourceMap.content.elements().collection.push_back(
+                        resourceGroup.sourceMap);
                 }
             } else if (pd.sectionContext() == DataStructureGroupSectionType) {
 
-                IntermediateParseResult<DataStructureGroup> dataStructureGroup(out.report);
-                cur = DataStructureGroupParser::parse(node, siblings, pd, dataStructureGroup);
+                IntermediateParseResult<DataStructureGroup> dataStructureGroup(
+                    out.report);
+                cur = DataStructureGroupParser::parse(
+                    node, siblings, pd, dataStructureGroup);
 
                 out.node.content.elements().push_back(dataStructureGroup.node);
 
                 if (pd.exportSourceMap()) {
-                    out.sourceMap.content.elements().collection.push_back(dataStructureGroup.sourceMap);
+                    out.sourceMap.content.elements().collection.push_back(
+                        dataStructureGroup.sourceMap);
                 }
             }
 
@@ -146,7 +168,8 @@ namespace snowcrash
 
         /**
          * Look ahead through all the nested sections and gather list of all
-         * named types along with their base types and the types they are sub-typed from
+         * named types along with their base types and the types they are
+         * sub-typed from
          */
         static void preprocessNestedSections(const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
@@ -166,7 +189,8 @@ namespace snowcrash
                 // Complete Action is recognized as resource section
                 if (sectionType == ResourceSectionType) {
 
-                    ActionType actionType = SectionProcessor<Action>::actionType(cur);
+                    ActionType actionType
+                        = SectionProcessor<Action>::actionType(cur);
 
                     if (actionType == CompleteActionType) {
                         sectionType = ActionSectionType;
@@ -175,21 +199,27 @@ namespace snowcrash
 
                 if (cur->type == mdp::HeaderMarkdownNodeType) {
 
-                    // If the current node is a Resource or DataStructures section, assign it as context
-                    // Otherwise, make sure the current context is not DataStructures section and remove the context
-                    if (sectionType == ResourceSectionType || sectionType == DataStructureGroupSectionType) {
+                    // If the current node is a Resource or DataStructures
+                    // section, assign it as context
+                    // Otherwise, make sure the current context is not
+                    // DataStructures section and remove the context
+                    if (sectionType == ResourceSectionType
+                        || sectionType == DataStructureGroupSectionType) {
 
                         contextSectionType = sectionType;
                         contextCur = cur;
-                    } else if (contextSectionType != DataStructureGroupSectionType) {
+                    } else if (contextSectionType
+                        != DataStructureGroupSectionType) {
 
                         contextSectionType = UndefinedSectionType;
                     }
 
-                    // If context is DataStructures section, NamedTypes should be filled
+                    // If context is DataStructures section, NamedTypes should
+                    // be filled
                     if (contextSectionType == DataStructureGroupSectionType) {
 
-                        if (sectionType != MSONSampleDefaultSectionType && sectionType != MSONPropertyMembersSectionType
+                        if (sectionType != MSONSampleDefaultSectionType
+                            && sectionType != MSONPropertyMembersSectionType
                             && sectionType != MSONValueMembersSectionType
                             && sectionType != UndefinedSectionType
                             && sectionType != DataStructureGroupSectionType) {
@@ -199,14 +229,20 @@ namespace snowcrash
                             fillNamedTypeTables(cur, pd, cur->text, out.report);
                         }
                     }
-                } else if (cur->type == mdp::ListItemMarkdownNodeType && contextSectionType == ResourceSectionType
+                } else if (cur->type == mdp::ListItemMarkdownNodeType
+                    && contextSectionType == ResourceSectionType
                     && sectionType == AttributesSectionType) {
 
                     Resource resource;
-                    SectionProcessor<Resource>::matchNamedResourceHeader(contextCur, resource);
+                    SectionProcessor<Resource>::matchNamedResourceHeader(
+                        contextCur, resource);
 
                     if (!resource.name.empty()) {
-                        fillNamedTypeTables(cur, pd, cur->children().front().text, out.report, resource.name);
+                        fillNamedTypeTables(cur,
+                            pd,
+                            cur->children().front().text,
+                            out.report,
+                            resource.name);
                     }
                 }
 
@@ -222,7 +258,9 @@ namespace snowcrash
         }
 
         static void checkForPossibleSectionMistakes(
-            const MarkdownNodeIterator& node, SectionParserData& pd, Report& report)
+            const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            Report& report)
         {
 
             SectionProcessor<Action>::checkForTypoMistake(node, pd, report);
@@ -254,7 +292,8 @@ namespace snowcrash
             }
 
             // Check if DataStructures section
-            nestedType = SectionProcessor<DataStructureGroup>::sectionType(node);
+            nestedType
+                = SectionProcessor<DataStructureGroup>::sectionType(node);
 
             if (nestedType != UndefinedSectionType) {
                 return nestedType;
@@ -263,8 +302,9 @@ namespace snowcrash
             return UndefinedSectionType;
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Blueprint>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Blueprint>& out)
         {
 
             checkLazyReferencing(pd, out);
@@ -281,22 +321,28 @@ namespace snowcrash
 
                 // ERR: No API name specified
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.error = Error(ExpectedAPINameMessage, BusinessError, sourceMap);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.error
+                    = Error(ExpectedAPINameMessage, BusinessError, sourceMap);
 
             } else if (!out.node.description.empty()) {
 
                 // WARN: No API name specified
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ExpectedAPINameMessage, APINameWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ExpectedAPINameMessage, APINameWarning, sourceMap));
             }
         }
 
-        static bool isUnexpectedNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isUnexpectedNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            // Since Blueprint is currently top-level node any unprocessed node should be reported
+            // Since Blueprint is currently top-level node any unprocessed node
+            // should be reported
             return true;
         }
 
@@ -308,7 +354,8 @@ namespace snowcrash
          * \param pd Section parser data
          * \param subject Signature of the named type
          * \param report Parse report
-         * \param name Name of the named type (only given in case of named resource)
+         * \param name Name of the named type (only given in case of named
+         * resource)
          */
         static void fillNamedTypeTables(const MarkdownNodeIterator& node,
             SectionParserData& pd,
@@ -322,11 +369,14 @@ namespace snowcrash
             mson::TypeDefinition typeDefinition;
             Report tmpReport;
 
-            SignatureTraits traits(SignatureTraits::IdentifierTrait | SignatureTraits::AttributesTrait);
+            SignatureTraits traits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::AttributesTrait);
 
             Signature signature
-                = SignatureSectionProcessorBase<Blueprint>::parseSignature(node, pd, traits, tmpReport, buffer);
-            mson::parseTypeDefinition(node, pd, signature.attributes, tmpReport, typeDefinition);
+                = SignatureSectionProcessorBase<Blueprint>::parseSignature(
+                    node, pd, traits, tmpReport, buffer);
+            mson::parseTypeDefinition(
+                node, pd, signature.attributes, tmpReport, typeDefinition);
 
             // Name of the named types cannot be variable
             if (!name.empty() && mson::checkVariable(signature.identifier)) {
@@ -340,75 +390,96 @@ namespace snowcrash
             }
 
             // If named type already exists, return error
-            if (pd.namedTypeDependencyTable.find(identifier) != pd.namedTypeDependencyTable.end()) {
+            if (pd.namedTypeDependencyTable.find(identifier)
+                != pd.namedTypeDependencyTable.end()) {
 
                 // ERR: Named type is defined more than once
                 std::stringstream ss;
-                ss << "named type '" << identifier << "' is defined more than once";
+                ss << "named type '" << identifier
+                   << "' is defined more than once";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 report.error = Error(ss.str(), MSONError, sourceMap);
                 return;
             }
 
-            mson::BaseTypeName baseTypeName = typeDefinition.typeSpecification.name.base;
+            mson::BaseTypeName baseTypeName
+                = typeDefinition.typeSpecification.name.base;
 
             // Initialize an entry in the dependency table
             pd.namedTypeDependencyTable[identifier] = std::set<mson::Literal>();
 
             // Add the respective entries to the tables
             if (baseTypeName != mson::UndefinedTypeName) {
-                pd.namedTypeBaseTable[identifier] = mson::parseBaseType(typeDefinition.typeSpecification.name.base);
+                pd.namedTypeBaseTable[identifier] = mson::parseBaseType(
+                    typeDefinition.typeSpecification.name.base);
 
                 // Add nested types as dependents
-                if (baseTypeName == mson::ArrayTypeName || baseTypeName == mson::EnumTypeName) {
+                if (baseTypeName == mson::ArrayTypeName
+                    || baseTypeName == mson::EnumTypeName) {
 
-                    for (mson::TypeNames::iterator it = typeDefinition.typeSpecification.nestedTypes.begin();
-                         it != typeDefinition.typeSpecification.nestedTypes.end();
+                    for (mson::TypeNames::iterator it
+                         = typeDefinition.typeSpecification.nestedTypes.begin();
+                         it
+                         != typeDefinition.typeSpecification.nestedTypes.end();
                          ++it) {
 
-                        if (!it->symbol.literal.empty() && !it->symbol.variable) {
-                            pd.namedTypeDependencyTable[identifier].insert(it->symbol.literal);
+                        if (!it->symbol.literal.empty()
+                            && !it->symbol.variable) {
+                            pd.namedTypeDependencyTable[identifier].insert(
+                                it->symbol.literal);
                         }
                     }
                 }
-            } else if (!typeDefinition.typeSpecification.name.symbol.literal.empty()
+            } else if (!typeDefinition.typeSpecification.name.symbol.literal
+                            .empty()
                 && !typeDefinition.typeSpecification.name.symbol.variable) {
 
-                pd.namedTypeInheritanceTable[identifier]
-                    = std::make_pair(typeDefinition.typeSpecification.name.symbol.literal, node->sourceMap);
+                pd.namedTypeInheritanceTable[identifier] = std::make_pair(
+                    typeDefinition.typeSpecification.name.symbol.literal,
+                    node->sourceMap);
 
                 // Make the sub type dependent on super type
-                pd.namedTypeDependencyTable[identifier].insert(typeDefinition.typeSpecification.name.symbol.literal);
+                pd.namedTypeDependencyTable[identifier].insert(
+                    typeDefinition.typeSpecification.name.symbol.literal);
             } else if (typeDefinition.typeSpecification.name.empty()) {
 
                 // If there is no specification, an object is assumed
-                pd.namedTypeBaseTable[identifier] = mson::ImplicitObjectBaseType;
+                pd.namedTypeBaseTable[identifier]
+                    = mson::ImplicitObjectBaseType;
             }
         }
 
         /**
-         * \brief Resolve named type base table entries from the named type inheritance table
+         * \brief Resolve named type base table entries from the named type
+         * inheritance table
          *
          * \param pd Section parser data
          * \param report Parse report
          */
-        static void resolveNamedTypeTables(SectionParserData& pd, Report& report)
+        static void resolveNamedTypeTables(
+            SectionParserData& pd, Report& report)
         {
 
             mson::NamedTypeInheritanceTable::iterator it;
             mson::NamedTypeDependencyTable::iterator depIt;
 
             // First resolve dependency tables
-            for (depIt = pd.namedTypeDependencyTable.begin(); depIt != pd.namedTypeDependencyTable.end(); depIt++) {
+            for (depIt = pd.namedTypeDependencyTable.begin();
+                 depIt != pd.namedTypeDependencyTable.end();
+                 depIt++) {
 
                 resolveNamedTypeDependencyTableEntry(pd, depIt->first, report);
             }
 
-            for (it = pd.namedTypeInheritanceTable.begin(); it != pd.namedTypeInheritanceTable.end(); it++) {
+            for (it = pd.namedTypeInheritanceTable.begin();
+                 it != pd.namedTypeInheritanceTable.end();
+                 it++) {
 
-                resolveNamedTypeBaseTableEntry(pd, it->first, it->second.first, it->second.second, report);
+                resolveNamedTypeBaseTableEntry(
+                    pd, it->first, it->second.first, it->second.second, report);
 
                 if (report.error.code != Error::OK) {
                     return;
@@ -424,8 +495,9 @@ namespace snowcrash
          * \param identifier The named type whose dependents need to be resolved
          * \param report Parse report
          */
-        static void resolveNamedTypeDependencyTableEntry(
-            SectionParserData& pd, const mson::Literal& identifier, Report& report)
+        static void resolveNamedTypeDependencyTableEntry(SectionParserData& pd,
+            const mson::Literal& identifier,
+            Report& report)
         {
 
             std::set<mson::Literal> diffDeps, finalDeps, initialDeps;
@@ -434,10 +506,14 @@ namespace snowcrash
                 initialDeps = pd.namedTypeDependencyTable[identifier];
                 diffDeps.clear();
 
-                for (std::set<mson::Literal>::iterator it = initialDeps.begin(); it != initialDeps.end(); it++) {
+                for (std::set<mson::Literal>::iterator it = initialDeps.begin();
+                     it != initialDeps.end();
+                     it++) {
 
-                    std::set<mson::Literal> superTypeDeps = pd.namedTypeDependencyTable[*it];
-                    pd.namedTypeDependencyTable[identifier].insert(superTypeDeps.begin(), superTypeDeps.end());
+                    std::set<mson::Literal> superTypeDeps
+                        = pd.namedTypeDependencyTable[*it];
+                    pd.namedTypeDependencyTable[identifier].insert(
+                        superTypeDeps.begin(), superTypeDeps.end());
                 }
 
                 // Check if the list of dependents has grown
@@ -452,7 +528,8 @@ namespace snowcrash
         };
 
         /**
-         * \brief For each entry in the named type inheritance table, resolve the sub-type's base type recursively
+         * \brief For each entry in the named type inheritance table, resolve
+         * the sub-type's base type recursively
          *
          * \param pd Section parser data
          * \param subType The sub named type between the two
@@ -467,7 +544,8 @@ namespace snowcrash
         {
 
             mson::BaseType baseType;
-            mson::NamedTypeBaseTable::iterator it = pd.namedTypeBaseTable.find(subType);
+            mson::NamedTypeBaseTable::iterator it
+                = pd.namedTypeBaseTable.find(subType);
 
             // If the base table entry is already filled, nothing else to do
             if (it != pd.namedTypeBaseTable.end()) {
@@ -481,10 +559,12 @@ namespace snowcrash
 
                 // ERR: A named type is circularly referenced
                 std::stringstream ss;
-                ss << "base type '" << subType << "' circularly referencing itself";
+                ss << "base type '" << subType
+                   << "' circularly referencing itself";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(nodeSourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        nodeSourceMap, pd.sourceCharacterIndex);
                 report.error = Error(ss.str(), MSONError, sourceMap);
                 return;
             }
@@ -492,28 +572,39 @@ namespace snowcrash
             // Otherwise, get the base type from super type
             it = pd.namedTypeBaseTable.find(superType);
 
-            // If super type is not already resolved, then it means that it is a sub type of something else
+            // If super type is not already resolved, then it means that it is a
+            // sub type of something else
             if (it == pd.namedTypeBaseTable.end()) {
 
                 // Try to get the super type of the current super type
-                mson::NamedTypeInheritanceTable::iterator inhIt = pd.namedTypeInheritanceTable.find(superType);
+                mson::NamedTypeInheritanceTable::iterator inhIt
+                    = pd.namedTypeInheritanceTable.find(superType);
 
                 // Check for recursive MSON definitions
                 if (inhIt == pd.namedTypeInheritanceTable.end()) {
 
-                    // ERR: We cannot find the super type in inheritance table at all
-                    // and there is not base type table entry for it, so, the blueprint is wrong
+                    // ERR: We cannot find the super type in inheritance table
+                    // at all
+                    // and there is not base type table entry for it, so, the
+                    // blueprint is wrong
                     std::stringstream ss;
-                    ss << "base type '" << superType << "' is not defined in the document";
+                    ss << "base type '" << superType
+                       << "' is not defined in the document";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(nodeSourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            nodeSourceMap, pd.sourceCharacterIndex);
                     report.error = Error(ss.str(), MSONError, sourceMap);
                     return;
                 }
 
-                // Recursively, try to get a base type for the current super type
-                resolveNamedTypeBaseTableEntry(pd, superType, inhIt->second.first, inhIt->second.second, report);
+                // Recursively, try to get a base type for the current super
+                // type
+                resolveNamedTypeBaseTableEntry(pd,
+                    superType,
+                    inhIt->second.first,
+                    inhIt->second.second,
+                    report);
 
                 if (report.error.code != Error::OK) {
                     return;
@@ -527,8 +618,9 @@ namespace snowcrash
             pd.namedTypeBaseTable[subType] = baseType;
         }
 
-        static void parseMetadata(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<MetadataCollection>& out)
+        static void parseMetadata(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<MetadataCollection>& out)
         {
 
             mdp::ByteBuffer content = node->text;
@@ -536,7 +628,9 @@ namespace snowcrash
 
             std::vector<mdp::ByteBuffer> lines = Split(content, '\n');
 
-            for (std::vector<mdp::ByteBuffer>::iterator it = lines.begin(); it != lines.end(); ++it) {
+            for (std::vector<mdp::ByteBuffer>::iterator it = lines.begin();
+                 it != lines.end();
+                 ++it) {
 
                 Metadata metadata;
 
@@ -556,17 +650,23 @@ namespace snowcrash
                 // Check duplicates
                 std::vector<mdp::ByteBuffer> duplicateKeys;
 
-                for (MetadataCollectionIterator it = out.node.begin(); it != out.node.end(); ++it) {
+                for (MetadataCollectionIterator it = out.node.begin();
+                     it != out.node.end();
+                     ++it) {
 
                     MetadataCollectionIterator from = it;
                     if (++from == out.node.end())
                         break;
 
-                    MetadataCollectionIterator duplicate
-                        = std::find_if(from, out.node.end(), std::bind2nd(MatchFirsts<Metadata>(), *it));
+                    MetadataCollectionIterator duplicate = std::find_if(from,
+                        out.node.end(),
+                        std::bind2nd(MatchFirsts<Metadata>(), *it));
 
                     if (duplicate != out.node.end()
-                        && std::find(duplicateKeys.begin(), duplicateKeys.end(), it->first) == duplicateKeys.end()) {
+                        && std::find(duplicateKeys.begin(),
+                               duplicateKeys.end(),
+                               it->first)
+                            == duplicateKeys.end()) {
 
                         duplicateKeys.push_back(it->first);
 
@@ -575,17 +675,21 @@ namespace snowcrash
                         ss << "duplicate definition of '" << it->first << "'";
 
                         mdp::CharactersRangeSet sourceMap
-                            = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                        out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                            = mdp::BytesRangeSetToCharactersRangeSet(
+                                node->sourceMap, pd.sourceCharacterIndex);
+                        out.report.warnings.push_back(
+                            Warning(ss.str(), DuplicateWarning, sourceMap));
                     }
                 }
             } else if (!out.node.empty()) {
 
                 // WARN: malformed metadata block
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 out.report.warnings.push_back(
-                    Warning("ignoring possible metadata, expected '<key> : <value>', one one per line",
+                    Warning("ignoring possible metadata, expected '<key> : "
+                            "<value>', one one per line",
                         FormattingWarning,
                         sourceMap));
             }
@@ -597,14 +701,17 @@ namespace snowcrash
          * \param blueprint The blueprint which is formed until now
          * \param name The resource group name to be checked
          */
-        static bool isResourceGroupDuplicate(const Blueprint& blueprint, mdp::ByteBuffer& name)
+        static bool isResourceGroupDuplicate(
+            const Blueprint& blueprint, mdp::ByteBuffer& name)
         {
 
-            for (Elements::const_iterator it = blueprint.content.elements().begin();
+            for (Elements::const_iterator it
+                 = blueprint.content.elements().begin();
                  it != blueprint.content.elements().end();
                  ++it) {
 
-                if (it->element == Element::CategoryElement && it->category == Element::ResourceGroupCategory
+                if (it->element == Element::CategoryElement
+                    && it->category == Element::ResourceGroupCategory
                     && it->attributes.name == name) {
 
                     return true;
@@ -615,26 +722,31 @@ namespace snowcrash
         }
 
         /**
-         *  \brief  Checks both blueprint and source map AST to resolve references with `Pending` state (Lazy
+         *  \brief  Checks both blueprint and source map AST to resolve
+         * references with `Pending` state (Lazy
          * referencing)
          *  \param  pd       Section parser state
          *  \param  out      Processed output
          */
-        static void checkLazyReferencing(SectionParserData& pd, const ParseResultRef<Blueprint>& out)
+        static void checkLazyReferencing(
+            SectionParserData& pd, const ParseResultRef<Blueprint>& out)
         {
 
             Collection<SourceMap<Element> >::iterator elementSourceMapIt;
 
             if (pd.exportSourceMap()) {
-                elementSourceMapIt = out.sourceMap.content.elements().collection.begin();
+                elementSourceMapIt
+                    = out.sourceMap.content.elements().collection.begin();
             }
 
-            for (Elements::iterator elementIt = out.node.content.elements().begin();
+            for (Elements::iterator elementIt
+                 = out.node.content.elements().begin();
                  elementIt != out.node.content.elements().end();
                  ++elementIt) {
 
                 if (elementIt->element == Element::CategoryElement) {
-                    checkResourceLazyReferencing(*elementIt, elementSourceMapIt, pd, out);
+                    checkResourceLazyReferencing(
+                        *elementIt, elementSourceMapIt, pd, out);
                 }
 
                 if (pd.exportSourceMap()) {
@@ -643,30 +755,41 @@ namespace snowcrash
             }
         }
 
-        /** Traverses Resource Collection to resolve references with `Pending` state (Lazy referencing) */
+        /** Traverses Resource Collection to resolve references with `Pending`
+         * state (Lazy referencing) */
         static void checkResourceLazyReferencing(Element& element,
             Collection<SourceMap<Element> >::iterator& elementSourceMap,
             SectionParserData& pd,
             const ParseResultRef<Blueprint>& out)
         {
 
-            Collection<SourceMap<Element> >::iterator resourceElementSourceMapIt;
+            Collection<SourceMap<Element> >::iterator
+                resourceElementSourceMapIt;
 
             if (pd.exportSourceMap()) {
-                resourceElementSourceMapIt = elementSourceMap->content.elements().collection.begin();
+                resourceElementSourceMapIt
+                    = elementSourceMap->content.elements().collection.begin();
             }
 
-            for (Elements::iterator resourceElementIt = element.content.elements().begin();
+            for (Elements::iterator resourceElementIt
+                 = element.content.elements().begin();
                  resourceElementIt != element.content.elements().end();
                  ++resourceElementIt) {
 
                 if (resourceElementIt->element == Element::ResourceElement) {
                     if (pd.exportSourceMap()) {
                         checkActionLazyReferencing(
-                            resourceElementIt->content.resource, resourceElementSourceMapIt->content.resource, pd, out);
+                            resourceElementIt->content.resource,
+                            resourceElementSourceMapIt->content.resource,
+                            pd,
+                            out);
                     } else {
                         SourceMap<Resource> tempSourceMap;
-                        checkActionLazyReferencing(resourceElementIt->content.resource, tempSourceMap, pd, out);
+                        checkActionLazyReferencing(
+                            resourceElementIt->content.resource,
+                            tempSourceMap,
+                            pd,
+                            out);
                     }
                 }
 
@@ -676,7 +799,8 @@ namespace snowcrash
             }
         }
 
-        /** Traverses Action Collection to resolve references with `Pending` state (Lazy referencing) */
+        /** Traverses Action Collection to resolve references with `Pending`
+         * state (Lazy referencing) */
         static void checkActionLazyReferencing(Resource& resource,
             SourceMap<Resource>& resourceSourceMap,
             SectionParserData& pd,
@@ -686,13 +810,16 @@ namespace snowcrash
             Collection<SourceMap<Action> >::iterator actionSourceMapIt;
 
             if (pd.exportSourceMap()) {
-                actionSourceMapIt = resourceSourceMap.actions.collection.begin();
+                actionSourceMapIt
+                    = resourceSourceMap.actions.collection.begin();
             }
 
-            for (Actions::iterator actionIt = resource.actions.begin(); actionIt != resource.actions.end();
+            for (Actions::iterator actionIt = resource.actions.begin();
+                 actionIt != resource.actions.end();
                  ++actionIt) {
 
-                checkExampleLazyReferencing(*actionIt, actionSourceMapIt, pd, out);
+                checkExampleLazyReferencing(
+                    *actionIt, actionSourceMapIt, pd, out);
 
                 if (pd.exportSourceMap()) {
                     actionSourceMapIt++;
@@ -700,7 +827,8 @@ namespace snowcrash
             }
         }
 
-        /** Traverses Transaction Example Collection AST to resolve references with `Pending` state (Lazy referencing)
+        /** Traverses Transaction Example Collection AST to resolve references
+         * with `Pending` state (Lazy referencing)
          */
         static void checkExampleLazyReferencing(Action& action,
             Collection<SourceMap<Action> >::iterator& actionSourceMapIt,
@@ -708,18 +836,23 @@ namespace snowcrash
             const ParseResultRef<Blueprint>& out)
         {
 
-            Collection<SourceMap<TransactionExample> >::iterator exampleSourceMapIt;
+            Collection<SourceMap<TransactionExample> >::iterator
+                exampleSourceMapIt;
 
             if (pd.exportSourceMap()) {
-                exampleSourceMapIt = actionSourceMapIt->examples.collection.begin();
+                exampleSourceMapIt
+                    = actionSourceMapIt->examples.collection.begin();
             }
 
-            for (TransactionExamples::iterator transactionExampleIt = action.examples.begin();
+            for (TransactionExamples::iterator transactionExampleIt
+                 = action.examples.begin();
                  transactionExampleIt != action.examples.end();
                  ++transactionExampleIt) {
 
-                checkRequestLazyReferencing(*transactionExampleIt, exampleSourceMapIt, pd, out);
-                checkResponseLazyReferencing(*transactionExampleIt, exampleSourceMapIt, pd, out);
+                checkRequestLazyReferencing(
+                    *transactionExampleIt, exampleSourceMapIt, pd, out);
+                checkResponseLazyReferencing(
+                    *transactionExampleIt, exampleSourceMapIt, pd, out);
 
                 if (pd.exportSourceMap()) {
                     exampleSourceMapIt++;
@@ -727,9 +860,12 @@ namespace snowcrash
             }
         }
 
-        /** Traverses Request Collection to resolve references with `Pending` state (Lazy referencing) */
-        static void checkRequestLazyReferencing(TransactionExample& transactionExample,
-            Collection<SourceMap<TransactionExample> >::iterator& transactionExampleSourceMapIt,
+        /** Traverses Request Collection to resolve references with `Pending`
+         * state (Lazy referencing) */
+        static void checkRequestLazyReferencing(
+            TransactionExample& transactionExample,
+            Collection<SourceMap<TransactionExample> >::iterator&
+                transactionExampleSourceMapIt,
             SectionParserData& pd,
             const ParseResultRef<Blueprint>& out)
         {
@@ -737,26 +873,34 @@ namespace snowcrash
             Collection<SourceMap<Request> >::iterator requestSourceMapIt;
 
             if (pd.exportSourceMap()) {
-                requestSourceMapIt = transactionExampleSourceMapIt->requests.collection.begin();
+                requestSourceMapIt = transactionExampleSourceMapIt->requests
+                                         .collection.begin();
             }
 
-            for (Requests::iterator requestIt = transactionExample.requests.begin();
+            for (Requests::iterator requestIt
+                 = transactionExample.requests.begin();
                  requestIt != transactionExample.requests.end();
                  ++requestIt) {
 
-                if (!requestIt->reference.id.empty() && requestIt->reference.meta.state == Reference::StatePending) {
+                if (!requestIt->reference.id.empty()
+                    && requestIt->reference.meta.state
+                        == Reference::StatePending) {
 
                     if (pd.exportSourceMap()) {
 
-                        ParseResultRef<Payload> payload(out.report, *requestIt, *requestSourceMapIt);
+                        ParseResultRef<Payload> payload(
+                            out.report, *requestIt, *requestSourceMapIt);
                         resolvePendingModels(pd, payload);
-                        SectionProcessor<Payload>::checkRequest(requestIt->reference.meta.node, pd, payload);
+                        SectionProcessor<Payload>::checkRequest(
+                            requestIt->reference.meta.node, pd, payload);
                     } else {
 
                         SourceMap<Payload> tempSourceMap;
-                        ParseResultRef<Payload> payload(out.report, *requestIt, tempSourceMap);
+                        ParseResultRef<Payload> payload(
+                            out.report, *requestIt, tempSourceMap);
                         resolvePendingModels(pd, payload);
-                        SectionProcessor<Payload>::checkRequest(requestIt->reference.meta.node, pd, payload);
+                        SectionProcessor<Payload>::checkRequest(
+                            requestIt->reference.meta.node, pd, payload);
                     }
                 }
 
@@ -766,9 +910,12 @@ namespace snowcrash
             }
         }
 
-        /** Traverses Response Collection to resolve references with `Pending` state (Lazy referencing) */
-        static void checkResponseLazyReferencing(TransactionExample& transactionExample,
-            Collection<SourceMap<TransactionExample> >::iterator& transactionExampleSourceMapIt,
+        /** Traverses Response Collection to resolve references with `Pending`
+         * state (Lazy referencing) */
+        static void checkResponseLazyReferencing(
+            TransactionExample& transactionExample,
+            Collection<SourceMap<TransactionExample> >::iterator&
+                transactionExampleSourceMapIt,
             SectionParserData& pd,
             const ParseResultRef<Blueprint>& out)
         {
@@ -776,26 +923,34 @@ namespace snowcrash
             Collection<SourceMap<Response> >::iterator responseSourceMapIt;
 
             if (pd.exportSourceMap()) {
-                responseSourceMapIt = transactionExampleSourceMapIt->responses.collection.begin();
+                responseSourceMapIt = transactionExampleSourceMapIt->responses
+                                          .collection.begin();
             }
 
-            for (Responses::iterator responseIt = transactionExample.responses.begin();
+            for (Responses::iterator responseIt
+                 = transactionExample.responses.begin();
                  responseIt != transactionExample.responses.end();
                  ++responseIt) {
 
-                if (!responseIt->reference.id.empty() && responseIt->reference.meta.state == Reference::StatePending) {
+                if (!responseIt->reference.id.empty()
+                    && responseIt->reference.meta.state
+                        == Reference::StatePending) {
 
                     if (pd.exportSourceMap()) {
 
-                        ParseResultRef<Payload> payload(out.report, *responseIt, *responseSourceMapIt);
+                        ParseResultRef<Payload> payload(
+                            out.report, *responseIt, *responseSourceMapIt);
                         resolvePendingModels(pd, payload);
-                        SectionProcessor<Payload>::checkResponse(responseIt->reference.meta.node, pd, payload);
+                        SectionProcessor<Payload>::checkResponse(
+                            responseIt->reference.meta.node, pd, payload);
                     } else {
 
                         SourceMap<Payload> tempSourceMap;
-                        ParseResultRef<Payload> payload(out.report, *responseIt, tempSourceMap);
+                        ParseResultRef<Payload> payload(
+                            out.report, *responseIt, tempSourceMap);
                         resolvePendingModels(pd, payload);
-                        SectionProcessor<Payload>::checkResponse(responseIt->reference.meta.node, pd, payload);
+                        SectionProcessor<Payload>::checkResponse(
+                            responseIt->reference.meta.node, pd, payload);
                     }
                 }
 
@@ -810,17 +965,21 @@ namespace snowcrash
          *  \param  pd       Section parser data
          *  \param  out      Processed output
          */
-        static void resolvePendingModels(SectionParserData& pd, const ParseResultRef<Payload>& out)
+        static void resolvePendingModels(
+            SectionParserData& pd, const ParseResultRef<Payload>& out)
         {
 
-            if (pd.modelTable.find(out.node.reference.id) == pd.modelTable.end()) {
+            if (pd.modelTable.find(out.node.reference.id)
+                == pd.modelTable.end()) {
 
                 // ERR: Undefined model reference
                 std::stringstream ss;
                 ss << "Undefined resource model " << out.node.reference.id;
 
-                mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(
-                    out.node.reference.meta.node->sourceMap, pd.sourceCharacterIndex);
+                mdp::CharactersRangeSet sourceMap
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        out.node.reference.meta.node->sourceMap,
+                        pd.sourceCharacterIndex);
                 out.report.error = Error(ss.str(), ModelError, sourceMap);
 
                 out.node.reference.meta.state = Reference::StateUnresolved;

--- a/src/BlueprintSourcemap.cc
+++ b/src/BlueprintSourcemap.cc
@@ -39,7 +39,8 @@ SourceMap<Element>::Content::Content(const SourceMap<Element>::Content& rhs)
     m_elements.reset(::new SourceMap<Elements>(*rhs.m_elements.get()));
 }
 
-SourceMap<Element>::Content& SourceMap<Element>::Content::operator=(const SourceMap<Element>::Content& rhs)
+SourceMap<Element>::Content& SourceMap<Element>::Content::operator=(
+    const SourceMap<Element>::Content& rhs)
 {
     this->copy = rhs.copy;
     this->resource = rhs.resource;
@@ -53,7 +54,8 @@ SourceMap<Element>::Content::~Content()
 {
 }
 
-SourceMap<Element>::SourceMap(const Element::Class& element_) : element(element_)
+SourceMap<Element>::SourceMap(const Element::Class& element_)
+    : element(element_)
 {
 }
 

--- a/src/BlueprintSourcemap.h
+++ b/src/BlueprintSourcemap.h
@@ -48,7 +48,8 @@ namespace snowcrash
         /** Source Map of Required flag */
         SourceMap<ParameterUse> use;
 
-        /** Source Map of Default Value, applicable only when `required == false` */
+        /** Source Map of Default Value, applicable only when `required ==
+         * false` */
         SourceMap<Value> defaultValue;
 
         /** Source Map of Example Value */
@@ -96,13 +97,16 @@ namespace snowcrash
         /** Source Map of Payload-specific Headers */
         SourceMap<Headers> headers;
 
-        /** Source Map of Payload-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
+        /** Source Map of Payload-specific Attributes (THIS SHOULD NOT BE HERE -
+         * should be under content) */
         SourceMap<Attributes> attributes;
 
-        /** Source Map of Body (THIS SHOULD NOT BE HERE - should be under content) */
+        /** Source Map of Body (THIS SHOULD NOT BE HERE - should be under
+         * content) */
         SourceMap<Asset> body;
 
-        /** Source Map of Schema (THIS SHOULD NOT BE HERE - should be under content) */
+        /** Source Map of Schema (THIS SHOULD NOT BE HERE - should be under
+         * content) */
         SourceMap<Asset> schema;
 
         /** Source Map of Model Reference */
@@ -155,13 +159,16 @@ namespace snowcrash
         /** Action-specific Parameters */
         SourceMap<Parameters> parameters;
 
-        /** Action-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
+        /** Action-specific Attributes (THIS SHOULD NOT BE HERE - should be
+         * under content) */
         SourceMap<Attributes> attributes;
 
-        /** Source Map of URI Template (THIS SHOULD NOT BE HERE - should be under element attributes) */
+        /** Source Map of URI Template (THIS SHOULD NOT BE HERE - should be
+         * under element attributes) */
         SourceMap<URITemplate> uriTemplate;
 
-        /** Source Map of Link Relation (THIS SHOULD NOT BE HERE - should be under element attributes) */
+        /** Source Map of Link Relation (THIS SHOULD NOT BE HERE - should be
+         * under element attributes) */
         SourceMap<Relation> relation;
 
         /**
@@ -203,7 +210,8 @@ namespace snowcrash
         /** Model representing this Resource */
         SourceMap<ResourceModel> model;
 
-        /** Source Map of Resource-specific Attributes (THIS SHOULD NOT BE HERE - should be under content) */
+        /** Source Map of Resource-specific Attributes (THIS SHOULD NOT BE HERE
+         * - should be under content) */
         SourceMap<Attributes> attributes;
 
         /** Parameters */
@@ -273,7 +281,8 @@ namespace snowcrash
             Content(const SourceMap<Element>::Content& rhs);
 
             /** Assignment operator */
-            SourceMap<Element>::Content& operator=(const SourceMap<Element>::Content& rhs);
+            SourceMap<Element>::Content& operator=(
+                const SourceMap<Element>::Content& rhs);
 
             /** Destructor */
             ~Content();
@@ -324,7 +333,8 @@ namespace snowcrash
     /**
      *  \brief API Blueprint Sourcemap AST
      *
-     *  This is top-level (or root if you prefer) of API Blueprint Sourcemap abstract syntax tree.
+     *  This is top-level (or root if you prefer) of API Blueprint Sourcemap
+     * abstract syntax tree.
      *  Start reading a parsed API here.
      */
     template <>

--- a/src/BlueprintUtility.h
+++ b/src/BlueprintUtility.h
@@ -33,7 +33,9 @@ namespace snowcrash
     /**
      *  \brief Matches a pair's first against a value.
      */
-    template <class T, class R = typename T::first_type, class Predicate = std::equal_to<R> >
+    template <class T,
+        class R = typename T::first_type,
+        class Predicate = std::equal_to<R> >
     struct MatchFirstWith : std::binary_function<T, R, bool> {
         bool operator()(const T& left, const R& right) const
         {
@@ -56,7 +58,8 @@ namespace snowcrash
      *  Matches payloads if their name and media type matches.
      */
     struct MatchPayload : std::binary_function<Payload, Payload, bool> {
-        bool operator()(const first_argument_type& left, const second_argument_type& right) const
+        bool operator()(const first_argument_type& left,
+            const second_argument_type& right) const
         {
 
             if (left.name != right.name)
@@ -67,7 +70,8 @@ namespace snowcrash
 
             header = std::find_if(left.headers.begin(),
                 left.headers.end(),
-                std::bind2nd(MatchFirstWith<Header, std::string>(), HTTPHeaderName::ContentType));
+                std::bind2nd(MatchFirstWith<Header, std::string>(),
+                    HTTPHeaderName::ContentType));
 
             std::string leftContentType;
 
@@ -77,7 +81,8 @@ namespace snowcrash
             // Resolve right content type
             header = std::find_if(right.headers.begin(),
                 right.headers.end(),
-                std::bind2nd(MatchFirstWith<Header, std::string>(), HTTPHeaderName::ContentType));
+                std::bind2nd(MatchFirstWith<Header, std::string>(),
+                    HTTPHeaderName::ContentType));
 
             std::string rightContentType;
 
@@ -90,7 +95,8 @@ namespace snowcrash
 
     /** URI matching predicate. */
     struct MatchResource : std::binary_function<Resource, Resource, bool> {
-        bool operator()(const first_argument_type& first, const second_argument_type& second) const
+        bool operator()(const first_argument_type& first,
+            const second_argument_type& second) const
         {
             return first.uriTemplate == second.uriTemplate;
         }
@@ -98,17 +104,21 @@ namespace snowcrash
 
     /**  Action matching predicate. */
     struct MatchAction : std::binary_function<Action, Action, bool> {
-        bool operator()(const first_argument_type& first, const second_argument_type& second) const
+        bool operator()(const first_argument_type& first,
+            const second_argument_type& second) const
         {
-            return first.uriTemplate == second.uriTemplate && first.method == second.method;
+            return first.uriTemplate == second.uriTemplate
+                && first.method == second.method;
         }
     };
 
     /** Relation matching predicate. */
     struct MatchRelation : std::binary_function<Action, Relation, bool> {
-        bool operator()(const first_argument_type& first, const second_argument_type& second) const
+        bool operator()(const first_argument_type& first,
+            const second_argument_type& second) const
         {
-            return !first.relation.str.empty() && !second.str.empty() && first.relation.str == second.str;
+            return !first.relation.str.empty() && !second.str.empty()
+                && first.relation.str == second.str;
         }
     };
 }

--- a/src/CodeBlockUtility.h
+++ b/src/CodeBlockUtility.h
@@ -27,11 +27,13 @@ namespace snowcrash
          */
         static size_t codeBlockIndentationLevel(const SectionType& type)
         {
-            if (type == BlueprintSectionType || type == ResourceGroupSectionType || type == ResourceSectionType
+            if (type == BlueprintSectionType || type == ResourceGroupSectionType
+                || type == ResourceSectionType
                 || type == ActionSectionType) {
 
                 return 1;
-            } else if (type == RequestBodySectionType || type == ResponseBodySectionType
+            } else if (type == RequestBodySectionType
+                || type == ResponseBodySectionType
                 || type == ModelBodySectionType) {
 
                 return 2;
@@ -42,13 +44,16 @@ namespace snowcrash
         }
 
         /**
-         *  \brief  Retrieve the textual content of a Markdown node as if it was a code block.
+         *  \brief  Retrieve the textual content of a Markdown node as if it was
+         * a code block.
          *  \param  pd      Parser status
          *  \param  report  Report log
          *  \param  conten  The content retrieved
          */
-        static void contentAsCodeBlock(
-            const MarkdownNodeIterator& node, const SectionParserData& pd, Report& report, mdp::ByteBuffer& content)
+        static void contentAsCodeBlock(const MarkdownNodeIterator& node,
+            const SectionParserData& pd,
+            Report& report,
+            mdp::ByteBuffer& content)
         {
 
             checkPossibleReference(node, pd, report);
@@ -72,17 +77,23 @@ namespace snowcrash
                 ss << " asset";
             }
 
-            ss << " is expected to be a pre-formatted code block, every of its line indented by exactly ";
+            ss << " is expected to be a pre-formatted code block, every of its "
+                  "line indented by exactly ";
             ss << level * 4 << " spaces or " << level << " tabs";
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-            report.warnings.push_back(Warning(ss.str(), IndentationWarning, sourceMap));
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
+            report.warnings.push_back(
+                Warning(ss.str(), IndentationWarning, sourceMap));
         }
 
         /** \brief  Retrieve the textual content of a signature markdown */
         static void signatureContentAsCodeBlock(
-            const MarkdownNodeIterator& node, const SectionParserData& pd, Report& report, mdp::ByteBuffer& content)
+            const MarkdownNodeIterator& node,
+            const SectionParserData& pd,
+            Report& report,
+            mdp::ByteBuffer& content)
         {
 
             mdp::ByteBuffer remainingContent;
@@ -104,30 +115,37 @@ namespace snowcrash
                 ss << " asset";
             }
 
-            ss << " is expected to be a pre-formatted code block, separate it by a newline and ";
+            ss << " is expected to be a pre-formatted code block, separate it "
+                  "by a newline and ";
             ss << "indent every of its line by ";
             ss << level * 4 << " spaces or " << level << " tabs";
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-            report.warnings.push_back(Warning(ss.str(), IndentationWarning, sourceMap));
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
+            report.warnings.push_back(
+                Warning(ss.str(), IndentationWarning, sourceMap));
         }
 
         /**
          *  \brief Check for potential excessive indentation of a list section
-         *  \return True if code block contains a recognized list section, false otherwise.
+         *  \return True if code block contains a recognized list section, false
+         * otherwise.
          */
-        static bool checkExcessiveIndentation(
-            const MarkdownNodeIterator& node, const SectionParserData& pd, Report& report)
+        static bool checkExcessiveIndentation(const MarkdownNodeIterator& node,
+            const SectionParserData& pd,
+            Report& report)
         {
 
-            // Check for possible superfluous indentation of a recognized list items.
+            // Check for possible superfluous indentation of a recognized list
+            // items.
             mdp::ByteBuffer r;
             mdp::ByteBuffer line = GetFirstLine(node->text, r);
             TrimString(line);
 
             // If line appears to be a Markdown list.
-            if (line.empty() || (line[0] != '-' && line[0] != '+' && line[0] != '*'))
+            if (line.empty()
+                || (line[0] != '-' && line[0] != '+' && line[0] != '*'))
                 return false;
 
             // Skip leading Markdown list item mark
@@ -158,8 +176,10 @@ namespace snowcrash
                 }
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                report.warnings.push_back(Warning(ss.str(), IndentationWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                report.warnings.push_back(
+                    Warning(ss.str(), IndentationWarning, sourceMap));
             }
 
             return false;
@@ -168,10 +188,12 @@ namespace snowcrash
         /**
          *  \brief  Parse one line of raw `key:value` data.
          *  \param  line            A line to parse
-         *  \param  keyValuePair    The output buffer to place the parsed data into
+         *  \param  keyValuePair    The output buffer to place the parsed data
+         * into
          *  \return True on success, false otherwise
          */
-        static bool keyValueFromLine(const mdp::ByteBuffer& line, KeyValuePair& keyValuePair)
+        static bool keyValueFromLine(
+            const mdp::ByteBuffer& line, KeyValuePair& keyValuePair)
         {
 
             std::vector<std::string> rawMetadata = SplitOnFirst(line, ':');
@@ -182,7 +204,8 @@ namespace snowcrash
             TrimString(keyValuePair.first);
             TrimString(keyValuePair.second);
 
-            return (!keyValuePair.first.empty() && !keyValuePair.second.empty());
+            return (
+                !keyValuePair.first.empty() && !keyValuePair.second.empty());
         }
 
         /**
@@ -191,7 +214,8 @@ namespace snowcrash
          *  \param  outSM The source map to which source map should be added
          *  \return asset The value of the asset
          */
-        static mdp::ByteBuffer addDanglingAsset(const MarkdownNodeIterator& node,
+        static mdp::ByteBuffer addDanglingAsset(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             SectionType& sectionType,
             Report& report,
@@ -209,7 +233,8 @@ namespace snowcrash
             TwoNewLines(asset);
             out += asset;
 
-            size_t level = CodeBlockUtility::codeBlockIndentationLevel(sectionType);
+            size_t level
+                = CodeBlockUtility::codeBlockIndentationLevel(sectionType);
 
             if (node->type == mdp::CodeMarkdownNodeType)
                 level--; // Deduct one level for a code block
@@ -219,23 +244,30 @@ namespace snowcrash
             if (level) {
                 // WARN: Dangling asset
                 std::stringstream ss;
-                ss << "dangling message-body asset, expected a pre-formatted code block, ";
-                ss << "indent every of it's line by " << level * 4 << " spaces or " << level << " tabs";
+                ss << "dangling message-body asset, expected a pre-formatted "
+                      "code block, ";
+                ss << "indent every of it's line by " << level * 4
+                   << " spaces or " << level << " tabs";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                report.warnings.push_back(Warning(ss.str(), IndentationWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                report.warnings.push_back(
+                    Warning(ss.str(), IndentationWarning, sourceMap));
             }
 
             return asset;
         }
 
         /**
-         *  \brief Check for potential resource model reference and warn about not recognizing them
-         *  \return True if code block contains a resource model reference, false otherwise.
+         *  \brief Check for potential resource model reference and warn about
+         * not recognizing them
+         *  \return True if code block contains a resource model reference,
+         * false otherwise.
          */
-        static bool checkPossibleReference(
-            const MarkdownNodeIterator& node, const SectionParserData& pd, Report& report)
+        static bool checkPossibleReference(const MarkdownNodeIterator& node,
+            const SectionParserData& pd,
+            Report& report)
         {
 
             mdp::ByteBuffer source = node->text;
@@ -247,12 +279,16 @@ namespace snowcrash
 
                 std::stringstream ss;
                 ss << "found a possible '" << symbol << "' model reference, ";
-                ss << "a reference must be directly in the " << SectionName(pd.sectionContext())
-                   << " section, indented by 4 spaces or 1 tab, without any additional sections";
+                ss << "a reference must be directly in the "
+                   << SectionName(pd.sectionContext())
+                   << " section, indented by 4 spaces or 1 tab, without any "
+                      "additional sections";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                report.warnings.push_back(
+                    Warning(ss.str(), IgnoringWarning, sourceMap));
 
                 return true;
             }

--- a/src/DataStructureGroupParser.h
+++ b/src/DataStructureGroupParser.h
@@ -17,17 +17,20 @@ namespace snowcrash
 {
 
     /** Data structure group matching regex */
-    const char* const DataStructureGroupRegex = "^[[:blank:]]*[Dd]ata[[:blank:]]+[Ss]tructures?[[:blank:]]*$";
+    const char* const DataStructureGroupRegex
+        = "^[[:blank:]]*[Dd]ata[[:blank:]]+[Ss]tructures?[[:blank:]]*$";
 
     /**
      * Data structure group section processor
      */
     template <>
-    struct SectionProcessor<DataStructureGroup> : public SectionProcessorBase<DataStructureGroup> {
+    struct SectionProcessor<DataStructureGroup>
+        : public SectionProcessorBase<DataStructureGroup> {
 
         NO_SECTION_DESCRIPTION(DataStructureGroup)
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<DataStructureGroup>& out)
@@ -40,15 +43,20 @@ namespace snowcrash
                 IntermediateParseResult<mson::NamedType> namedType(out.report);
                 cur = MSONNamedTypeParser::parse(node, siblings, pd, namedType);
 
-                if (isNamedTypeDuplicate(pd.blueprint, namedType.node.name.symbol.literal)) {
+                if (isNamedTypeDuplicate(
+                        pd.blueprint, namedType.node.name.symbol.literal)) {
 
                     // WARN: duplicate named type
                     std::stringstream ss;
-                    ss << "named type with name '" << namedType.node.name.symbol.literal << "' already exists";
+                    ss << "named type with name '"
+                       << namedType.node.name.symbol.literal
+                       << "' already exists";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), DuplicateWarning, sourceMap));
                     return cur;
                 }
 
@@ -61,19 +69,24 @@ namespace snowcrash
 
                     SourceMap<Element> elementSM(Element::DataStructureElement);
 
-                    elementSM.content.dataStructure.name = namedType.sourceMap.name;
-                    elementSM.content.dataStructure.typeDefinition = namedType.sourceMap.typeDefinition;
-                    elementSM.content.dataStructure.sections = namedType.sourceMap.sections;
+                    elementSM.content.dataStructure.name
+                        = namedType.sourceMap.name;
+                    elementSM.content.dataStructure.typeDefinition
+                        = namedType.sourceMap.typeDefinition;
+                    elementSM.content.dataStructure.sections
+                        = namedType.sourceMap.sections;
 
-                    out.sourceMap.content.elements().collection.push_back(elementSM);
+                    out.sourceMap.content.elements().collection.push_back(
+                        elementSM);
                 }
             }
 
             return cur;
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<DataStructureGroup>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<DataStructureGroup>& out)
         {
 
             out.node.element = Element::CategoryElement;
@@ -89,7 +102,8 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::HeaderMarkdownNodeType && !node->text.empty()) {
+            if (node->type == mdp::HeaderMarkdownNodeType
+                && !node->text.empty()) {
 
                 mdp::ByteBuffer remaining, subject = node->text;
 
@@ -112,7 +126,9 @@ namespace snowcrash
 
         static SectionTypes upperSectionTypes()
         {
-            return { DataStructureGroupSectionType, ResourceGroupSectionType, ResourceSectionType };
+            return { DataStructureGroupSectionType,
+                ResourceGroupSectionType,
+                ResourceSectionType };
         }
 
         /**
@@ -121,27 +137,33 @@ namespace snowcrash
          * \param blueprint The blueprint which is formed until now
          * \param name The named type name to be checked
          */
-        static bool isNamedTypeDuplicate(const Blueprint& blueprint, mdp::ByteBuffer& name)
+        static bool isNamedTypeDuplicate(
+            const Blueprint& blueprint, mdp::ByteBuffer& name)
         {
 
-            for (Elements::const_iterator it = blueprint.content.elements().begin();
+            for (Elements::const_iterator it
+                 = blueprint.content.elements().begin();
                  it != blueprint.content.elements().end();
                  ++it) {
 
                 if (it->element == Element::CategoryElement) {
 
-                    for (Elements::const_iterator subIt = it->content.elements().begin();
+                    for (Elements::const_iterator subIt
+                         = it->content.elements().begin();
                          subIt != it->content.elements().end();
                          ++subIt) {
 
                         if (subIt->element == Element::ResourceElement
-                            && subIt->content.resource.attributes.name.symbol.literal == name) {
+                            && subIt->content.resource.attributes.name.symbol
+                                    .literal
+                                == name) {
 
                             return true;
                         }
 
                         if (subIt->element == Element::DataStructureElement
-                            && subIt->content.dataStructure.name.symbol.literal == name) {
+                            && subIt->content.dataStructure.name.symbol.literal
+                                == name) {
 
                             return true;
                         }
@@ -154,7 +176,8 @@ namespace snowcrash
     };
 
     /** Data Structures Parser */
-    typedef SectionParser<DataStructureGroup, HeaderSectionAdapter> DataStructureGroupParser;
+    typedef SectionParser<DataStructureGroup, HeaderSectionAdapter>
+        DataStructureGroupParser;
 }
 
 #endif

--- a/src/HTTP.cc
+++ b/src/HTTP.cc
@@ -40,7 +40,8 @@ HTTPMethodTraits snowcrash::GetMethodTrait(HTTPMethod method)
     traits.method = method;
 
     // Following HTTP methods MUST NOT contain response body
-    // FIXME: When refactoring traits don't forget that 'CONNECT' has no body only when 1xx-2xx
+    // FIXME: When refactoring traits don't forget that 'CONNECT' has no body
+    // only when 1xx-2xx
     if (method == HTTPMethodName::Head || method == HTTPMethodName::Connect) {
         traits.allowBody = false;
     }

--- a/src/HTTP.h
+++ b/src/HTTP.h
@@ -19,8 +19,9 @@
  *  defined type due to C++98 string concatenation limitations.
  *  FIXME: To be improved with migration to C++11.
  */
-#define HTTP_REQUEST_METHOD                                                                                            \
-    "(GET|POST|PUT|DELETE|OPTIONS|PATCH|PROPPATCH|LOCK|UNLOCK|COPY|MOVE|MKCOL|HEAD|LINK|UNLINK|CONNECT)"
+#define HTTP_REQUEST_METHOD                                                    \
+    "(GET|POST|PUT|DELETE|OPTIONS|PATCH|PROPPATCH|LOCK|UNLOCK|COPY|MOVE|"      \
+    "MKCOL|HEAD|LINK|UNLINK|CONNECT)"
 
 /**
  *  \brief URI Template.

--- a/src/HeadersParser.cc
+++ b/src/HeadersParser.cc
@@ -6,13 +6,16 @@ using namespace snowcrash;
 static HeaderIterator findHeader(const Headers& headers, const Header& header)
 {
 
-    return std::find_if(
-        headers.begin(), headers.end(), std::bind2nd(MatchFirsts<Header, IEqual<Header::first_type> >(), header));
+    return std::find_if(headers.begin(),
+        headers.end(),
+        std::bind2nd(
+            MatchFirsts<Header, IEqual<Header::first_type> >(), header));
 }
 
 typedef std::vector<std::string> HeadersKeyCollection;
 
-/** Get collection of allowed keywords - workarround due to C++98 restriction - static initialization of vector */
+/** Get collection of allowed keywords - workarround due to C++98 restriction -
+ * static initialization of vector */
 static const HeadersKeyCollection& getAllowedMultipleDefinitions()
 {
 
@@ -20,7 +23,8 @@ static const HeadersKeyCollection& getAllowedMultipleDefinitions()
         HTTPHeaderName::SetCookie, HTTPHeaderName::Link,
     };
 
-    static const HeadersKeyCollection allowedMultipleDefinitions(keys, keys + (sizeof(keys) / sizeof(keys[0])));
+    static const HeadersKeyCollection allowedMultipleDefinitions(
+        keys, keys + (sizeof(keys) / sizeof(keys[0])));
 
     return allowedMultipleDefinitions;
 }
@@ -33,7 +37,9 @@ static bool isAllowedMultipleDefinition(const Header& header)
 
     return std::find_if(keys.begin(),
                keys.end(),
-               std::bind1st(MatchFirstWith<Header, std::string, IEqual<std::string> >(), header))
+               std::bind1st(
+                   MatchFirstWith<Header, std::string, IEqual<std::string> >(),
+                   header))
         != keys.end();
 }
 
@@ -44,7 +50,8 @@ static bool isNotValidTokenChar(const std::string::value_type& c)
     return !(std::isalnum(c) || (validChars.find(c) != std::string::npos));
 }
 
-static std::string::const_iterator findNonValidCharInHeaderName(const std::string& token)
+static std::string::const_iterator findNonValidCharInHeaderName(
+    const std::string& token)
 {
 
     return std::find_if(token.begin(), token.end(), isNotValidTokenChar);
@@ -61,7 +68,8 @@ std::string HeaderNameTokenChecker::getMessage() const
 
     const char invalidChar = *findNonValidCharInHeaderName(headerName);
     std::stringstream ss;
-    ss << "HTTP header name '" << headerName << "' contains illegal character '" << invalidChar << "' (0x" << std::hex
+    ss << "HTTP header name '" << headerName << "' contains illegal character '"
+       << invalidChar << "' (0x" << std::hex
        << static_cast<int16_t>(invalidChar) << ") skipping the header";
 
     return ss.str();
@@ -70,7 +78,8 @@ std::string HeaderNameTokenChecker::getMessage() const
 bool ColonPresentedChecker::operator()() const
 {
 
-    return captures[3].size() >= 1 && (captures[3].find(':') != std::string::npos);
+    return captures[3].size() >= 1
+        && (captures[3].find(':') != std::string::npos);
 }
 
 std::string ColonPresentedChecker::getMessage() const
@@ -85,7 +94,8 @@ std::string ColonPresentedChecker::getMessage() const
 bool HeadersDuplicateChecker::operator()() const
 {
 
-    return findHeader(headers, header) == headers.end() || isAllowedMultipleDefinition(header);
+    return findHeader(headers, header) == headers.end()
+        || isAllowedMultipleDefinition(header);
 }
 
 std::string HeadersDuplicateChecker::getMessage() const
@@ -117,7 +127,8 @@ bool HeaderParserValidator::operator()(const ValidateFunctorBase& rule)
     bool rc = rule();
 
     if (!rc) {
-        out.report.warnings.push_back(Warning(rule.getMessage(), HTTPWarning, sourceMap));
+        out.report.warnings.push_back(
+            Warning(rule.getMessage(), HTTPWarning, sourceMap));
     }
 
     return rc;

--- a/src/HeadersParser.h
+++ b/src/HeadersParser.h
@@ -42,13 +42,15 @@ namespace snowcrash
         virtual bool operator()() const = 0;
     };
 
-    /** Functor implementation for check header name is valid token according to specification \see
+    /** Functor implementation for check header name is valid token according to
+     * specification \see
      * http://tools.ietf.org/html/rfc7230#section-3.2.6 */
     struct HeaderNameTokenChecker : public ValidateFunctorBase {
 
         const std::string& headerName;
 
-        explicit HeaderNameTokenChecker(const std::string& headerName) : headerName(headerName)
+        explicit HeaderNameTokenChecker(const std::string& headerName)
+            : headerName(headerName)
         {
         }
 
@@ -56,12 +58,14 @@ namespace snowcrash
         virtual std::string getMessage() const;
     };
 
-    /** Functor implementation for check header contains colon character between name and value */
+    /** Functor implementation for check header contains colon character between
+     * name and value */
     struct ColonPresentedChecker : public ValidateFunctorBase {
 
         const CaptureGroups& captures;
 
-        explicit ColonPresentedChecker(const CaptureGroups& captures) : captures(captures)
+        explicit ColonPresentedChecker(const CaptureGroups& captures)
+            : captures(captures)
         {
         }
 
@@ -75,7 +79,8 @@ namespace snowcrash
         const Header& header;
         const Headers& headers;
 
-        explicit HeadersDuplicateChecker(const Header& header, const Headers& headers)
+        explicit HeadersDuplicateChecker(
+            const Header& header, const Headers& headers)
             : header(header), headers(headers)
         {
         }
@@ -89,7 +94,8 @@ namespace snowcrash
 
         const Header& header;
 
-        explicit HeaderValuePresentedChecker(const Header& header) : header(header)
+        explicit HeaderValuePresentedChecker(const Header& header)
+            : header(header)
         {
         }
 
@@ -97,13 +103,15 @@ namespace snowcrash
         virtual std::string getMessage() const;
     };
 
-    /** Functor receive and invoke individual Validators and conditionaly push reports  */
+    /** Functor receive and invoke individual Validators and conditionaly push
+     * reports  */
     struct HeaderParserValidator {
 
         const ParseResultRef<Headers>& out;
         mdp::CharactersRangeSet sourceMap;
 
-        HeaderParserValidator(const ParseResultRef<Headers>& out, mdp::CharactersRangeSet sourceMap)
+        HeaderParserValidator(const ParseResultRef<Headers>& out,
+            mdp::CharactersRangeSet sourceMap)
             : out(out), sourceMap(sourceMap)
         {
         }
@@ -117,7 +125,8 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Headers> : public SectionProcessorBase<Headers> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -125,7 +134,8 @@ namespace snowcrash
         {
 
             mdp::ByteBuffer content;
-            CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, content);
+            CodeBlockUtility::signatureContentAsCodeBlock(
+                node, pd, out.report, content);
 
             // drop first line (it contain " + Headers")
             // we need just "content"
@@ -139,7 +149,8 @@ namespace snowcrash
 
         NO_SECTION_DESCRIPTION(Headers)
 
-        static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processContent(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Headers>& out)
@@ -148,12 +159,14 @@ namespace snowcrash
             mdp::ByteBuffer content;
             CodeBlockUtility::contentAsCodeBlock(node, pd, out.report, content);
 
-            headersFromContent(node, node->sourceMap.begin(), node->sourceMap.end(), pd, out);
+            headersFromContent(
+                node, node->sourceMap.begin(), node->sourceMap.end(), pd, out);
 
             return ++MarkdownNodeIterator(node);
         }
 
-        static bool isContentNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isContentNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
             return (SectionKeywordSignature(node) == UndefinedSectionType);
@@ -162,7 +175,8 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 mdp::ByteBuffer subject = node->children().front().text;
                 mdp::ByteBuffer signature;
@@ -178,16 +192,21 @@ namespace snowcrash
             return UndefinedSectionType;
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Headers>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Headers>& out)
         {
 
             if (out.node.empty()) {
 
                 // WARN: No valid headers defined
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning("no valid headers specified", FormattingWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning("no valid headers specified",
+                        FormattingWarning,
+                        sourceMap));
             }
         }
 
@@ -199,7 +218,8 @@ namespace snowcrash
          *
          * \param line - contains individual line with header definition
          * \param header - is filled by name and value if definition is valid
-         * \param out - "report" member can receive warning while checking validity
+         * \param out - "report" member can receive warning while checking
+         * validity
          * \param sourceMap - just contain source mapping for warning report
          */
         static bool parseHeaderLine(const mdp::ByteBuffer& line,
@@ -215,10 +235,11 @@ namespace snowcrash
 
             if (!matched) {
                 // WARN: unable to parse header
-                out.report.warnings.push_back(Warning(
-                    "unable to parse HTTP header, expected '<header name> : <header value>', one header per line",
-                    FormattingWarning,
-                    sourceMap));
+                out.report.warnings.push_back(
+                    Warning("unable to parse HTTP header, expected '<header "
+                            "name> : <header value>', one header per line",
+                        FormattingWarning,
+                        sourceMap));
                 return false;
             }
 
@@ -238,14 +259,16 @@ namespace snowcrash
             return !header.first.empty();
         }
 
-        static bool fetchLine(const std::string& input, mdp::BytesRange& map, std::string& line)
+        static bool fetchLine(
+            const std::string& input, mdp::BytesRange& map, std::string& line)
         {
 
             if (input.length() < (map.location + map.length)) {
                 return false;
             }
 
-            TrimRange trim = GetTrimInfo(input.begin() + map.location, input.begin() + map.location + map.length);
+            TrimRange trim = GetTrimInfo(input.begin() + map.location,
+                input.begin() + map.location + map.length);
 
             map.length = std::get<1>(trim);
 
@@ -262,7 +285,8 @@ namespace snowcrash
 
         static bool isCodeFence(const std::string& line)
         {
-            return (!memcmp(line.c_str(), "```", 3) || !memcmp(line.c_str(), "~~~", 3));
+            return (!memcmp(line.c_str(), "```", 3)
+                || !memcmp(line.c_str(), "~~~", 3));
         }
 
         /** Retrieve headers from content */
@@ -297,7 +321,8 @@ namespace snowcrash
                 mdp::BytesRangeSet byteMap;
                 byteMap.push_back(map);
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(byteMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        byteMap, pd.sourceCharacterIndex);
 
                 if (parseHeaderLine(line, header, out, sourceMap)) {
                     out.node.push_back(header);
@@ -319,8 +344,10 @@ namespace snowcrash
             SourceMap<TransactionExamples>& examplesSM)
         {
 
-            Collection<TransactionExample>::iterator exampleIt = examples.begin();
-            Collection<SourceMap<TransactionExample> >::iterator exampleSourceMapIt;
+            Collection<TransactionExample>::iterator exampleIt
+                = examples.begin();
+            Collection<SourceMap<TransactionExample> >::iterator
+                exampleSourceMapIt;
 
             if (pd.exportSourceMap()) {
                 exampleSourceMapIt = examplesSM.collection.begin();
@@ -328,42 +355,52 @@ namespace snowcrash
 
             while (exampleIt != examples.end()) {
 
-                Collection<Request>::iterator requestIt = exampleIt->requests.begin();
+                Collection<Request>::iterator requestIt
+                    = exampleIt->requests.begin();
                 Collection<SourceMap<Request> >::iterator requestSourceMapIt;
 
                 if (pd.exportSourceMap()) {
-                    requestSourceMapIt = exampleSourceMapIt->requests.collection.begin();
+                    requestSourceMapIt
+                        = exampleSourceMapIt->requests.collection.begin();
                 }
 
                 // Requests
                 while (requestIt != exampleIt->requests.end()) {
 
-                    requestIt->headers.insert(requestIt->headers.begin(), headers.begin(), headers.end());
+                    requestIt->headers.insert(requestIt->headers.begin(),
+                        headers.begin(),
+                        headers.end());
                     ++requestIt;
 
                     if (pd.exportSourceMap()) {
-                        requestSourceMapIt->headers.collection.insert(requestSourceMapIt->headers.collection.begin(),
+                        requestSourceMapIt->headers.collection.insert(
+                            requestSourceMapIt->headers.collection.begin(),
                             headersSM.collection.begin(),
                             headersSM.collection.end());
                         ++requestSourceMapIt;
                     }
                 }
 
-                Collection<Response>::iterator responseIt = exampleIt->responses.begin();
+                Collection<Response>::iterator responseIt
+                    = exampleIt->responses.begin();
                 Collection<SourceMap<Response> >::iterator responseSourceMapIt;
 
                 if (pd.exportSourceMap()) {
-                    responseSourceMapIt = exampleSourceMapIt->responses.collection.begin();
+                    responseSourceMapIt
+                        = exampleSourceMapIt->responses.collection.begin();
                 }
 
                 // Responses
                 while (responseIt != exampleIt->responses.end()) {
 
-                    responseIt->headers.insert(responseIt->headers.begin(), headers.begin(), headers.end());
+                    responseIt->headers.insert(responseIt->headers.begin(),
+                        headers.begin(),
+                        headers.end());
                     ++responseIt;
 
                     if (pd.exportSourceMap()) {
-                        responseSourceMapIt->headers.collection.insert(responseSourceMapIt->headers.collection.begin(),
+                        responseSourceMapIt->headers.collection.insert(
+                            responseSourceMapIt->headers.collection.begin(),
                             headersSM.collection.begin(),
                             headersSM.collection.end());
                         ++responseSourceMapIt;

--- a/src/MSON.cc
+++ b/src/MSON.cc
@@ -56,7 +56,8 @@ const Elements& TypeSection::Content::elements() const
     return *m_elements;
 }
 
-TypeSection::Content::Content(const Markdown& description_, const Literal& value_)
+TypeSection::Content::Content(
+    const Markdown& description_, const Literal& value_)
     : description(description_), value(value_)
 {
     m_elements.reset(::new Elements);
@@ -69,7 +70,8 @@ TypeSection::Content::Content(const TypeSection::Content& rhs)
     m_elements.reset(::new Elements(*rhs.m_elements.get()));
 }
 
-TypeSection::Content& TypeSection::Content::operator=(const TypeSection::Content& rhs)
+TypeSection::Content& TypeSection::Content::operator=(
+    const TypeSection::Content& rhs)
 {
     this->description = rhs.description;
     this->value = rhs.value;
@@ -84,19 +86,22 @@ TypeSection::Content::~Content()
 
 bool TypeSection::empty() const
 {
-    return (this->klass == TypeSection::UndefinedClass && this->content.value.empty()
+    return (this->klass == TypeSection::UndefinedClass
+        && this->content.value.empty()
         && this->content.description.empty()
         && this->content.elements().empty());
 }
 
 bool NamedType::empty() const
 {
-    return (this->typeDefinition.empty() && this->name.empty() && this->sections.empty());
+    return (this->typeDefinition.empty() && this->name.empty()
+        && this->sections.empty());
 }
 
 bool ValueMember::empty() const
 {
-    return (this->valueDefinition.empty() && this->sections.empty() && this->description.empty());
+    return (this->valueDefinition.empty() && this->sections.empty()
+        && this->description.empty());
 }
 
 bool PropertyName::empty() const
@@ -106,7 +111,9 @@ bool PropertyName::empty() const
 
 bool PropertyMember::empty() const
 {
-    return (this->name.empty() && this->description.empty() && this->sections.empty() && this->valueDefinition.empty());
+    return (this->name.empty() && this->description.empty()
+        && this->sections.empty()
+        && this->valueDefinition.empty());
 }
 
 OneOf& Element::Content::oneOf()

--- a/src/MSON.h
+++ b/src/MSON.h
@@ -57,7 +57,8 @@ namespace mson
     typedef std::map<Literal, BaseType> NamedTypeBaseTable;
 
     /** Named Types inheritance table */
-    typedef std::map<Literal, std::pair<Literal, mdp::BytesRangeSet> > NamedTypeInheritanceTable;
+    typedef std::map<Literal, std::pair<Literal, mdp::BytesRangeSet> >
+        NamedTypeInheritanceTable;
 
     /** Named Types dependency table */
     typedef std::map<Literal, std::set<Literal> > NamedTypeDependencyTable;
@@ -143,7 +144,8 @@ namespace mson
         SampleTypeAttribute = (1 << 3),   // The type is a sample
         DefaultTypeAttribute = (1 << 4),  // The type is default
         NullableTypeAttribute = (1 << 5), // The type is nullable
-        FixedTypeTypeAttribute = (1 << 6) // This type works like fixed, but it is unheritable
+        FixedTypeTypeAttribute
+        = (1 << 6) // This type works like fixed, but it is unheritable
     };
 
     /** List of type attributes */
@@ -234,7 +236,8 @@ namespace mson
             const Elements& elements() const;
 
             /** Constructor */
-            Content(const Markdown& description_ = Markdown(), const Literal& value_ = Literal());
+            Content(const Markdown& description_ = Markdown(),
+                const Literal& value_ = Literal());
 
             /** Copy constructor */
             Content(const TypeSection::Content& rhs);
@@ -250,7 +253,8 @@ namespace mson
         };
 
         /** Constructor */
-        TypeSection(const TypeSection::Class& klass_ = TypeSection::UndefinedClass)
+        TypeSection(
+            const TypeSection::Class& klass_ = TypeSection::UndefinedClass)
             : baseType(UndefinedBaseType), klass(klass_)
         {
         }

--- a/src/MSONMixinParser.h
+++ b/src/MSONMixinParser.h
@@ -24,17 +24,20 @@ namespace snowcrash
      * MSON Mixin Section Processor
      */
     template <>
-    struct SectionProcessor<mson::Mixin> : public SignatureSectionProcessorBase<mson::Mixin> {
+    struct SectionProcessor<mson::Mixin>
+        : public SignatureSectionProcessorBase<mson::Mixin> {
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::AttributesTrait);
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::AttributesTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<mson::Mixin>& out)
@@ -43,26 +46,34 @@ namespace snowcrash
             CaptureGroups captureGroups;
             std::vector<mdp::ByteBuffer> attributes = signature.attributes;
 
-            if (RegexCapture(signature.identifier, MSONMixinRegex, captureGroups, 2) && !captureGroups[1].empty()) {
+            if (RegexCapture(
+                    signature.identifier, MSONMixinRegex, captureGroups, 2)
+                && !captureGroups[1].empty()) {
 
                 // Get the type name and insert it into attributes
-                std::string typeName = signature.identifier.substr(captureGroups[1].length());
+                std::string typeName
+                    = signature.identifier.substr(captureGroups[1].length());
                 attributes.insert(attributes.begin(), typeName);
             }
 
-            mson::parseTypeDefinition(node, pd, attributes, out.report, out.node);
+            mson::parseTypeDefinition(
+                node, pd, attributes, out.report, out.node);
 
             if (pd.exportSourceMap()) {
                 out.sourceMap.sourceMap = node->sourceMap;
             }
 
-            if ((out.node.baseType == mson::PrimitiveBaseType) || (out.node.baseType == mson::UndefinedBaseType)) {
+            if ((out.node.baseType == mson::PrimitiveBaseType)
+                || (out.node.baseType == mson::UndefinedBaseType)) {
 
                 // WARN: invalid mixin base type
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(
-                    Warning("mixin type may not include a type of a primitive sub-type", FormattingWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(Warning(
+                    "mixin type may not include a type of a primitive sub-type",
+                    FormattingWarning,
+                    sourceMap));
             }
 
             // Check circular references
@@ -70,8 +81,12 @@ namespace snowcrash
                 && !out.node.typeSpecification.name.symbol.literal.empty()
                 && !out.node.typeSpecification.name.symbol.variable) {
 
-                mson::addDependency(
-                    node, pd, out.node.typeSpecification.name.symbol.literal, pd.namedTypeContext, out.report, true);
+                mson::addDependency(node,
+                    pd,
+                    out.node.typeSpecification.name.symbol.literal,
+                    pd.namedTypeContext,
+                    out.report,
+                    true);
             }
 
             return ++MarkdownNodeIterator(node);
@@ -82,7 +97,8 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 mdp::ByteBuffer subject = node->children().front().text;
 

--- a/src/MSONNamedTypeParser.h
+++ b/src/MSONNamedTypeParser.h
@@ -23,35 +23,45 @@ namespace snowcrash
      * MSON Named Type Section Processor
      */
     template <>
-    struct SectionProcessor<mson::NamedType> : public SignatureSectionProcessorBase<mson::NamedType> {
+    struct SectionProcessor<mson::NamedType>
+        : public SignatureSectionProcessorBase<mson::NamedType> {
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::AttributesTrait);
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::AttributesTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<mson::NamedType>& out)
         {
 
             mson::parseTypeName(signature.identifier, out.node.name, false);
-            mson::parseTypeDefinition(node, pd, signature.attributes, out.report, out.node.typeDefinition);
+            mson::parseTypeDefinition(node,
+                pd,
+                signature.attributes,
+                out.report,
+                out.node.typeDefinition);
 
             mdp::ByteBuffer subject = node->text;
             TrimString(subject);
 
-            if (subject[0] != '`' && RegexMatch(out.node.name.symbol.literal, MSONReservedCharsRegex)) {
+            if (subject[0] != '`' && RegexMatch(out.node.name.symbol.literal,
+                                         MSONReservedCharsRegex)) {
 
                 // WARN: named type name should not contain reserved characters
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 out.report.warnings.push_back(
-                    Warning("please escape the name of the data structure using backticks since it contains MSON "
+                    Warning("please escape the name of the data structure "
+                            "using backticks since it contains MSON "
                             "reserved characters",
                         FormattingWarning,
                         sourceMap));
@@ -68,7 +78,8 @@ namespace snowcrash
                 }
             }
 
-            // Named types should have type specification when sub-typed from primitive types
+            // Named types should have type specification when sub-typed from
+            // primitive types
             if (out.node.typeDefinition.baseType == mson::UndefinedBaseType) {
                 out.node.typeDefinition.baseType = mson::ImplicitObjectBaseType;
             }
@@ -79,7 +90,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processDescription(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::NamedType>& out)
@@ -89,22 +101,30 @@ namespace snowcrash
                 node, pd, out.node.sections, out.sourceMap.sections);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::NamedType>& out)
         {
 
-            ParseResultRef<mson::TypeSections> typeSections(out.report, out.node.sections, out.sourceMap.sections);
+            ParseResultRef<mson::TypeSections> typeSections(
+                out.report, out.node.sections, out.sourceMap.sections);
 
-            return SectionProcessor<mson::ValueMember>::processNestedMembers<MSONTypeSectionHeaderParser>(
-                node, siblings, pd, typeSections, out.node.typeDefinition.baseType);
+            return SectionProcessor<mson::ValueMember>::
+                processNestedMembers<MSONTypeSectionHeaderParser>(node,
+                    siblings,
+                    pd,
+                    typeSections,
+                    out.node.typeDefinition.baseType);
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            return SectionProcessor<mson::ValueMember>::isDescriptionNode(node, sectionType);
+            return SectionProcessor<mson::ValueMember>::isDescriptionNode(
+                node, sectionType);
         }
 
         static SectionType sectionType(const MarkdownNodeIterator& node)
@@ -112,7 +132,8 @@ namespace snowcrash
 
             SectionType sectionType = SectionKeywordSignature(node);
 
-            if (node->type == mdp::HeaderMarkdownNodeType && sectionType == UndefinedSectionType) {
+            if (node->type == mdp::HeaderMarkdownNodeType
+                && sectionType == UndefinedSectionType) {
 
                 return MSONNamedTypeSectionType;
             }
@@ -126,8 +147,9 @@ namespace snowcrash
             return SectionProcessor<mson::ValueMember>::nestedSectionType(node);
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<mson::NamedType>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<mson::NamedType>& out)
         {
 
             // Clear named type context
@@ -136,7 +158,8 @@ namespace snowcrash
     };
 
     /** MSON Named Type Section Parser */
-    typedef SectionParser<mson::NamedType, HeaderSectionAdapter> MSONNamedTypeParser;
+    typedef SectionParser<mson::NamedType, HeaderSectionAdapter>
+        MSONNamedTypeParser;
 }
 
 #endif

--- a/src/MSONOneOfParser.cc
+++ b/src/MSONOneOfParser.cc
@@ -14,7 +14,8 @@ namespace snowcrash
 {
 
     /** Implementation of processNestedSection */
-    MarkdownNodeIterator SectionProcessor<mson::OneOf>::processNestedSection(const MarkdownNodeIterator& node,
+    MarkdownNodeIterator SectionProcessor<mson::OneOf>::processNestedSection(
+        const MarkdownNodeIterator& node,
         const MarkdownNodes& siblings,
         SectionParserData& pd,
         const ParseResultRef<mson::OneOf>& out)
@@ -52,10 +53,12 @@ namespace snowcrash
             }
 
             case MSONPropertyMembersSectionType: {
-                IntermediateParseResult<mson::TypeSection> typeSection(out.report);
+                IntermediateParseResult<mson::TypeSection> typeSection(
+                    out.report);
                 typeSection.node.baseType = mson::ObjectBaseType;
 
-                cur = MSONTypeSectionListParser::parse(node, siblings, pd, typeSection);
+                cur = MSONTypeSectionListParser::parse(
+                    node, siblings, pd, typeSection);
 
                 element.buildFromElements(typeSection.node.content.elements());
 
@@ -67,8 +70,10 @@ namespace snowcrash
             }
 
             case MSONPropertyMemberSectionType: {
-                IntermediateParseResult<mson::PropertyMember> propertyMember(out.report);
-                cur = MSONPropertyMemberParser::parse(node, siblings, pd, propertyMember);
+                IntermediateParseResult<mson::PropertyMember> propertyMember(
+                    out.report);
+                cur = MSONPropertyMemberParser::parse(
+                    node, siblings, pd, propertyMember);
 
                 element.build(propertyMember.node);
 
@@ -95,7 +100,8 @@ namespace snowcrash
     }
 
     /** Implementation of nestedSectionType */
-    SectionType SectionProcessor<mson::OneOf>::nestedSectionType(const MarkdownNodeIterator& node)
+    SectionType SectionProcessor<mson::OneOf>::nestedSectionType(
+        const MarkdownNodeIterator& node)
     {
 
         SectionType nestedType = UndefinedSectionType;

--- a/src/MSONOneOfParser.h
+++ b/src/MSONOneOfParser.h
@@ -17,13 +17,15 @@ namespace snowcrash
 {
 
     /** MSON One Of matching regex */
-    const char* const MSONOneOfRegex = "^[[:blank:]]*[Oo]ne[[:blank:]]+[Oo]f[[:blank:]]*$";
+    const char* const MSONOneOfRegex
+        = "^[[:blank:]]*[Oo]ne[[:blank:]]+[Oo]f[[:blank:]]*$";
 
     /**
      * MSON One Of Section Processor
      */
     template <>
-    struct SectionProcessor<mson::OneOf> : public SignatureSectionProcessorBase<mson::OneOf> {
+    struct SectionProcessor<mson::OneOf>
+        : public SignatureSectionProcessorBase<mson::OneOf> {
 
         static SignatureTraits signatureTraits()
         {
@@ -36,28 +38,37 @@ namespace snowcrash
         NO_SECTION_DESCRIPTION(mson::OneOf)
 
         static MarkdownNodeIterator processNestedSection(
-            const MarkdownNodeIterator&, const MarkdownNodes&, SectionParserData&, const ParseResultRef<mson::OneOf>&);
+            const MarkdownNodeIterator&,
+            const MarkdownNodes&,
+            SectionParserData&,
+            const ParseResultRef<mson::OneOf>&);
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<mson::OneOf>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<mson::OneOf>& out)
         {
 
             if (out.node.empty()) {
 
                 // WARN: one of type do not have nested members
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 out.report.warnings.push_back(
-                    Warning("one of type must have nested members", EmptyDefinitionWarning, sourceMap));
+                    Warning("one of type must have nested members",
+                        EmptyDefinitionWarning,
+                        sourceMap));
             }
         }
 
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
-                mdp::ByteBuffer remaining, subject = node->children().front().text;
+                mdp::ByteBuffer remaining,
+                    subject = node->children().front().text;
 
                 subject = GetFirstLine(subject, remaining);
                 TrimString(subject);

--- a/src/MSONParameterParser.h
+++ b/src/MSONParameterParser.h
@@ -22,33 +22,39 @@ namespace snowcrash
      * MSON Parameter Section Processor
      */
     template <>
-    struct SectionProcessor<MSONParameter> : public SignatureSectionProcessorBase<MSONParameter> {
+    struct SectionProcessor<MSONParameter>
+        : public SignatureSectionProcessorBase<MSONParameter> {
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::ValuesTrait
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::ValuesTrait
                 | SignatureTraits::AttributesTrait
                 | SignatureTraits::ContentTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<MSONParameter>& out)
         {
 
-            out.node.name = StripBackticks(const_cast<std::string&>(signature.identifier));
+            out.node.name = StripBackticks(
+                const_cast<std::string&>(signature.identifier));
             out.node.description = signature.content;
             out.node.exampleValue = signature.value;
 
             if (!signature.remainingContent.empty()) {
-                out.node.description += "\n" + signature.remainingContent + "\n";
+                out.node.description
+                    += "\n" + signature.remainingContent + "\n";
             }
 
-            SectionProcessor<Parameter>::parseAttributes(node, pd, signature.attributes, out, false);
+            SectionProcessor<Parameter>::parseAttributes(
+                node, pd, signature.attributes, out, false);
 
             if (pd.exportSourceMap()) {
                 if (!out.node.name.empty()) {
@@ -67,7 +73,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<MSONParameter>& out)
@@ -80,21 +87,26 @@ namespace snowcrash
             switch (sectionType) {
                 case MSONSampleDefaultSectionType: {
                     typeSection.node.baseType = mson::ImplicitPrimitiveBaseType;
-                    cur = MSONTypeSectionListParser::parse(node, siblings, pd, typeSection);
+                    cur = MSONTypeSectionListParser::parse(
+                        node, siblings, pd, typeSection);
 
                     if (typeSection.node.content.value.empty()) {
                         break;
                     }
 
-                    if (typeSection.node.klass == mson::TypeSection::DefaultClass) {
+                    if (typeSection.node.klass
+                        == mson::TypeSection::DefaultClass) {
                         out.node.defaultValue = typeSection.node.content.value;
 
                         if (pd.exportSourceMap()) {
-                            out.sourceMap.defaultValue.sourceMap = typeSection.sourceMap.value.sourceMap;
+                            out.sourceMap.defaultValue.sourceMap
+                                = typeSection.sourceMap.value.sourceMap;
                         }
-                    } else if (typeSection.node.klass == mson::TypeSection::SampleClass) {
+                    } else if (typeSection.node.klass
+                        == mson::TypeSection::SampleClass) {
                         out.node.exampleValue = typeSection.node.content.value;
-                        out.sourceMap.exampleValue.sourceMap = typeSection.sourceMap.value.sourceMap;
+                        out.sourceMap.exampleValue.sourceMap
+                            = typeSection.sourceMap.value.sourceMap;
                     }
 
                     break;
@@ -102,7 +114,8 @@ namespace snowcrash
 
                 case MSONValueMembersSectionType: {
                     typeSection.node.baseType = mson::ImplicitValueBaseType;
-                    cur = MSONTypeSectionListParser::parse(node, siblings, pd, typeSection);
+                    cur = MSONTypeSectionListParser::parse(
+                        node, siblings, pd, typeSection);
 
                     out.node.values.clear();
 
@@ -110,22 +123,32 @@ namespace snowcrash
                         out.sourceMap.values.collection.clear();
                     }
 
-                    for (size_t i = 0; i < typeSection.node.content.elements().size(); i++) {
-                        mson::ValueMember valueMember = typeSection.node.content.elements().at(i).content.value;
+                    for (size_t i = 0;
+                         i < typeSection.node.content.elements().size();
+                         i++) {
+                        mson::ValueMember valueMember
+                            = typeSection.node.content.elements()
+                                  .at(i)
+                                  .content.value;
                         SourceMap<mson::ValueMember> valueMemberSM;
 
                         if (pd.exportSourceMap()) {
-                            valueMemberSM = typeSection.sourceMap.elements().collection.at(i).value;
+                            valueMemberSM = typeSection.sourceMap.elements()
+                                                .collection.at(i)
+                                                .value;
                         }
 
                         if (valueMember.valueDefinition.values.size() == 1) {
-                            out.node.values.push_back(valueMember.valueDefinition.values[0].literal);
+                            out.node.values.push_back(
+                                valueMember.valueDefinition.values[0].literal);
 
                             if (pd.exportSourceMap()) {
                                 SourceMap<Value> valueSM;
-                                valueSM.sourceMap = valueMemberSM.valueDefinition.sourceMap;
+                                valueSM.sourceMap
+                                    = valueMemberSM.valueDefinition.sourceMap;
 
-                                out.sourceMap.values.collection.push_back(valueSM);
+                                out.sourceMap.values.collection.push_back(
+                                    valueSM);
                             }
                         }
                     }
@@ -140,12 +163,15 @@ namespace snowcrash
             return cur;
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<MSONParameter>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<MSONParameter>& out)
         {
 
-            SectionProcessor<Parameter>::checkDefaultAndRequiredClash<MSONParameter>(node, pd, out);
-            SectionProcessor<Parameter>::checkExampleAndDefaultValue<MSONParameter>(node, pd, out);
+            SectionProcessor<Parameter>::
+                checkDefaultAndRequiredClash<MSONParameter>(node, pd, out);
+            SectionProcessor<Parameter>::
+                checkExampleAndDefaultValue<MSONParameter>(node, pd, out);
         }
 
         static SectionType nestedSectionType(const MarkdownNodeIterator& node)
@@ -161,7 +187,8 @@ namespace snowcrash
     };
 
     /** MSON Parameter Section Parser */
-    typedef SectionParser<MSONParameter, ListSectionAdapter> MSONParameterParser;
+    typedef SectionParser<MSONParameter, ListSectionAdapter>
+        MSONParameterParser;
 }
 
 #endif

--- a/src/MSONPropertyMemberParser.h
+++ b/src/MSONPropertyMemberParser.h
@@ -20,7 +20,8 @@ namespace snowcrash
      * MSON Property Member Section Processor
      */
     template <>
-    struct SectionProcessor<mson::PropertyMember> : public SignatureSectionProcessorBase<mson::PropertyMember> {
+    struct SectionProcessor<mson::PropertyMember>
+        : public SignatureSectionProcessorBase<mson::PropertyMember> {
 
         static Signature parseSignature(const MarkdownNodeIterator& node,
             snowcrash::SectionParserData& pd,
@@ -35,27 +36,30 @@ namespace snowcrash
                 subject = ReconstructMarkdownHeader(*node);
             }
 
-            return SignatureSectionProcessorBase<mson::PropertyMember>::parseSignature(
-                node, pd, traits, report, subject);
+            return SignatureSectionProcessorBase<mson::PropertyMember>::
+                parseSignature(node, pd, traits, report, subject);
         }
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::ValuesTrait
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::ValuesTrait
                 | SignatureTraits::AttributesTrait
                 | SignatureTraits::ContentTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<mson::PropertyMember>& out)
         {
 
-            mson::parsePropertyName(node, pd, signature.identifier, out.report, out.node.name);
+            mson::parsePropertyName(
+                node, pd, signature.identifier, out.report, out.node.name);
 
             if (pd.exportSourceMap() && !out.node.name.empty()) {
                 out.sourceMap.name.sourceMap = node->sourceMap;
@@ -65,7 +69,8 @@ namespace snowcrash
                 node, pd, signature, out.report, out.node, out.sourceMap);
         }
 
-        static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processDescription(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::PropertyMember>& out)
@@ -75,22 +80,30 @@ namespace snowcrash
                 node, pd, out.node.sections, out.sourceMap.sections);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::PropertyMember>& out)
         {
 
-            ParseResultRef<mson::TypeSections> typeSections(out.report, out.node.sections, out.sourceMap.sections);
+            ParseResultRef<mson::TypeSections> typeSections(
+                out.report, out.node.sections, out.sourceMap.sections);
 
-            return SectionProcessor<mson::ValueMember>::processNestedMembers<MSONTypeSectionListParser>(
-                node, siblings, pd, typeSections, out.node.valueDefinition.typeDefinition.baseType);
+            return SectionProcessor<mson::ValueMember>::
+                processNestedMembers<MSONTypeSectionListParser>(node,
+                    siblings,
+                    pd,
+                    typeSections,
+                    out.node.valueDefinition.typeDefinition.baseType);
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            return SectionProcessor<mson::ValueMember>::isDescriptionNode(node, sectionType);
+            return SectionProcessor<mson::ValueMember>::isDescriptionNode(
+                node, sectionType);
         }
 
         static SectionType nestedSectionType(const MarkdownNodeIterator& node)
@@ -99,8 +112,9 @@ namespace snowcrash
             return SectionProcessor<mson::ValueMember>::nestedSectionType(node);
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<mson::PropertyMember>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<mson::PropertyMember>& out)
         {
 
             SectionProcessor<mson::ValueMember>::finalizeImplicitBaseType(
@@ -109,7 +123,8 @@ namespace snowcrash
     };
 
     /** MSON Property Member Section Parser */
-    typedef SectionParser<mson::PropertyMember, ListSectionAdapter> MSONPropertyMemberParser;
+    typedef SectionParser<mson::PropertyMember, ListSectionAdapter>
+        MSONPropertyMemberParser;
 }
 
 #endif

--- a/src/MSONSourcemap.cc
+++ b/src/MSONSourcemap.cc
@@ -12,17 +12,20 @@ using namespace snowcrash;
 
 bool SourceMap<mson::NamedType>::empty() const
 {
-    return (name.sourceMap.empty() && typeDefinition.sourceMap.empty() && sections.collection.empty());
+    return (name.sourceMap.empty() && typeDefinition.sourceMap.empty()
+        && sections.collection.empty());
 }
 
 bool SourceMap<mson::ValueMember>::empty() const
 {
-    return (description.sourceMap.empty() && valueDefinition.sourceMap.empty() && sections.collection.empty());
+    return (description.sourceMap.empty() && valueDefinition.sourceMap.empty()
+        && sections.collection.empty());
 }
 
 bool SourceMap<mson::PropertyMember>::empty() const
 {
-    return (name.sourceMap.empty() && description.sourceMap.empty() && valueDefinition.sourceMap.empty()
+    return (name.sourceMap.empty() && description.sourceMap.empty()
+        && valueDefinition.sourceMap.empty()
         && sections.collection.empty());
 }
 
@@ -43,7 +46,8 @@ const SourceMap<mson::Elements>& SourceMap<mson::TypeSection>::elements() const
 }
 
 SourceMap<mson::TypeSection>::SourceMap(
-    const SourceMap<mson::Markdown>& description_, const SourceMap<mson::Literal>& value_)
+    const SourceMap<mson::Markdown>& description_,
+    const SourceMap<mson::Literal>& value_)
     : description(description_), value(value_)
 {
     m_elements.reset(::new SourceMap<mson::Elements>);
@@ -56,7 +60,8 @@ SourceMap<mson::TypeSection>::SourceMap(const SourceMap<mson::TypeSection>& rhs)
     m_elements.reset(::new SourceMap<mson::Elements>(*rhs.m_elements.get()));
 }
 
-SourceMap<mson::TypeSection>& SourceMap<mson::TypeSection>::operator=(const SourceMap<mson::TypeSection>& rhs)
+SourceMap<mson::TypeSection>& SourceMap<mson::TypeSection>::operator=(
+    const SourceMap<mson::TypeSection>& rhs)
 {
     this->description = rhs.description;
     this->value = rhs.value;
@@ -101,7 +106,8 @@ const SourceMap<mson::Elements>& SourceMap<mson::Element>::elements() const
     return *m_elements;
 }
 
-SourceMap<mson::Element>& SourceMap<mson::Element>::operator=(const SourceMap<mson::Elements>& rhs)
+SourceMap<mson::Element>& SourceMap<mson::Element>::operator=(
+    const SourceMap<mson::Elements>& rhs)
 {
     m_elements.reset(::new SourceMap<mson::Elements>(rhs));
 
@@ -121,7 +127,8 @@ SourceMap<mson::Element>::SourceMap(const SourceMap<mson::Element>& rhs)
     m_elements.reset(::new SourceMap<mson::Elements>(*rhs.m_elements.get()));
 }
 
-SourceMap<mson::Element>& SourceMap<mson::Element>::operator=(const SourceMap<mson::Element>& rhs)
+SourceMap<mson::Element>& SourceMap<mson::Element>::operator=(
+    const SourceMap<mson::Element>& rhs)
 {
     this->property = rhs.property;
     this->value = rhs.value;

--- a/src/MSONSourcemap.h
+++ b/src/MSONSourcemap.h
@@ -30,10 +30,10 @@ namespace snowcrash
      */
 }
 
-#define SOURCE_MAP_COLLECTION(T, TC)                                                                                   \
-    template <>                                                                                                        \
-    struct SourceMap<TC> {                                                                                             \
-        Collection<SourceMap<T> >::type collection;                                                                    \
+#define SOURCE_MAP_COLLECTION(T, TC)                                           \
+    template <>                                                                \
+    struct SourceMap<TC> {                                                     \
+        Collection<SourceMap<T> >::type collection;                            \
     };
 
 namespace snowcrash
@@ -72,14 +72,17 @@ namespace snowcrash
         const SourceMap<mson::Elements>& elements() const;
 
         /** Constructor */
-        SourceMap(const SourceMap<mson::Markdown>& description_ = SourceMap<mson::Markdown>(),
-            const SourceMap<mson::Literal>& value_ = SourceMap<mson::Literal>());
+        SourceMap(const SourceMap<mson::Markdown>& description_
+            = SourceMap<mson::Markdown>(),
+            const SourceMap<mson::Literal>& value_
+            = SourceMap<mson::Literal>());
 
         /** Copy constructor */
         SourceMap(const SourceMap<mson::TypeSection>& rhs);
 
         /** Assignment operator */
-        SourceMap<mson::TypeSection>& operator=(const SourceMap<mson::TypeSection>& rhs);
+        SourceMap<mson::TypeSection>& operator=(
+            const SourceMap<mson::TypeSection>& rhs);
 
         /** Desctructor */
         ~SourceMap();
@@ -127,7 +130,8 @@ namespace snowcrash
 
     /** Source Map structure for Property Member */
     template <>
-    struct SourceMap<mson::PropertyMember> : public SourceMap<mson::ValueMember> {
+    struct SourceMap<mson::PropertyMember>
+        : public SourceMap<mson::ValueMember> {
 
         /** Source Map for Property Name */
         SourceMap<mson::PropertyName> name;
@@ -161,7 +165,8 @@ namespace snowcrash
         const SourceMap<mson::Elements>& elements() const;
 
         /** Builds the structure from group of elements */
-        SourceMap<mson::Element>& operator=(const SourceMap<mson::Elements>& rhs);
+        SourceMap<mson::Element>& operator=(
+            const SourceMap<mson::Elements>& rhs);
 
         /** Constructor */
         SourceMap();
@@ -170,7 +175,8 @@ namespace snowcrash
         SourceMap(const SourceMap<mson::Element>& rhs);
 
         /** Assignment operator */
-        SourceMap<mson::Element>& operator=(const SourceMap<mson::Element>& rhs);
+        SourceMap<mson::Element>& operator=(
+            const SourceMap<mson::Element>& rhs);
 
         /** Destructor */
         ~SourceMap();

--- a/src/MSONTypeSectionParser.cc
+++ b/src/MSONTypeSectionParser.cc
@@ -13,7 +13,9 @@ namespace snowcrash
 {
 
     /** Implementation of processNestedSection */
-    MarkdownNodeIterator SectionProcessor<mson::TypeSection>::processNestedSection(const MarkdownNodeIterator& node,
+    MarkdownNodeIterator
+    SectionProcessor<mson::TypeSection>::processNestedSection(
+        const MarkdownNodeIterator& node,
         const MarkdownNodes& siblings,
         SectionParserData& pd,
         const ParseResultRef<mson::TypeSection>& out)
@@ -29,7 +31,8 @@ namespace snowcrash
             return cur;
         }
 
-        if (parentSectionType == MSONPropertyMembersSectionType || parentSectionType == MSONValueMembersSectionType) {
+        if (parentSectionType == MSONPropertyMembersSectionType
+            || parentSectionType == MSONValueMembersSectionType) {
 
             switch (pd.sectionContext()) {
                 case MSONMixinSectionType: {
@@ -48,11 +51,14 @@ namespace snowcrash
                 case MSONOneOfSectionType: {
                     if (parentSectionType != MSONPropertyMembersSectionType) {
 
-                        // WARN: One of can not be a nested member for a non object structure type
+                        // WARN: One of can not be a nested member for a non
+                        // object structure type
                         mdp::CharactersRangeSet sourceMap
-                            = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                            = mdp::BytesRangeSetToCharactersRangeSet(
+                                node->sourceMap, pd.sourceCharacterIndex);
                         out.report.warnings.push_back(
-                            Warning("one-of can not be a nested member for a type not sub typed from object",
+                            Warning("one-of can not be a nested member for a "
+                                    "type not sub typed from object",
                                 LogicalErrorWarning,
                                 sourceMap));
 
@@ -74,8 +80,10 @@ namespace snowcrash
                 case MSONSectionType: {
                     if (parentSectionType == MSONPropertyMembersSectionType) {
 
-                        IntermediateParseResult<mson::PropertyMember> propertyMember(out.report);
-                        cur = MSONPropertyMemberParser::parse(node, siblings, pd, propertyMember);
+                        IntermediateParseResult<mson::PropertyMember>
+                            propertyMember(out.report);
+                        cur = MSONPropertyMemberParser::parse(
+                            node, siblings, pd, propertyMember);
 
                         element.build(propertyMember.node);
 
@@ -84,8 +92,10 @@ namespace snowcrash
                         }
                     } else {
 
-                        IntermediateParseResult<mson::ValueMember> valueMember(out.report);
-                        cur = MSONValueMemberParser::parse(node, siblings, pd, valueMember);
+                        IntermediateParseResult<mson::ValueMember> valueMember(
+                            out.report);
+                        cur = MSONValueMemberParser::parse(
+                            node, siblings, pd, valueMember);
 
                         element.build(valueMember.node);
 
@@ -108,21 +118,26 @@ namespace snowcrash
                     // WARN: mixin and oneOf not supported in sample/default
                     std::stringstream ss;
 
-                    ss << "sample and default type sections cannot have `" << SectionName(pd.sectionContext())
-                       << "` type";
+                    ss << "sample and default type sections cannot have `"
+                       << SectionName(pd.sectionContext()) << "` type";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), LogicalErrorWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), LogicalErrorWarning, sourceMap));
                     break;
                 }
 
                 case MSONSectionType: {
-                    if ((out.node.baseType == mson::ValueBaseType || out.node.baseType == mson::ImplicitValueBaseType)
+                    if ((out.node.baseType == mson::ValueBaseType
+                            || out.node.baseType == mson::ImplicitValueBaseType)
                         && node->type == mdp::ListItemMarkdownNodeType) {
 
-                        IntermediateParseResult<mson::ValueMember> valueMember(out.report);
-                        cur = MSONValueMemberParser::parse(node, siblings, pd, valueMember);
+                        IntermediateParseResult<mson::ValueMember> valueMember(
+                            out.report);
+                        cur = MSONValueMemberParser::parse(
+                            node, siblings, pd, valueMember);
 
                         element.build(valueMember.node);
 
@@ -130,11 +145,14 @@ namespace snowcrash
                             elementSM.value = valueMember.sourceMap;
                         }
                     } else if ((out.node.baseType == mson::ObjectBaseType
-                                   || out.node.baseType == mson::ImplicitObjectBaseType)
+                                   || out.node.baseType
+                                       == mson::ImplicitObjectBaseType)
                         && node->type == mdp::ListItemMarkdownNodeType) {
 
-                        IntermediateParseResult<mson::PropertyMember> propertyMember(out.report);
-                        cur = MSONPropertyMemberParser::parse(node, siblings, pd, propertyMember);
+                        IntermediateParseResult<mson::PropertyMember>
+                            propertyMember(out.report);
+                        cur = MSONPropertyMemberParser::parse(
+                            node, siblings, pd, propertyMember);
 
                         element.build(propertyMember.node);
 
@@ -144,17 +162,20 @@ namespace snowcrash
                     }
 
                     if (out.node.baseType == mson::PrimitiveBaseType
-                        || out.node.baseType == mson::ImplicitPrimitiveBaseType) {
+                        || out.node.baseType
+                            == mson::ImplicitPrimitiveBaseType) {
 
                         if (!out.node.content.value.empty()) {
                             TwoNewLines(out.node.content.value);
                         }
 
-                        mdp::ByteBuffer content = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
+                        mdp::ByteBuffer content = mdp::MapBytesRangeSet(
+                            node->sourceMap, pd.sourceData);
                         out.node.content.value += content;
 
                         if (pd.exportSourceMap() && !content.empty()) {
-                            out.sourceMap.value.sourceMap.append(node->sourceMap);
+                            out.sourceMap.value.sourceMap.append(
+                                node->sourceMap);
                         }
 
                         cur = ++MarkdownNodeIterator(node);
@@ -180,7 +201,8 @@ namespace snowcrash
     }
 
     /** Implementation of nestedSectionType */
-    SectionType SectionProcessor<mson::TypeSection>::nestedSectionType(const MarkdownNodeIterator& node)
+    SectionType SectionProcessor<mson::TypeSection>::nestedSectionType(
+        const MarkdownNodeIterator& node)
     {
 
         SectionType nestedType = UndefinedSectionType;

--- a/src/MSONTypeSectionParser.h
+++ b/src/MSONTypeSectionParser.h
@@ -18,32 +18,39 @@ namespace snowcrash
 {
 
     /** MSON Default Type Section matching regex */
-    const char* const MSONDefaultTypeSectionRegex = "^[[:blank:]]*[Dd]efault[[:blank:]]*(:.*)?$";
+    const char* const MSONDefaultTypeSectionRegex
+        = "^[[:blank:]]*[Dd]efault[[:blank:]]*(:.*)?$";
 
     /** MSON Sample Type Section matching regex */
-    const char* const MSONSampleTypeSectionRegex = "^[[:blank:]]*[Ss]ample[[:blank:]]*(:.*)?$";
+    const char* const MSONSampleTypeSectionRegex
+        = "^[[:blank:]]*[Ss]ample[[:blank:]]*(:.*)?$";
 
     /** MSON Value Members Type Section matching regex */
-    const char* const MSONValueMembersTypeSectionRegex = "^[[:blank:]]*([Ii]tems|[Mm]embers)[[:blank:]]*$";
+    const char* const MSONValueMembersTypeSectionRegex
+        = "^[[:blank:]]*([Ii]tems|[Mm]embers)[[:blank:]]*$";
 
     /** MSON Property Members Type Section matching regex */
-    const char* const MSONPropertyMembersTypeSectionRegex = "^[[:blank:]]*([Pp]roperties)[[:blank:]]*$";
+    const char* const MSONPropertyMembersTypeSectionRegex
+        = "^[[:blank:]]*([Pp]roperties)[[:blank:]]*$";
 
     /**
      * MSON Type Section Section Processor
      */
     template <>
-    struct SectionProcessor<mson::TypeSection> : public SignatureSectionProcessorBase<mson::TypeSection> {
+    struct SectionProcessor<mson::TypeSection>
+        : public SignatureSectionProcessorBase<mson::TypeSection> {
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::ValuesTrait);
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                | SignatureTraits::ValuesTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<mson::TypeSection>& out)
@@ -62,35 +69,45 @@ namespace snowcrash
             } else if (IEqual<std::string>()(signature.identifier, "Items")
                 || IEqual<std::string>()(signature.identifier, "Members")) {
 
-                if (out.node.baseType != mson::ValueBaseType && out.node.baseType != mson::ImplicitValueBaseType) {
+                if (out.node.baseType != mson::ValueBaseType
+                    && out.node.baseType != mson::ImplicitValueBaseType) {
 
-                    // WARN: Items/Members should only be allowed for value types
+                    // WARN: Items/Members should only be allowed for value
+                    // types
                     std::stringstream ss;
 
                     ss << "type section `" << signature.identifier;
-                    ss << "` not allowed for a type sub-typed from a primitive or object type";
+                    ss << "` not allowed for a type sub-typed from a primitive "
+                          "or object type";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), LogicalErrorWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), LogicalErrorWarning, sourceMap));
 
                     return node;
                 }
 
                 out.node.klass = mson::TypeSection::MemberTypeClass;
-            } else if (IEqual<std::string>()(signature.identifier, "Properties")) {
+            } else if (IEqual<std::string>()(
+                           signature.identifier, "Properties")) {
 
-                if (out.node.baseType != mson::ObjectBaseType && out.node.baseType != mson::ImplicitObjectBaseType) {
+                if (out.node.baseType != mson::ObjectBaseType
+                    && out.node.baseType != mson::ImplicitObjectBaseType) {
 
                     // WARN: Properties should only be allowed for object types
                     std::stringstream ss;
 
                     ss << "type section `" << signature.identifier;
-                    ss << "` is only allowed for a type sub-typed from an object type";
+                    ss << "` is only allowed for a type sub-typed from an "
+                          "object type";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), LogicalErrorWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), LogicalErrorWarning, sourceMap));
 
                     return node;
                 }
@@ -98,7 +115,8 @@ namespace snowcrash
                 out.node.klass = mson::TypeSection::MemberTypeClass;
             }
 
-            if (assignValues && (!signature.values.empty() || !signature.value.empty())) {
+            if (assignValues
+                && (!signature.values.empty() || !signature.value.empty())) {
 
                 if (out.node.baseType == mson::PrimitiveBaseType
                     || out.node.baseType == mson::ImplicitPrimitiveBaseType) {
@@ -121,18 +139,23 @@ namespace snowcrash
 
                         if (pd.exportSourceMap()) {
 
-                            elementSM.value.valueDefinition.sourceMap = node->sourceMap;
-                            out.sourceMap.elements().collection.push_back(elementSM);
+                            elementSM.value.valueDefinition.sourceMap
+                                = node->sourceMap;
+                            out.sourceMap.elements().collection.push_back(
+                                elementSM);
                         }
                     }
                 } else if (out.node.baseType == mson::ObjectBaseType
                     || out.node.baseType == mson::ImplicitObjectBaseType) {
 
-                    // WARN: sample/default is for an object but it has values in signature
+                    // WARN: sample/default is for an object but it has values
+                    // in signature
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     out.report.warnings.push_back(
-                        Warning("a sample and/or default type section for a type which is sub-typed from an object "
+                        Warning("a sample and/or default type section for a "
+                                "type which is sub-typed from an object "
                                 "cannot have value(s) beside the keyword",
                             LogicalErrorWarning,
                             sourceMap));
@@ -141,7 +164,8 @@ namespace snowcrash
 
             if (assignValues && !signature.remainingContent.empty()
                 && (out.node.baseType == mson::PrimitiveBaseType
-                       || out.node.baseType == mson::ImplicitPrimitiveBaseType)) {
+                       || out.node.baseType
+                           == mson::ImplicitPrimitiveBaseType)) {
 
                 out.node.content.value += signature.remainingContent;
 
@@ -155,7 +179,8 @@ namespace snowcrash
 
         NO_SECTION_DESCRIPTION(mson::TypeSection)
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator&,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator&,
             const MarkdownNodes&,
             SectionParserData&,
             const ParseResultRef<mson::TypeSection>&);
@@ -165,10 +190,12 @@ namespace snowcrash
 
             mdp::ByteBuffer subject, remaining;
 
-            if (node->type == mdp::HeaderMarkdownNodeType && !node->text.empty()) {
+            if (node->type == mdp::HeaderMarkdownNodeType
+                && !node->text.empty()) {
 
                 subject = node->text;
-            } else if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            } else if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 subject = node->children().front().text;
             }
@@ -176,7 +203,8 @@ namespace snowcrash
             subject = GetFirstLine(subject, remaining);
             TrimString(subject);
 
-            if (RegexMatch(subject, MSONDefaultTypeSectionRegex) || RegexMatch(subject, MSONSampleTypeSectionRegex)) {
+            if (RegexMatch(subject, MSONDefaultTypeSectionRegex)
+                || RegexMatch(subject, MSONSampleTypeSectionRegex)) {
 
                 return MSONSampleDefaultSectionType;
             }
@@ -196,10 +224,12 @@ namespace snowcrash
     };
 
     /** MSON Type Section (Header) Section Parser */
-    typedef SectionParser<mson::TypeSection, HeaderSectionAdapter> MSONTypeSectionHeaderParser;
+    typedef SectionParser<mson::TypeSection, HeaderSectionAdapter>
+        MSONTypeSectionHeaderParser;
 
     /** MSON Type Section (List) Section Parser */
-    typedef SectionParser<mson::TypeSection, ListSectionAdapter> MSONTypeSectionListParser;
+    typedef SectionParser<mson::TypeSection, ListSectionAdapter>
+        MSONTypeSectionListParser;
 }
 
 #endif

--- a/src/MSONUtility.h
+++ b/src/MSONUtility.h
@@ -28,7 +28,8 @@ namespace mson
 
         std::string emphasisChars = mdp::MarkdownEmphasisChars;
 
-        if (emphasisChars.find(subject[0]) != std::string::npos && subject[0] == subject[subject.length() - 1]) {
+        if (emphasisChars.find(subject[0]) != std::string::npos
+            && subject[0] == subject[subject.length() - 1]) {
 
             return true;
         }
@@ -46,7 +47,8 @@ namespace mson
     inline BaseType parseBaseType(const BaseTypeName& type)
     {
 
-        if ((type == StringTypeName) || (type == NumberTypeName) || (type == BooleanTypeName)) {
+        if ((type == StringTypeName) || (type == NumberTypeName)
+            || (type == BooleanTypeName)) {
 
             return PrimitiveBaseType;
         }
@@ -78,7 +80,8 @@ namespace mson
 
         if (checkVariable(subject)) {
 
-            std::string escapedString = snowcrash::RetrieveEscaped(buffer, 0, true);
+            std::string escapedString
+                = snowcrash::RetrieveEscaped(buffer, 0, true);
 
             value.literal = escapedString;
             value.variable = true;
@@ -124,7 +127,8 @@ namespace mson
      * \param typeName MSON Type Name
      * \param isBaseType If false, will be parsed as a symbol
      */
-    inline void parseTypeName(const std::string& subject, TypeName& typeName, bool isBaseType = true)
+    inline void parseTypeName(
+        const std::string& subject, TypeName& typeName, bool isBaseType = true)
     {
 
         if (isBaseType && subject == "boolean") {
@@ -145,14 +149,16 @@ namespace mson
     }
 
     /**
-     * \brief Check Type Attribute from a string and fill list of type attributes accordingly
+     * \brief Check Type Attribute from a string and fill list of type
+     * attributes accordingly
      *
      * \param attribute String that needs to be checked for attribute
      * \param typeAttributes List of type attributes
      *
      * \return True if the given string is a type attribute
      */
-    inline bool parseTypeAttribute(const std::string& attribute, TypeAttributes& typeAttributes)
+    inline bool parseTypeAttribute(
+        const std::string& attribute, TypeAttributes& typeAttributes)
     {
 
         bool isAttribute = true;
@@ -184,14 +190,17 @@ namespace mson
      * \param subject Attribute string representing the type specification
      * \param typeSpecification MSON Type Specification
      */
-    inline void parseTypeSpecification(const std::string& attribute, TypeSpecification& typeSpecification)
+    inline void parseTypeSpecification(
+        const std::string& attribute, TypeSpecification& typeSpecification)
     {
 
         std::string subject = snowcrash::StripMarkdownLink(attribute);
 
-        bool lookingAtNested = false;   // If true, we are looking at nested types
-        bool lookingForEndLink = false; // If true, we detected a link text and are looking for the end of it
-        bool alreadyParsedLink = false; // If true, we already parsed the link text in the link
+        bool lookingAtNested = false; // If true, we are looking at nested types
+        bool lookingForEndLink = false; // If true, we detected a link text and
+                                        // are looking for the end of it
+        bool alreadyParsedLink
+            = false; // If true, we already parsed the link text in the link
 
         bool trimSubject = false;
 
@@ -200,7 +209,8 @@ namespace mson
 
         while (i < subject.length()) {
 
-            if (subject[i] == mdp::MarkdownBeginReference && !alreadyParsedLink) {
+            if (subject[i] == mdp::MarkdownBeginReference
+                && !alreadyParsedLink) {
 
                 trimSubject = true;
 
@@ -216,7 +226,9 @@ namespace mson
                 } else {
                     lookingForEndLink = true;
                 }
-            } else if (subject[i] == mdp::MarkdownEndReference && lookingAtNested && lookingForEndLink) {
+            } else if (subject[i] == mdp::MarkdownEndReference
+                && lookingAtNested
+                && lookingForEndLink) {
 
                 trimSubject = true;
 
@@ -231,7 +243,9 @@ namespace mson
 
                 alreadyParsedLink = true;
                 lookingForEndLink = false;
-            } else if (subject[i] == scpl::Delimiters::AttributeDelimiter && lookingAtNested && !lookingForEndLink) {
+            } else if (subject[i] == scpl::Delimiters::AttributeDelimiter
+                && lookingAtNested
+                && !lookingForEndLink) {
 
                 trimSubject = true;
 
@@ -273,7 +287,8 @@ namespace mson
         }
 
         // Remove the ending square bracket
-        if (lookingAtNested && buffer[buffer.length() - 1] == mdp::MarkdownEndReference) {
+        if (lookingAtNested
+            && buffer[buffer.length() - 1] == mdp::MarkdownEndReference) {
 
             buffer = buffer.substr(0, buffer.length() - 1);
         }
@@ -291,11 +306,13 @@ namespace mson
     }
 
     /**
-     * \brief Add a dependency to the dependency list of the dependents while checking for circular references
+     * \brief Add a dependency to the dependency list of the dependents while
+     * checking for circular references
      *
      * \param node Current markdown node iterator
      * \param pd Section parser data
-     * \param dependency The named type which should be added to the dependency list
+     * \param dependency The named type which should be added to the dependency
+     * list
      * \param dependent The named type to which the dependency should be added
      * \param report Parse result report
      */
@@ -308,44 +325,57 @@ namespace mson
     {
 
         // First, check if the type exists
-        if (pd.namedTypeDependencyTable.find(dependency) == pd.namedTypeDependencyTable.end()) {
+        if (pd.namedTypeDependencyTable.find(dependency)
+            == pd.namedTypeDependencyTable.end()) {
 
             // ERR: We cannot find the dependency type
             std::stringstream ss;
-            ss << "base type '" << dependency << "' is not defined in the document";
+            ss << "base type '" << dependency
+               << "' is not defined in the document";
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-            report.error = snowcrash::Error(ss.str(), snowcrash::MSONError, sourceMap);
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
+            report.error
+                = snowcrash::Error(ss.str(), snowcrash::MSONError, sourceMap);
             return;
         }
 
-        std::set<mson::Literal> dependencyDeps = pd.namedTypeDependencyTable[dependency];
+        std::set<mson::Literal> dependencyDeps
+            = pd.namedTypeDependencyTable[dependency];
 
         // Second, check if it is circular reference between them
-        if (circularCheck && (dependent == dependency || dependencyDeps.find(dependent) != dependencyDeps.end())) {
+        if (circularCheck
+            && (dependent == dependency
+                   || dependencyDeps.find(dependent) != dependencyDeps.end())) {
 
             // ERR: Dependency named type circular references itself
             std::stringstream ss;
-            ss << "base type '" << dependent << "' circularly referencing itself";
+            ss << "base type '" << dependent
+               << "' circularly referencing itself";
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-            report.error = snowcrash::Error(ss.str(), snowcrash::MSONError, sourceMap);
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
+            report.error
+                = snowcrash::Error(ss.str(), snowcrash::MSONError, sourceMap);
             return;
         }
 
         // Third, check if the dependency is already in the list
-        if (pd.namedTypeDependencyTable[dependent].find(dependency) != pd.namedTypeDependencyTable[dependent].end()) {
+        if (pd.namedTypeDependencyTable[dependent].find(dependency)
+            != pd.namedTypeDependencyTable[dependent].end()) {
             return;
         }
 
-        for (mson::NamedTypeDependencyTable::iterator it = pd.namedTypeDependencyTable.begin();
+        for (mson::NamedTypeDependencyTable::iterator it
+             = pd.namedTypeDependencyTable.begin();
              it != pd.namedTypeDependencyTable.end();
              ++it) {
 
             // If the entry is dependent itself or contain dependent in its list
-            if (it->first == dependent || it->second.find(dependent) != it->second.end()) {
+            if (it->first == dependent
+                || it->second.find(dependent) != it->second.end()) {
 
                 it->second.insert(dependency);
                 it->second.insert(dependencyDeps.begin(), dependencyDeps.end());
@@ -371,7 +401,9 @@ namespace mson
 
         bool foundTypeSpecification = false;
 
-        for (std::vector<std::string>::const_iterator it = attributes.begin(); it != attributes.end(); it++) {
+        for (std::vector<std::string>::const_iterator it = attributes.begin();
+             it != attributes.end();
+             it++) {
 
             // If not a recognized type attribute
             if (!parseTypeAttribute(*it, typeDefinition.attributes)) {
@@ -381,22 +413,28 @@ namespace mson
 
                     // WARN: Ignoring unrecognized type attribute
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     report.warnings.push_back(snowcrash::Warning(
-                        "ignoring unrecognized type attribute", snowcrash::IgnoringWarning, sourceMap));
+                        "ignoring unrecognized type attribute",
+                        snowcrash::IgnoringWarning,
+                        sourceMap));
                 } else {
 
                     foundTypeSpecification = true;
-                    parseTypeSpecification(*it, typeDefinition.typeSpecification);
+                    parseTypeSpecification(
+                        *it, typeDefinition.typeSpecification);
                 }
             }
         }
 
-        typeDefinition.baseType = parseBaseType(typeDefinition.typeSpecification.name.base);
-        NamedTypeBaseTable::iterator it
-            = pd.namedTypeBaseTable.find(typeDefinition.typeSpecification.name.symbol.literal);
+        typeDefinition.baseType
+            = parseBaseType(typeDefinition.typeSpecification.name.base);
+        NamedTypeBaseTable::iterator it = pd.namedTypeBaseTable.find(
+            typeDefinition.typeSpecification.name.symbol.literal);
 
-        if (typeDefinition.baseType == UndefinedBaseType && it != pd.namedTypeBaseTable.end()) {
+        if (typeDefinition.baseType == UndefinedBaseType
+            && it != pd.namedTypeBaseTable.end()) {
 
             typeDefinition.baseType = it->second;
         }
@@ -405,17 +443,24 @@ namespace mson
             && !typeDefinition.typeSpecification.name.symbol.literal.empty()
             && !typeDefinition.typeSpecification.name.symbol.variable) {
 
-            addDependency(node, pd, typeDefinition.typeSpecification.name.symbol.literal, pd.namedTypeContext, report);
+            addDependency(node,
+                pd,
+                typeDefinition.typeSpecification.name.symbol.literal,
+                pd.namedTypeContext,
+                report);
         }
 
-        if (typeDefinition.baseType != ValueBaseType && typeDefinition.baseType != ImplicitValueBaseType
+        if (typeDefinition.baseType != ValueBaseType
+            && typeDefinition.baseType != ImplicitValueBaseType
             && !typeDefinition.typeSpecification.nestedTypes.empty()) {
 
             // WARN: Nested types for non (array or enum) structure base type
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
             report.warnings.push_back(
-                snowcrash::Warning("nested types should be present only for types which are sub typed from either "
+                snowcrash::Warning("nested types should be present only for "
+                                   "types which are sub typed from either "
                                    "array or enum structure type",
                     snowcrash::LogicalErrorWarning,
                     sourceMap));
@@ -442,35 +487,51 @@ namespace mson
 
         if (checkVariable(subject)) {
 
-            std::string escapedString = snowcrash::RetrieveEscaped(buffer, 0, true);
+            std::string escapedString
+                = snowcrash::RetrieveEscaped(buffer, 0, true);
 
-            SignatureTraits traits(SignatureTraits::ValuesTrait | SignatureTraits::AttributesTrait);
+            SignatureTraits traits(SignatureTraits::ValuesTrait
+                | SignatureTraits::AttributesTrait);
 
             Signature signature
-                = SignatureSectionProcessorBase<PropertyName>::parseSignature(node, pd, traits, report, escapedString);
+                = SignatureSectionProcessorBase<PropertyName>::parseSignature(
+                    node, pd, traits, report, escapedString);
 
             if (!signature.value.empty()) {
-                propertyName.variable.values.push_back(parseValue(signature.value));
+                propertyName.variable.values.push_back(
+                    parseValue(signature.value));
             }
 
-            parseTypeDefinition(node, pd, signature.attributes, report, propertyName.variable.typeDefinition);
+            parseTypeDefinition(node,
+                pd,
+                signature.attributes,
+                report,
+                propertyName.variable.typeDefinition);
         } else {
             propertyName.literal = snowcrash::StripBackticks(buffer);
         }
     }
 
     /**
-     * \brief Check is the given base types are the same after taking the implicitness into account
+     * \brief Check is the given base types are the same after taking the
+     * implicitness into account
      */
-    inline bool isSameBaseType(const mson::BaseType lhs, const mson::BaseType rhs)
+    inline bool isSameBaseType(
+        const mson::BaseType lhs, const mson::BaseType rhs)
     {
 
-        if (lhs == rhs || (lhs == mson::ImplicitObjectBaseType && rhs == mson::ObjectBaseType)
-            || (lhs == mson::ObjectBaseType && rhs == mson::ImplicitObjectBaseType)
-            || (lhs == mson::ImplicitValueBaseType && rhs == mson::ValueBaseType)
-            || (lhs == mson::ValueBaseType && rhs == mson::ImplicitValueBaseType)
-            || (lhs == mson::ImplicitPrimitiveBaseType && rhs == mson::PrimitiveBaseType)
-            || (lhs == mson::PrimitiveBaseType && rhs == mson::ImplicitPrimitiveBaseType)) {
+        if (lhs == rhs || (lhs == mson::ImplicitObjectBaseType
+                              && rhs == mson::ObjectBaseType)
+            || (lhs == mson::ObjectBaseType
+                   && rhs == mson::ImplicitObjectBaseType)
+            || (lhs == mson::ImplicitValueBaseType
+                   && rhs == mson::ValueBaseType)
+            || (lhs == mson::ValueBaseType
+                   && rhs == mson::ImplicitValueBaseType)
+            || (lhs == mson::ImplicitPrimitiveBaseType
+                   && rhs == mson::PrimitiveBaseType)
+            || (lhs == mson::PrimitiveBaseType
+                   && rhs == mson::ImplicitPrimitiveBaseType)) {
 
             return true;
         }

--- a/src/MSONValueMemberParser.cc
+++ b/src/MSONValueMemberParser.cc
@@ -13,7 +13,8 @@ namespace snowcrash
 {
 
     /** Implementation of nestedSectionType */
-    SectionType SectionProcessor<mson::ValueMember>::nestedSectionType(const MarkdownNodeIterator& node)
+    SectionType SectionProcessor<mson::ValueMember>::nestedSectionType(
+        const MarkdownNodeIterator& node)
     {
 
         SectionType nestedType = UndefinedSectionType;
@@ -43,7 +44,9 @@ namespace snowcrash
     }
 
     /** Implementation of resolveAndProcessMSONSection */
-    MarkdownNodeIterator SectionProcessor<mson::ValueMember>::processMSONSection(const MarkdownNodeIterator& node,
+    MarkdownNodeIterator
+    SectionProcessor<mson::ValueMember>::processMSONSection(
+        const MarkdownNodeIterator& node,
         const MarkdownNodes& siblings,
         SectionParserData& pd,
         const ParseResultRef<mson::TypeSections>& sections,
@@ -53,15 +56,19 @@ namespace snowcrash
         MarkdownNodeIterator cur = node;
 
         // If we encounter a header node, stop parsing. Headers which are not
-        // type section signatures are ineligible to be nested sections of a MSON section
+        // type section signatures are ineligible to be nested sections of a
+        // MSON section
         if (node->type == mdp::HeaderMarkdownNodeType) {
             return cur;
         }
 
         // If the nodes follow after some block description without member
         // seperator, then they are treated as description
-        if (!sections.node.empty() && sections.node.back().klass == mson::TypeSection::BlockDescriptionClass) {
-            return SectionProcessor<mson::ValueMember>::blockDescription(node, pd, sections.node, sections.sourceMap);
+        if (!sections.node.empty()
+            && sections.node.back().klass
+                == mson::TypeSection::BlockDescriptionClass) {
+            return SectionProcessor<mson::ValueMember>::blockDescription(
+                node, pd, sections.node, sections.sourceMap);
         }
 
         // Try to resolve base type if not given
@@ -69,7 +76,9 @@ namespace snowcrash
 
         // Build a section to indicate nested members
         if (sections.node.empty()
-            || (!sections.node.empty() && sections.node.back().klass != mson::TypeSection::MemberTypeClass)) {
+            || (!sections.node.empty()
+                   && sections.node.back().klass
+                       != mson::TypeSection::MemberTypeClass)) {
 
             mson::TypeSection typeSection(mson::TypeSection::MemberTypeClass);
 
@@ -93,11 +102,14 @@ namespace snowcrash
 
             if (!isSameBaseType(baseType, mixin.node.baseType)) {
 
-                // WARN: Mixin base type should be compatible with the parent base type
+                // WARN: Mixin base type should be compatible with the parent
+                // base type
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 sections.report.warnings.push_back(
-                    Warning("mixin base type should be the same as parent base type. objects should contain object "
+                    Warning("mixin base type should be the same as parent base "
+                            "type. objects should contain object "
                             "mixins. arrays should contain array mixins",
                         LogicalErrorWarning,
                         sourceMap));
@@ -110,13 +122,18 @@ namespace snowcrash
             }
         } else if (pd.sectionContext() == MSONOneOfSectionType) {
 
-            if (baseType != mson::ObjectBaseType && baseType != mson::ImplicitObjectBaseType) {
+            if (baseType != mson::ObjectBaseType
+                && baseType != mson::ImplicitObjectBaseType) {
 
-                // WARN: One of can not be a nested member for a non object structure type
+                // WARN: One of can not be a nested member for a non object
+                // structure type
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 sections.report.warnings.push_back(Warning(
-                    "one of may be a nested member of a object sub-types only", LogicalErrorWarning, sourceMap));
+                    "one of may be a nested member of a object sub-types only",
+                    LogicalErrorWarning,
+                    sourceMap));
 
                 return cur;
             }
@@ -131,25 +148,33 @@ namespace snowcrash
             }
         } else {
 
-            if ((baseType == mson::ValueBaseType || baseType == mson::ImplicitValueBaseType)
+            if ((baseType == mson::ValueBaseType
+                    || baseType == mson::ImplicitValueBaseType)
                 && node->type == mdp::ListItemMarkdownNodeType) {
 
-                IntermediateParseResult<mson::ValueMember> valueMember(sections.report);
-                cur = MSONValueMemberParser::parse(node, siblings, pd, valueMember);
+                IntermediateParseResult<mson::ValueMember> valueMember(
+                    sections.report);
+                cur = MSONValueMemberParser::parse(
+                    node, siblings, pd, valueMember);
 
                 element.build(valueMember.node);
 
-                if ((valueMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType
-                        || valueMember.node.valueDefinition.typeDefinition.baseType == mson::ObjectBaseType)
+                if ((valueMember.node.valueDefinition.typeDefinition.baseType
+                            == mson::ImplicitObjectBaseType
+                        || valueMember.node.valueDefinition.typeDefinition
+                                .baseType
+                            == mson::ObjectBaseType)
                     && !valueMember.node.valueDefinition.values.empty()) {
                     // WARN: object definition contain value
                     // e.g
                     // - a (array)
                     //   - key (object)
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     sections.report.warnings.push_back(
-                        Warning("array member definition of type 'object' contains value. You should use type "
+                        Warning("array member definition of type 'object' "
+                                "contains value. You should use type "
                                 "definition without value eg. '- (object)'",
                             LogicalErrorWarning,
                             sourceMap));
@@ -158,24 +183,32 @@ namespace snowcrash
                 if (pd.exportSourceMap()) {
                     elementSM.value = valueMember.sourceMap;
                 }
-            } else if ((baseType == mson::ObjectBaseType || baseType == mson::ImplicitObjectBaseType)
+            } else if ((baseType == mson::ObjectBaseType
+                           || baseType == mson::ImplicitObjectBaseType)
                 && node->type == mdp::ListItemMarkdownNodeType) {
 
-                IntermediateParseResult<mson::PropertyMember> propertyMember(sections.report);
-                cur = MSONPropertyMemberParser::parse(node, siblings, pd, propertyMember);
+                IntermediateParseResult<mson::PropertyMember> propertyMember(
+                    sections.report);
+                cur = MSONPropertyMemberParser::parse(
+                    node, siblings, pd, propertyMember);
 
                 element.build(propertyMember.node);
 
-                if ((propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType
-                        || propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ObjectBaseType)
+                if ((propertyMember.node.valueDefinition.typeDefinition.baseType
+                            == mson::ImplicitObjectBaseType
+                        || propertyMember.node.valueDefinition.typeDefinition
+                                .baseType
+                            == mson::ObjectBaseType)
                     && !propertyMember.node.valueDefinition.values.empty()) {
                     // WARN: object definition contain value
                     // e.g
                     // - key: value (object)
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     sections.report.warnings.push_back(
-                        Warning("'object' with value definition. You should use type definition without value eg. '- "
+                        Warning("'object' with value definition. You should "
+                                "use type definition without value eg. '- "
                                 "key (object)'",
                             LogicalErrorWarning,
                             sourceMap));
@@ -184,19 +217,28 @@ namespace snowcrash
                 if (pd.exportSourceMap()) {
                     elementSM.property = propertyMember.sourceMap;
                 }
-            } else if (baseType == mson::PrimitiveBaseType || baseType == mson::ImplicitPrimitiveBaseType) {
+            } else if (baseType == mson::PrimitiveBaseType
+                || baseType == mson::ImplicitPrimitiveBaseType) {
 
                 // WARN: Primitive type members should not have nested members
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                sections.report.warnings.push_back(Warning(
-                    "sub-types of primitive types should not have nested members", LogicalErrorWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                sections.report.warnings.push_back(
+                    Warning("sub-types of primitive types should not have "
+                            "nested members",
+                        LogicalErrorWarning,
+                        sourceMap));
             } else {
 
                 // WARN: Ignoring unrecognized block in mson nested members
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                sections.report.warnings.push_back(Warning("ignorning unrecognized block", IgnoringWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                sections.report.warnings.push_back(
+                    Warning("ignorning unrecognized block",
+                        IgnoringWarning,
+                        sourceMap));
 
                 cur = ++MarkdownNodeIterator(node);
             }
@@ -206,7 +248,9 @@ namespace snowcrash
             sections.node.back().content.elements().push_back(element);
 
             if (pd.exportSourceMap()) {
-                sections.sourceMap.collection.back().elements().collection.push_back(elementSM);
+                sections.sourceMap.collection.back()
+                    .elements()
+                    .collection.push_back(elementSM);
             }
         }
 

--- a/src/MSONValueMemberParser.h
+++ b/src/MSONValueMemberParser.h
@@ -22,7 +22,8 @@ namespace snowcrash
      * MSON Value Member Section Processor
      */
     template <>
-    struct SectionProcessor<mson::ValueMember> : public SignatureSectionProcessorBase<mson::ValueMember> {
+    struct SectionProcessor<mson::ValueMember>
+        : public SignatureSectionProcessorBase<mson::ValueMember> {
 
         static Signature parseSignature(const MarkdownNodeIterator& node,
             snowcrash::SectionParserData& pd,
@@ -37,19 +38,22 @@ namespace snowcrash
                 subject = ReconstructMarkdownHeader(*node);
             }
 
-            return SignatureSectionProcessorBase<mson::ValueMember>::parseSignature(node, pd, traits, report, subject);
+            return SignatureSectionProcessorBase<mson::ValueMember>::
+                parseSignature(node, pd, traits, report, subject);
         }
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(
-                SignatureTraits::ValuesTrait | SignatureTraits::AttributesTrait | SignatureTraits::ContentTrait);
+            SignatureTraits signatureTraits(SignatureTraits::ValuesTrait
+                | SignatureTraits::AttributesTrait
+                | SignatureTraits::ContentTrait);
 
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<mson::ValueMember>& out)
@@ -59,7 +63,8 @@ namespace snowcrash
                 node, pd, signature, out.report, out.node, out.sourceMap);
         }
 
-        static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processDescription(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::ValueMember>& out)
@@ -69,22 +74,30 @@ namespace snowcrash
                 node, pd, out.node.sections, out.sourceMap.sections);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::ValueMember>& out)
         {
 
-            ParseResultRef<mson::TypeSections> typeSections(out.report, out.node.sections, out.sourceMap.sections);
+            ParseResultRef<mson::TypeSections> typeSections(
+                out.report, out.node.sections, out.sourceMap.sections);
 
-            return SectionProcessor<mson::ValueMember>::processNestedMembers<MSONTypeSectionListParser>(
-                node, siblings, pd, typeSections, out.node.valueDefinition.typeDefinition.baseType);
+            return SectionProcessor<mson::ValueMember>::
+                processNestedMembers<MSONTypeSectionListParser>(node,
+                    siblings,
+                    pd,
+                    typeSections,
+                    out.node.valueDefinition.typeDefinition.baseType);
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            if (SectionProcessor<mson::ValueMember>::nestedSectionType(node) != MSONSectionType
+            if (SectionProcessor<mson::ValueMember>::nestedSectionType(node)
+                    != MSONSectionType
                 || node->type == mdp::HeaderMarkdownNodeType) {
 
                 return false;
@@ -94,13 +107,15 @@ namespace snowcrash
                 return true;
             }
 
-            return SectionProcessorBase<mson::ValueMember>::isDescriptionNode(node, sectionType);
+            return SectionProcessorBase<mson::ValueMember>::isDescriptionNode(
+                node, sectionType);
         }
 
         static SectionType nestedSectionType(const MarkdownNodeIterator&);
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<mson::ValueMember>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<mson::ValueMember>& out)
         {
 
             SectionProcessor<mson::ValueMember>::finalizeImplicitBaseType(
@@ -117,7 +132,8 @@ namespace snowcrash
          * \param valueMember MSON Value Member
          * \param sourceMap MSON Value Member source map
          */
-        static MarkdownNodeIterator useSignatureData(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator useSignatureData(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             Report& report,
@@ -131,53 +147,76 @@ namespace snowcrash
                 sourceMap.description.sourceMap = node->sourceMap;
             }
 
-            mson::parseTypeDefinition(
-                node, pd, signature.attributes, report, valueMember.valueDefinition.typeDefinition);
-            parseRemainingContent(node, pd, signature.remainingContent, valueMember.sections, sourceMap.sections);
+            mson::parseTypeDefinition(node,
+                pd,
+                signature.attributes,
+                report,
+                valueMember.valueDefinition.typeDefinition);
+            parseRemainingContent(node,
+                pd,
+                signature.remainingContent,
+                valueMember.sections,
+                sourceMap.sections);
 
             // Check for circular references
-            mson::TypeSpecification typeSpecification = valueMember.valueDefinition.typeDefinition.typeSpecification;
+            mson::TypeSpecification typeSpecification
+                = valueMember.valueDefinition.typeDefinition.typeSpecification;
 
             if (typeSpecification.name.base == mson::ArrayTypeName
                 || typeSpecification.name.base == mson::EnumTypeName) {
 
-                for (mson::TypeNames::iterator it = typeSpecification.nestedTypes.begin();
+                for (mson::TypeNames::iterator it
+                     = typeSpecification.nestedTypes.begin();
                      it != typeSpecification.nestedTypes.end();
                      ++it) {
 
                     if (!it->symbol.literal.empty() && !it->symbol.variable) {
-                        mson::addDependency(node, pd, it->symbol.literal, pd.namedTypeContext, report);
+                        mson::addDependency(node,
+                            pd,
+                            it->symbol.literal,
+                            pd.namedTypeContext,
+                            report);
                     }
                 }
             } else if (typeSpecification.name.base == mson::UndefinedTypeName
                 && !typeSpecification.name.symbol.literal.empty()
                 && !typeSpecification.name.symbol.variable) {
 
-                mson::addDependency(node, pd, typeSpecification.name.symbol.literal, pd.namedTypeContext, report);
+                mson::addDependency(node,
+                    pd,
+                    typeSpecification.name.symbol.literal,
+                    pd.namedTypeContext,
+                    report);
             }
 
             // Properly parse the values in the signature
             if (signature.values.size() > 1) {
 
-                if (valueMember.valueDefinition.typeDefinition.baseType == mson::PrimitiveBaseType) {
+                if (valueMember.valueDefinition.typeDefinition.baseType
+                    == mson::PrimitiveBaseType) {
 
-                    valueMember.valueDefinition.values.push_back(mson::parseValue(signature.value));
+                    valueMember.valueDefinition.values.push_back(
+                        mson::parseValue(signature.value));
 
                     if (pd.exportSourceMap()) {
                         sourceMap.valueDefinition.sourceMap = node->sourceMap;
                     }
 
                     return ++MarkdownNodeIterator(node);
-                } else if (valueMember.valueDefinition.typeDefinition.baseType == mson::UndefinedBaseType) {
-                    valueMember.valueDefinition.typeDefinition.baseType = mson::ImplicitValueBaseType;
+                } else if (valueMember.valueDefinition.typeDefinition.baseType
+                    == mson::UndefinedBaseType) {
+                    valueMember.valueDefinition.typeDefinition.baseType
+                        = mson::ImplicitValueBaseType;
                 }
             }
 
-            for (std::vector<mdp::ByteBuffer>::const_iterator it = signature.values.begin();
+            for (std::vector<mdp::ByteBuffer>::const_iterator it
+                 = signature.values.begin();
                  it != signature.values.end();
                  it++) {
 
-                valueMember.valueDefinition.values.push_back(mson::parseValue(*it));
+                valueMember.valueDefinition.values.push_back(
+                    mson::parseValue(*it));
             }
 
             if (pd.exportSourceMap() && !valueMember.valueDefinition.empty()) {
@@ -211,7 +250,8 @@ namespace snowcrash
                 return;
             }
 
-            mson::TypeSection typeSection(mson::TypeSection::BlockDescriptionClass);
+            mson::TypeSection typeSection(
+                mson::TypeSection::BlockDescriptionClass);
 
             typeSection.content.description = remainingContent;
             sections.push_back(typeSection);
@@ -233,18 +273,22 @@ namespace snowcrash
          * \param sections MSON Type Section collection
          * \param sourceMap MSON Type Section collection source map
          */
-        static MarkdownNodeIterator blockDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator blockDescription(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             mson::TypeSections& sections,
             SourceMap<mson::TypeSections>& sourceMap)
         {
 
             if (sections.empty()
-                || (sections.size() == 1 && sections[0].klass == mson::TypeSection::BlockDescriptionClass)) {
+                || (sections.size() == 1
+                       && sections[0].klass
+                           == mson::TypeSection::BlockDescriptionClass)) {
 
                 if (sections.empty()) {
 
-                    mson::TypeSection typeSection(mson::TypeSection::BlockDescriptionClass);
+                    mson::TypeSection typeSection(
+                        mson::TypeSection::BlockDescriptionClass);
                     sections.push_back(typeSection);
 
                     if (pd.exportSourceMap()) {
@@ -258,13 +302,15 @@ namespace snowcrash
                     TwoNewLines(sections[0].content.description);
                 }
 
-                mdp::ByteBuffer content = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
+                mdp::ByteBuffer content
+                    = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
                 TrimString(content);
 
                 sections[0].content.description += content;
 
                 if (pd.exportSourceMap() && !content.empty()) {
-                    sourceMap.collection[0].description.sourceMap.append(node->sourceMap);
+                    sourceMap.collection[0].description.sourceMap.append(
+                        node->sourceMap);
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -274,16 +320,19 @@ namespace snowcrash
         }
 
         /**
-         * \brief Process nested member types for a member (either property or value) and Named Type.
+         * \brief Process nested member types for a member (either property or
+         * value) and Named Type.
          *
          * \param node Node to process
          * \param siblings Siblings of the node being processed
          * \param pd Section Parser Data
          * \param sections MSON Type Section collection Parse Result
-         * \param baseType Base Type of the MSON member to be sent for nested type sections
+         * \param baseType Base Type of the MSON member to be sent for nested
+         * type sections
          */
         template <typename PARSER>
-        static MarkdownNodeIterator processNestedMembers(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedMembers(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::TypeSections>& sections,
@@ -292,25 +341,30 @@ namespace snowcrash
 
             MarkdownNodeIterator cur = node;
 
-            if (pd.sectionContext() == MSONSectionType || pd.sectionContext() == MSONMixinSectionType
+            if (pd.sectionContext() == MSONSectionType
+                || pd.sectionContext() == MSONMixinSectionType
                 || pd.sectionContext() == MSONOneOfSectionType) {
 
-                cur = processMSONSection(node, siblings, pd, sections, baseType);
+                cur = processMSONSection(
+                    node, siblings, pd, sections, baseType);
             } else {
 
                 // Try to resolve base type if not given before parsing further
                 resolveImplicitBaseType(node, pd.sectionContext(), baseType);
 
-                IntermediateParseResult<mson::TypeSection> typeSection(sections.report);
+                IntermediateParseResult<mson::TypeSection> typeSection(
+                    sections.report);
                 typeSection.node.baseType = baseType;
 
                 cur = PARSER::parse(node, siblings, pd, typeSection);
 
-                if (typeSection.node.klass != mson::TypeSection::UndefinedClass) {
+                if (typeSection.node.klass
+                    != mson::TypeSection::UndefinedClass) {
                     sections.node.push_back(typeSection.node);
 
                     if (pd.exportSourceMap()) {
-                        sections.sourceMap.collection.push_back(typeSection.sourceMap);
+                        sections.sourceMap.collection.push_back(
+                            typeSection.sourceMap);
                     }
                 }
             }
@@ -325,9 +379,11 @@ namespace snowcrash
          * \param siblings Siblings of the node being processed
          * \param pd Section Parser Data
          * \param sections MSON Type Section collection Parse Result
-         * \param baseType Base Type of the MSON member to be sent for nested type sections
+         * \param baseType Base Type of the MSON member to be sent for nested
+         * type sections
          */
-        static MarkdownNodeIterator processMSONSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processMSONSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<mson::TypeSections>& sections,
@@ -351,10 +407,12 @@ namespace snowcrash
          *
          * \param node Node to process
          * \param sectionType Section Type
-         * \param baseType Base Type of the MSON member that needs to be resolved
+         * \param baseType Base Type of the MSON member that needs to be
+         * resolved
          */
-        static void resolveImplicitBaseType(
-            const MarkdownNodeIterator& node, const SectionType& sectionType, mson::BaseType& baseType)
+        static void resolveImplicitBaseType(const MarkdownNodeIterator& node,
+            const SectionType& sectionType,
+            mson::BaseType& baseType)
         {
 
             if (baseType != mson::UndefinedBaseType) {
@@ -389,7 +447,8 @@ namespace snowcrash
     };
 
     /** MSON Value Member Section Parser */
-    typedef SectionParser<mson::ValueMember, ListSectionAdapter> MSONValueMemberParser;
+    typedef SectionParser<mson::ValueMember, ListSectionAdapter>
+        MSONValueMemberParser;
 }
 
 #endif

--- a/src/ModelTable.h
+++ b/src/ModelTable.h
@@ -28,7 +28,8 @@ namespace snowcrash
 {
 
     /** Symbol reference matching regex */
-    const char* const ModelReferenceRegex("^[[:blank:]]*\\[" SYMBOL_IDENTIFIER "]\\[][[:blank:]]*$");
+    const char* const ModelReferenceRegex(
+        "^[[:blank:]]*\\[" SYMBOL_IDENTIFIER "]\\[][[:blank:]]*$");
 
     // Resource Object Model Table
     typedef std::map<Identifier, ResourceModel> ModelTable;
@@ -36,9 +37,12 @@ namespace snowcrash
     // Resource Object Model Table source map
     typedef std::map<Identifier, SourceMap<ResourceModel> > ModelSourceMapTable;
 
-    // Checks whether given source data represents reference to a symbol returning true if so,
-    // false otherwise. If source data is represent reference referred symbol name is filled in.
-    inline bool GetModelReference(const mdp::ByteBuffer& sourceData, Identifier& referredModel)
+    // Checks whether given source data represents reference to a symbol
+    // returning true if so,
+    // false otherwise. If source data is represent reference referred symbol
+    // name is filled in.
+    inline bool GetModelReference(
+        const mdp::ByteBuffer& sourceData, Identifier& referredModel)
     {
 
         CaptureGroups captureGroups;
@@ -74,9 +78,12 @@ namespace snowcrash
 
         std::cout << "Resource Model Symbols:\n";
 
-        for (ModelTable::const_iterator it = modelTable.begin(); it != modelTable.end(); ++it) {
+        for (ModelTable::const_iterator it = modelTable.begin();
+             it != modelTable.end();
+             ++it) {
 
-            std::cout << "- " << it->first << " - body: '" << EscapeNewlines(it->second.body) << "'\n";
+            std::cout << "- " << it->first << " - body: '"
+                      << EscapeNewlines(it->second.body) << "'\n";
         }
 
         std::cout << std::endl;

--- a/src/ParameterParser.h
+++ b/src/ParameterParser.h
@@ -37,10 +37,12 @@ namespace snowcrash
     const std::string DescriptionIdentifier = "...";
 
     /** Parameter Required matching regex */
-    const char* const ParameterRequiredRegex = "^[[:blank:]]*[Rr]equired[[:blank:]]*$";
+    const char* const ParameterRequiredRegex
+        = "^[[:blank:]]*[Rr]equired[[:blank:]]*$";
 
     /** Parameter Optional matching regex */
-    const char* const ParameterOptionalRegex = "^[[:blank:]]*[Oo]ptional[[:blank:]]*$";
+    const char* const ParameterOptionalRegex
+        = "^[[:blank:]]*[Oo]ptional[[:blank:]]*$";
 
     /** Additonal Parameter Traits Example matching regex */
     const char* const AdditionalTraitsExampleRegex = "`([^`]*)`";
@@ -49,20 +51,24 @@ namespace snowcrash
     const char* const AdditionalTraitsUseRegex = "([Oo]ptional|[Rr]equired)";
 
     /** Parameter Values matching regex */
-    const char* const ParameterValuesRegex = "^[[:blank:]]*[Vv]alues[[:blank:]]*$";
+    const char* const ParameterValuesRegex
+        = "^[[:blank:]]*[Vv]alues[[:blank:]]*$";
 
     /** Values expected content */
     const char* const ExpectedValuesContent
-        = "nested list of possible parameter values, one element per list item e.g. '`value`'";
+        = "nested list of possible parameter values, one element per list item "
+          "e.g. '`value`'";
 
     /** Additional Traits warning for old syntax */
     const char* const OldSyntaxAdditionalTraitsWarning
-        = ", expected '([required | optional], [<type>], [`<example value>`])', e.g. '(optional, string, `Hello "
+        = ", expected '([required | optional], [<type>], [`<example "
+          "value>`])', e.g. '(optional, string, `Hello "
           "World`)'";
 
     /** Additional Traits warning for new syntax */
     const char* const NewSyntaxAdditionalTraitsWarning
-        = ", expected '([required | optional], [<type> | enum[<type>])', e.g. '(optional, string)'";
+        = ", expected '([required | optional], [<type> | enum[<type>])', e.g. "
+          "'(optional, string)'";
 
     /* Type wrapped by enum matching regex */
     const char* const EnumRegex = "^enum\\[([^][]+)]$";
@@ -80,12 +86,14 @@ namespace snowcrash
      * Parameter section processor
      */
     template <>
-    struct SectionProcessor<Parameter> : public SignatureSectionProcessorBase<Parameter> {
+    struct SectionProcessor<Parameter>
+        : public SignatureSectionProcessorBase<Parameter> {
 
         static SignatureTraits signatureTraits()
         {
 
-            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait | SignatureTraits::ValuesTrait
+            SignatureTraits signatureTraits(SignatureTraits::IdentifierTrait
+                    | SignatureTraits::ValuesTrait
                     | SignatureTraits::AttributesTrait
                     | SignatureTraits::ContentTrait,
                 Delimiters('=', snowcrash::DescriptionIdentifier));
@@ -93,7 +101,8 @@ namespace snowcrash
             return signatureTraits;
         }
 
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             SectionParserData& pd,
             const Signature& signature,
             const ParseResultRef<Parameter>& out)
@@ -109,7 +118,8 @@ namespace snowcrash
 
             TrimString(out.node.description);
 
-            SectionProcessor<Parameter>::parseAttributes(node, pd, signature.attributes, out);
+            SectionProcessor<Parameter>::parseAttributes(
+                node, pd, signature.attributes, out);
 
             if (pd.exportSourceMap()) {
                 if (!out.node.name.empty()) {
@@ -128,7 +138,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Parameter>& out)
@@ -146,8 +157,10 @@ namespace snowcrash
                 ss << " for parameter '" << out.node.name << "'";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), RedefinitionWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), RedefinitionWarning, sourceMap));
             }
 
             // Clear any previous values
@@ -157,24 +170,29 @@ namespace snowcrash
                 out.sourceMap.values.collection.clear();
             }
 
-            ParseResultRef<Values> values(out.report, out.node.values, out.sourceMap.values);
+            ParseResultRef<Values> values(
+                out.report, out.node.values, out.sourceMap.values);
             ValuesParser::parse(node, siblings, pd, values);
 
             if (out.node.values.empty()) {
                 // WARN: empty definition
                 std::stringstream ss;
-                ss << "no possible values specified for parameter '" << out.node.name << "'";
+                ss << "no possible values specified for parameter '"
+                   << out.node.name << "'";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
             }
 
             return ++MarkdownNodeIterator(node);
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Parameter>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Parameter>& out)
         {
 
             checkDefaultAndRequiredClash<Parameter>(node, pd, out);
@@ -184,24 +202,31 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 mdp::ByteBuffer subject, remainingContent;
-                subject = GetFirstLine(node->children().front().text, remainingContent);
+                subject = GetFirstLine(
+                    node->children().front().text, remainingContent);
                 TrimString(subject);
 
                 // Look ahead into nested list items
-                for (MarkdownNodeIterator it = node->children().begin(); it != node->children().end(); ++it) {
+                for (MarkdownNodeIterator it = node->children().begin();
+                     it != node->children().end();
+                     ++it) {
 
-                    if (it->type == mdp::ListItemMarkdownNodeType && !it->children().empty()) {
+                    if (it->type == mdp::ListItemMarkdownNodeType
+                        && !it->children().empty()) {
 
                         mdp::ByteBuffer itSubject, itRemainingContent;
-                        itSubject = GetFirstLine(it->children().front().text, itRemainingContent);
+                        itSubject = GetFirstLine(
+                            it->children().front().text, itRemainingContent);
                         TrimString(itSubject);
 
                         if (RegexMatch(itSubject, MSONDefaultTypeSectionRegex)
                             || RegexMatch(itSubject, MSONSampleTypeSectionRegex)
-                            || RegexMatch(itSubject, MSONValueMembersTypeSectionRegex)) {
+                            || RegexMatch(itSubject,
+                                   MSONValueMembersTypeSectionRegex)) {
 
                             return MSONParameterSectionType;
                         }
@@ -241,7 +266,8 @@ namespace snowcrash
         {
 
             out.node.use = UndefinedParameterUse;
-            size_t max = oldSyntax ? OLD_SYNTAX_MAX_ATTRIBUTES : NEW_SYNTAX_MAX_ATTRIBUTES;
+            size_t max = oldSyntax ? OLD_SYNTAX_MAX_ATTRIBUTES :
+                                     NEW_SYNTAX_MAX_ATTRIBUTES;
 
             if (attributes.size() > max) {
                 return warnAboutAdditionalTraits(node, pd, out, oldSyntax);
@@ -253,19 +279,24 @@ namespace snowcrash
             for (size_t i = 0; i < attributes.size(); i++) {
                 CaptureGroups captureGroups;
 
-                if (RegexMatch(attributes[i], ParameterOptionalRegex) && !definedUse) {
+                if (RegexMatch(attributes[i], ParameterOptionalRegex)
+                    && !definedUse) {
                     out.node.use = OptionalParameterUse;
                     definedUse = true;
-                } else if (RegexMatch(attributes[i], ParameterRequiredRegex) && !definedUse) {
+                } else if (RegexMatch(attributes[i], ParameterRequiredRegex)
+                    && !definedUse) {
                     out.node.use = RequiredParameterUse;
                     definedUse = true;
-                } else if (oldSyntax && RegexCapture(attributes[i], AdditionalTraitsExampleRegex, captureGroups)
+                } else if (oldSyntax && RegexCapture(attributes[i],
+                                            AdditionalTraitsExampleRegex,
+                                            captureGroups)
                     && captureGroups.size() > 1) {
 
                     out.node.exampleValue = captureGroups[1];
                 } else {
                     if (!out.node.type.empty()) {
-                        return warnAboutAdditionalTraits(node, pd, out, oldSyntax);
+                        return warnAboutAdditionalTraits(
+                            node, pd, out, oldSyntax);
                     }
 
                     out.node.type = attributes[i];
@@ -274,7 +305,8 @@ namespace snowcrash
 
             // For new syntax, Retrieve the type which is wrapped by enum[]
             if (!oldSyntax && !out.node.type.empty()) {
-                std::string typeInsideEnum = RegexCaptureFirst(out.node.type, EnumRegex);
+                std::string typeInsideEnum
+                    = RegexCaptureFirst(out.node.type, EnumRegex);
                 TrimString(typeInsideEnum);
 
                 if (!typeInsideEnum.empty()) {
@@ -299,17 +331,23 @@ namespace snowcrash
 
         template <typename T>
         static void warnAboutAdditionalTraits(
-            const mdp::MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<T>& out, bool oldSyntax)
+            const mdp::MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<T>& out,
+            bool oldSyntax)
         {
 
             // WARN: Additional parameters traits warning
             std::stringstream ss;
             ss << "unable to parse additional parameter traits";
-            ss << (oldSyntax ? OldSyntaxAdditionalTraitsWarning : NewSyntaxAdditionalTraitsWarning);
+            ss << (oldSyntax ? OldSyntaxAdditionalTraitsWarning :
+                               NewSyntaxAdditionalTraitsWarning);
 
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-            out.report.warnings.push_back(Warning(ss.str(), FormattingWarning, sourceMap));
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
+            out.report.warnings.push_back(
+                Warning(ss.str(), FormattingWarning, sourceMap));
 
             out.node.type.clear();
             out.node.use = UndefinedParameterUse;
@@ -331,30 +369,39 @@ namespace snowcrash
 
         template <typename T>
         static void checkDefaultAndRequiredClash(
-            const mdp::MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<T>& out)
+            const mdp::MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<T>& out)
         {
 
             // Check possible required vs default clash
-            if (out.node.use != OptionalParameterUse && !out.node.defaultValue.empty()) {
+            if (out.node.use != OptionalParameterUse
+                && !out.node.defaultValue.empty()) {
 
                 // WARN: Required vs default clash
                 std::stringstream ss;
                 ss << "specifying parameter '" << out.node.name
                    << "' as required supersedes its default value"
-                      ", declare the parameter as 'optional' to specify its default value";
+                      ", declare the parameter as 'optional' to specify its "
+                      "default value";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), LogicalErrorWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), LogicalErrorWarning, sourceMap));
             }
         }
 
         template <typename T>
         static void checkExampleAndDefaultValue(
-            const mdp::MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<T>& out)
+            const mdp::MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<T>& out)
         {
 
-            if ((out.node.exampleValue.empty() && out.node.defaultValue.empty()) || out.node.values.empty()) {
+            if ((out.node.exampleValue.empty() && out.node.defaultValue.empty())
+                || out.node.values.empty()) {
 
                 return;
             }
@@ -365,7 +412,9 @@ namespace snowcrash
             std::stringstream ss;
             bool printWarning = false;
 
-            for (Collection<Value>::iterator it = out.node.values.begin(); it != out.node.values.end(); ++it) {
+            for (Collection<Value>::iterator it = out.node.values.begin();
+                 it != out.node.values.end();
+                 ++it) {
 
                 if (out.node.exampleValue == *it) {
                     isExampleFound = true;
@@ -379,7 +428,8 @@ namespace snowcrash
             if (!out.node.exampleValue.empty() && !isExampleFound) {
 
                 // WARN: missing example in values.
-                ss << "the example value '" << out.node.exampleValue << "' of parameter '" << out.node.name
+                ss << "the example value '" << out.node.exampleValue
+                   << "' of parameter '" << out.node.name
                    << "' is not in its list of expected values";
                 printWarning = true;
             }
@@ -387,15 +437,18 @@ namespace snowcrash
             if (!out.node.defaultValue.empty() && !isDefaultFound) {
 
                 // WARN: missing default in values.
-                ss << "the default value '" << out.node.defaultValue << "' of parameter '" << out.node.name
+                ss << "the default value '" << out.node.defaultValue
+                   << "' of parameter '" << out.node.name
                    << "' is not in its list of expected values";
                 printWarning = true;
             }
 
             if (printWarning) {
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), LogicalErrorWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), LogicalErrorWarning, sourceMap));
             }
         }
 
@@ -414,7 +467,9 @@ namespace snowcrash
                 return NotParameterType; // Empty string, invalid
             }
 
-            if (RegexCapture(innerSignature, "^" PARAMETER_IDENTIFIER "[[:blank:]]*", captureGroups)
+            if (RegexCapture(innerSignature,
+                    "^" PARAMETER_IDENTIFIER "[[:blank:]]*",
+                    captureGroups)
                 && !captureGroups[0].empty()) {
 
                 innerSignature = innerSignature.substr(captureGroups[0].size());

--- a/src/ParametersParser.h
+++ b/src/ParametersParser.h
@@ -20,11 +20,13 @@ namespace snowcrash
 {
 
     /** Parameters matching regex */
-    const char* const ParametersRegex = "^[[:blank:]]*[Pp]arameters?[[:blank:]]*$";
+    const char* const ParametersRegex
+        = "^[[:blank:]]*[Pp]arameters?[[:blank:]]*$";
 
     /** No parameters specified message */
     const char* const NoParametersMessage
-        = "no parameters specified, expected a nested list of parameters, one parameter per list item";
+        = "no parameters specified, expected a nested list of parameters, one "
+          "parameter per list item";
 
     /** Internal type alias for Collection iterator of Parameter */
     typedef Collection<Parameter>::iterator ParameterIterator;
@@ -33,9 +35,11 @@ namespace snowcrash
      * Parameters section processor
      */
     template <>
-    struct SectionProcessor<Parameters> : public SectionProcessorBase<Parameters> {
+    struct SectionProcessor<Parameters>
+        : public SectionProcessorBase<Parameters> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -51,11 +55,14 @@ namespace snowcrash
                 // WARN: Extra content in parameters section
                 std::stringstream ss;
                 ss << "ignoring additional content after 'parameters' keyword,";
-                ss << " expected a nested list of parameters, one parameter per list item";
+                ss << " expected a nested list of parameters, one parameter "
+                      "per list item";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), IgnoringWarning, sourceMap));
             }
 
             return ++MarkdownNodeIterator(node);
@@ -63,7 +70,8 @@ namespace snowcrash
 
         NO_SECTION_DESCRIPTION(Parameters)
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Parameters>& out)
@@ -74,7 +82,8 @@ namespace snowcrash
             if (pd.sectionContext() == ParameterSectionType) {
                 ParameterParser::parse(node, siblings, pd, parameter);
             } else if (pd.sectionContext() == MSONParameterSectionType) {
-                IntermediateParseResult<MSONParameter> msonParameter(out.report);
+                IntermediateParseResult<MSONParameter> msonParameter(
+                    out.report);
                 MSONParameterParser::parse(node, siblings, pd, msonParameter);
 
                 // Copy values from MSON Parameter to normal parameter
@@ -87,18 +96,22 @@ namespace snowcrash
 
             if (!out.node.empty()) {
 
-                ParameterIterator duplicate = findParameter(out.node, parameter.node);
+                ParameterIterator duplicate
+                    = findParameter(out.node, parameter.node);
 
                 if (duplicate != out.node.end()) {
                     removeParameter(duplicate, pd, out);
 
                     // WARN: Parameter already defined
                     std::stringstream ss;
-                    ss << "overshadowing previous parameter '" << parameter.node.name << "' definition";
+                    ss << "overshadowing previous parameter '"
+                       << parameter.node.name << "' definition";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), RedefinitionWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), RedefinitionWarning, sourceMap));
                 }
             }
 
@@ -114,9 +127,11 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
-                mdp::ByteBuffer remaining, subject = node->children().front().text;
+                mdp::ByteBuffer remaining,
+                    subject = node->children().front().text;
 
                 subject = GetFirstLine(subject, remaining);
                 TrimString(subject);
@@ -135,35 +150,43 @@ namespace snowcrash
             return SectionProcessor<Parameter>::sectionType(node);
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Parameters>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Parameters>& out)
         {
 
             if (out.node.empty()) {
 
                 // WARN: No parameters defined
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(NoParametersMessage, FormattingWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(NoParametersMessage, FormattingWarning, sourceMap));
             }
         }
 
         /** Finds a parameter inside a parameters collection */
-        static ParameterIterator findParameter(Parameters& parameters, const Parameter& parameter)
+        static ParameterIterator findParameter(
+            Parameters& parameters, const Parameter& parameter)
         {
 
-            return std::find_if(parameters.begin(), parameters.end(), std::bind2nd(MatchName<Parameter>(), parameter));
+            return std::find_if(parameters.begin(),
+                parameters.end(),
+                std::bind2nd(MatchName<Parameter>(), parameter));
         }
 
-        static void removeParameter(
-            ParameterIterator& parameter, SectionParserData& pd, const ParseResultRef<Parameters>& out)
+        static void removeParameter(ParameterIterator& parameter,
+            SectionParserData& pd,
+            const ParseResultRef<Parameters>& out)
         {
 
             out.node.erase(parameter);
 
             if (pd.exportSourceMap()) {
                 size_t parameterIndex = parameter - out.node.begin();
-                out.sourceMap.collection.erase(out.sourceMap.collection.begin() + parameterIndex);
+                out.sourceMap.collection.erase(
+                    out.sourceMap.collection.begin() + parameterIndex);
             }
         }
     };
@@ -177,15 +200,18 @@ namespace snowcrash
     // must end either with "}" or ",".
 
     // FIXME: The implementation is very naive and can be sped up.
-    static bool isValidUriTemplateParam(const std::string& uriTemplate, const std::string& param)
+    static bool isValidUriTemplateParam(
+        const std::string& uriTemplate, const std::string& param)
     {
 
-        if (uriTemplate.find("{" + param) == std::string::npos && uriTemplate.find("?" + param) == std::string::npos
+        if (uriTemplate.find("{" + param) == std::string::npos
+            && uriTemplate.find("?" + param) == std::string::npos
             && uriTemplate.find("," + param) == std::string::npos) {
             return false;
         }
 
-        if (uriTemplate.find(param + "}") == std::string::npos && uriTemplate.find(param + ",") == std::string::npos) {
+        if (uriTemplate.find(param + "}") == std::string::npos
+            && uriTemplate.find(param + ",") == std::string::npos) {
             return false;
         }
 
@@ -204,22 +230,26 @@ namespace snowcrash
         const ParseResultRef<T>& out)
     {
 
-        for (ParameterIterator it = parameters.begin(); it != parameters.end(); ++it) {
+        for (ParameterIterator it = parameters.begin(); it != parameters.end();
+             ++it) {
 
             if (!isValidUriTemplateParam(out.node.uriTemplate, it->name)) {
 
                 // WARN: parameter name not present
                 std::stringstream ss;
-                ss << "parameter '" << it->name << "' is not found within the URI template '" << out.node.uriTemplate
-                   << "'";
+                ss << "parameter '" << it->name
+                   << "' is not found within the URI template '"
+                   << out.node.uriTemplate << "'";
 
                 if (!out.node.name.empty()) {
                     ss << " for '" << out.node.name << "' ";
                 }
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), LogicalErrorWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), LogicalErrorWarning, sourceMap));
             }
         }
     }

--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -38,14 +38,18 @@ namespace snowcrash
 
     /** Request matching regex */
     const char* const RequestRegex
-        = "^[[:blank:]]*[Rr]equest([[:blank:]]" SYMBOL_IDENTIFIER ")?" MEDIA_TYPE "?[[:blank:]]*";
+        = "^[[:blank:]]*[Rr]equest([[:blank:]]" SYMBOL_IDENTIFIER
+          ")?" MEDIA_TYPE "?[[:blank:]]*";
 
     /** Response matching regex */
-    const char* const ResponseRegex = "^[[:blank:]]*[Rr]esponse([[:blank:][:digit:]]+)?" MEDIA_TYPE "?[[:blank:]]*";
+    const char* const ResponseRegex
+        = "^[[:blank:]]*[Rr]esponse([[:blank:][:digit:]]+)?" MEDIA_TYPE
+          "?[[:blank:]]*";
 
     /** Model matching regex */
     const char* const ModelRegex
-        = "^[[:blank:]]*(" SYMBOL_IDENTIFIER "[[:blank:]]+)?[Mm]odel" MEDIA_TYPE "?[[:blank:]]*$";
+        = "^[[:blank:]]*(" SYMBOL_IDENTIFIER "[[:blank:]]+)?[Mm]odel" MEDIA_TYPE
+          "?[[:blank:]]*$";
 
     /**
      * Payload Section Processor
@@ -53,7 +57,8 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Payload> : public SectionProcessorBase<Payload> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -67,12 +72,17 @@ namespace snowcrash
 
             // WARN: missing status code
             if (out.node.name.empty()
-                && (pd.sectionContext() == ResponseSectionType || pd.sectionContext() == ResponseBodySectionType)) {
+                && (pd.sectionContext() == ResponseSectionType
+                       || pd.sectionContext() == ResponseBodySectionType)) {
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(
-                    "missing response HTTP status code, assuming 'Response 200'", EmptyDefinitionWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning("missing response HTTP status code, assuming "
+                            "'Response 200'",
+                        EmptyDefinitionWarning,
+                        sourceMap));
                 out.node.name = "200";
             }
 
@@ -81,14 +91,17 @@ namespace snowcrash
                     out.node.description = remainingContent;
 
                     if (pd.exportSourceMap() && !out.node.description.empty()) {
-                        out.sourceMap.description.sourceMap.append(node->sourceMap);
+                        out.sourceMap.description.sourceMap.append(
+                            node->sourceMap);
                     }
-                } else if (!parseModelReference(node, pd, remainingContent, out)) {
+                } else if (!parseModelReference(
+                               node, pd, remainingContent, out)) {
 
                     // NOTE: NOT THE CORRECT WAY TO DO THIS
                     // https://github.com/apiaryio/snowcrash/commit/a7c5868e62df0048a85e2f9aeeb42c3b3e0a2f07#commitcomment-7322085
                     pd.sectionsContext.push_back(BodySectionType);
-                    CodeBlockUtility::signatureContentAsCodeBlock(node, pd, out.report, out.node.body);
+                    CodeBlockUtility::signatureContentAsCodeBlock(
+                        node, pd, out.report, out.node.body);
                     TwoNewLines(out.node.body);
                     pd.sectionsContext.pop_back();
 
@@ -105,7 +118,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processContent(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Payload>& out)
@@ -118,20 +132,25 @@ namespace snowcrash
                 std::stringstream ss;
 
                 ss << "ignoring extraneous content after model reference";
-                ss << ", expected model reference only e.g. '[" << out.node.reference.id << "][]'";
+                ss << ", expected model reference only e.g. '["
+                   << out.node.reference.id << "][]'";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), IgnoringWarning, sourceMap));
             } else {
 
-                if (!out.node.body.empty() || node->type != mdp::ParagraphMarkdownNodeType
+                if (!out.node.body.empty()
+                    || node->type != mdp::ParagraphMarkdownNodeType
                     || !parseModelReference(node, pd, node->text, out)) {
 
                     // NOTE: NOT THE CORRECT WAY TO DO THIS
                     // https://github.com/apiaryio/snowcrash/commit/a7c5868e62df0048a85e2f9aeeb42c3b3e0a2f07#commitcomment-7322085
                     pd.sectionsContext.push_back(BodySectionType);
-                    CodeBlockUtility::contentAsCodeBlock(node, pd, out.report, content);
+                    CodeBlockUtility::contentAsCodeBlock(
+                        node, pd, out.report, content);
                     pd.sectionsContext.pop_back();
 
                     out.node.body += content;
@@ -145,7 +164,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Payload>& out)
@@ -153,44 +173,57 @@ namespace snowcrash
 
             switch (pd.sectionContext()) {
                 case HeadersSectionType: {
-                    ParseResultRef<Headers> headers(out.report, out.node.headers, out.sourceMap.headers);
+                    ParseResultRef<Headers> headers(
+                        out.report, out.node.headers, out.sourceMap.headers);
                     return HeadersParser::parse(node, siblings, pd, headers);
                 }
 
                 case AttributesSectionType: {
-                    ParseResultRef<Attributes> attributes(out.report, out.node.attributes, out.sourceMap.attributes);
-                    return AttributesParser::parse(node, siblings, pd, attributes);
+                    ParseResultRef<Attributes> attributes(out.report,
+                        out.node.attributes,
+                        out.sourceMap.attributes);
+                    return AttributesParser::parse(
+                        node, siblings, pd, attributes);
                 }
 
                 case ParametersSectionType: {
                     if (pd.parentSectionContext() != RequestSectionType) {
-                        // WARN: Only request section can have parameters section
+                        // WARN: Only request section can have parameters
+                        // section
                         mdp::CharactersRangeSet sourceMap
-                            = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                            = mdp::BytesRangeSetToCharactersRangeSet(
+                                node->sourceMap, pd.sourceCharacterIndex);
                         out.report.warnings.push_back(
-                            Warning("ignoring parameters section in a non request payload section",
+                            Warning("ignoring parameters section in a non "
+                                    "request payload section",
                                 IgnoringWarning,
                                 sourceMap));
 
                         return ++MarkdownNodeIterator(node);
                     }
 
-                    ParseResultRef<Parameters> parameters(out.report, out.node.parameters, out.sourceMap.parameters);
-                    return ParametersParser::parse(node, siblings, pd, parameters);
+                    ParseResultRef<Parameters> parameters(out.report,
+                        out.node.parameters,
+                        out.sourceMap.parameters);
+                    return ParametersParser::parse(
+                        node, siblings, pd, parameters);
                 }
 
                 case BodySectionType: {
                     if (!out.node.body.empty()) {
                         // WARN: Multiple body section
                         mdp::CharactersRangeSet sourceMap
-                            = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                            = mdp::BytesRangeSetToCharactersRangeSet(
+                                node->sourceMap, pd.sourceCharacterIndex);
                         out.report.warnings.push_back(
-                            Warning("ignoring additional 'body' content, it is already defined",
+                            Warning("ignoring additional 'body' content, it is "
+                                    "already defined",
                                 RedefinitionWarning,
                                 sourceMap));
                     }
 
-                    ParseResultRef<Asset> asset(out.report, out.node.body, out.sourceMap.body);
+                    ParseResultRef<Asset> asset(
+                        out.report, out.node.body, out.sourceMap.body);
                     return AssetParser::parse(node, siblings, pd, asset);
                 }
 
@@ -198,14 +231,17 @@ namespace snowcrash
                     if (!out.node.schema.empty()) {
                         // WARN: Multiple schema section
                         mdp::CharactersRangeSet sourceMap
-                            = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                            = mdp::BytesRangeSetToCharactersRangeSet(
+                                node->sourceMap, pd.sourceCharacterIndex);
                         out.report.warnings.push_back(
-                            Warning("ignoring additional 'schema' content, it is already defined",
+                            Warning("ignoring additional 'schema' content, it "
+                                    "is already defined",
                                 RedefinitionWarning,
                                 sourceMap));
                     }
 
-                    ParseResultRef<Asset> asset(out.report, out.node.schema, out.sourceMap.schema);
+                    ParseResultRef<Asset> asset(
+                        out.report, out.node.schema, out.sourceMap.schema);
                     return AssetParser::parse(node, siblings, pd, asset);
                 }
 
@@ -216,18 +252,20 @@ namespace snowcrash
             return node;
         }
 
-        static MarkdownNodeIterator processUnexpectedNode(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processUnexpectedNode(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionType& sectionType,
             const ParseResultRef<Payload>& out)
         {
 
-            if ((node->type == mdp::ParagraphMarkdownNodeType || node->type == mdp::CodeMarkdownNodeType)
+            if ((node->type == mdp::ParagraphMarkdownNodeType
+                    || node->type == mdp::CodeMarkdownNodeType)
                 && sectionType == BodySectionType) {
 
-                mdp::ByteBuffer content
-                    = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.body);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(
+                    node, pd, sectionType, out.report, out.node.body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
                     out.sourceMap.body.sourceMap.append(node->sourceMap);
@@ -236,13 +274,17 @@ namespace snowcrash
                 return ++MarkdownNodeIterator(node);
             }
 
-            return SectionProcessorBase<Payload>::processUnexpectedNode(node, siblings, pd, sectionType, out);
+            return SectionProcessorBase<Payload>::processUnexpectedNode(
+                node, siblings, pd, sectionType, out);
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            if (!isAbbreviated(sectionType) && SectionProcessorBase<Payload>::isDescriptionNode(node, sectionType)) {
+            if (!isAbbreviated(sectionType)
+                && SectionProcessorBase<Payload>::isDescriptionNode(
+                       node, sectionType)) {
 
                 return true;
             }
@@ -250,10 +292,12 @@ namespace snowcrash
             return false;
         }
 
-        static bool isContentNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isContentNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            if (isAbbreviated(sectionType) && (SectionKeywordSignature(node) == UndefinedSectionType)) {
+            if (isAbbreviated(sectionType)
+                && (SectionKeywordSignature(node) == UndefinedSectionType)) {
 
                 return true;
             }
@@ -264,7 +308,8 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 SectionType nestedType = UndefinedSectionType;
                 PayloadSignature signature = payloadSignature(node);
@@ -273,7 +318,9 @@ namespace snowcrash
                     return UndefinedSectionType;
                 }
 
-                for (MarkdownNodeIterator child = node->children().begin(); child != node->children().end(); ++child) {
+                for (MarkdownNodeIterator child = node->children().begin();
+                     child != node->children().end();
+                     ++child) {
 
                     nestedType = nestedSectionType(child);
 
@@ -325,23 +372,27 @@ namespace snowcrash
             return UndefinedSectionType;
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Payload>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Payload>& out)
         {
 
             SectionType sectionType = pd.sectionContext();
 
-            if (sectionType == RequestSectionType || sectionType == RequestBodySectionType) {
+            if (sectionType == RequestSectionType
+                || sectionType == RequestBodySectionType) {
 
                 checkRequest(node, pd, out);
-            } else if (sectionType == ResponseSectionType || sectionType == ResponseBodySectionType) {
+            } else if (sectionType == ResponseSectionType
+                || sectionType == ResponseBodySectionType) {
 
                 checkResponse(node, pd, out);
             }
         }
 
         /** Resolve payload signature */
-        static PayloadSignature payloadSignature(const MarkdownNodeIterator& node)
+        static PayloadSignature payloadSignature(
+            const MarkdownNodeIterator& node)
         {
 
             mdp::ByteBuffer subject = node->children().front().text;
@@ -364,18 +415,25 @@ namespace snowcrash
         }
 
         /** Get SectionType from PayloadSignature and nestedSectionType */
-        static SectionType getSectionType(PayloadSignature signature, SectionType nestedType)
+        static SectionType getSectionType(
+            PayloadSignature signature, SectionType nestedType)
         {
 
             switch (signature) {
                 case RequestPayloadSignature:
-                    return (nestedType != UndefinedSectionType) ? RequestSectionType : RequestBodySectionType;
+                    return (nestedType != UndefinedSectionType) ?
+                        RequestSectionType :
+                        RequestBodySectionType;
 
                 case ResponsePayloadSignature:
-                    return (nestedType != UndefinedSectionType) ? ResponseSectionType : ResponseBodySectionType;
+                    return (nestedType != UndefinedSectionType) ?
+                        ResponseSectionType :
+                        ResponseBodySectionType;
 
                 case ModelPayloadSignature:
-                    return (nestedType != UndefinedSectionType) ? ModelSectionType : ModelBodySectionType;
+                    return (nestedType != UndefinedSectionType) ?
+                        ModelSectionType :
+                        ModelBodySectionType;
 
                 default:
                     break;
@@ -388,7 +446,8 @@ namespace snowcrash
         static bool isAbbreviated(SectionType sectionType)
         {
 
-            return (sectionType == RequestBodySectionType || sectionType == ResponseBodySectionType
+            return (sectionType == RequestBodySectionType
+                || sectionType == ResponseBodySectionType
                 || sectionType == ModelBodySectionType);
         }
 
@@ -423,13 +482,15 @@ namespace snowcrash
                     return true;
             }
 
-            if (RegexCapture(signature, regex, captureGroups, 5) && !captureGroups.empty()) {
+            if (RegexCapture(signature, regex, captureGroups, 5)
+                && !captureGroups.empty()) {
 
                 mdp::ByteBuffer target = signature;
                 mdp::ByteBuffer::size_type pos = target.find(captureGroups[0]);
 
                 if (pos != mdp::ByteBuffer::npos) {
-                    target.replace(pos, captureGroups[0].length(), mdp::ByteBuffer());
+                    target.replace(
+                        pos, captureGroups[0].length(), mdp::ByteBuffer());
                 }
 
                 TrimString(target);
@@ -437,7 +498,8 @@ namespace snowcrash
                 if (!target.empty()) {
                     // WARN: unable to parse payload signature
                     std::stringstream ss;
-                    ss << "unable to parse " << SectionName(pd.sectionContext()) << " signature, expected ";
+                    ss << "unable to parse " << SectionName(pd.sectionContext())
+                       << " signature, expected ";
 
                     switch (pd.sectionContext()) {
                         case RequestSectionType:
@@ -447,7 +509,8 @@ namespace snowcrash
 
                         case ResponseBodySectionType:
                         case ResponseSectionType:
-                            ss << "'response [<HTTP status code>] [(<media type>)]'";
+                            ss << "'response [<HTTP status code>] [(<media "
+                                  "type>)]'";
                             break;
 
                         case ModelSectionType:
@@ -460,17 +523,21 @@ namespace snowcrash
                     }
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), FormattingWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), FormattingWarning, sourceMap));
 
                     return false;
                 }
 
-                if (pd.sectionContext() == ModelSectionType || pd.sectionContext() == ModelBodySectionType) {
+                if (pd.sectionContext() == ModelSectionType
+                    || pd.sectionContext() == ModelBodySectionType) {
 
                     out.node.name = captureGroups[2];
                     mediaType = captureGroups[4];
-                } else if (pd.sectionContext() == RequestSectionType || pd.sectionContext() == RequestBodySectionType) {
+                } else if (pd.sectionContext() == RequestSectionType
+                    || pd.sectionContext() == RequestBodySectionType) {
 
                     out.node.name = captureGroups[1];
                     mediaType = captureGroups[4];
@@ -487,7 +554,8 @@ namespace snowcrash
                 }
 
                 if (!mediaType.empty()) {
-                    Header header = std::make_pair(HTTPHeaderName::ContentType, mediaType);
+                    Header header = std::make_pair(
+                        HTTPHeaderName::ContentType, mediaType);
                     out.node.headers.push_back(header);
 
                     if (pd.exportSourceMap()) {
@@ -505,7 +573,8 @@ namespace snowcrash
             return true;
         }
 
-        /** Given the reference id(name), initializes reference of the payload accordingly (if possible resolve it) */
+        /** Given the reference id(name), initializes reference of the payload
+         * accordingly (if possible resolve it) */
         static bool parseModelReference(const MarkdownNodeIterator& node,
             SectionParserData& pd,
             mdp::ByteBuffer& source,
@@ -545,41 +614,54 @@ namespace snowcrash
         }
 
         /**
-         *  \brief  Assigns the reference, referred as reference id(name), into the payload
+         *  \brief  Assigns the reference, referred as reference id(name), into
+         * the payload
          *  \param  pd       Section parser state
          *  \param  out      Processed output
          */
-        static void assingReferredPayload(SectionParserData& pd, const ParseResultRef<Payload>& out)
+        static void assingReferredPayload(
+            SectionParserData& pd, const ParseResultRef<Payload>& out)
         {
 
             SourceMap<ResourceModel> modelSM;
-            ResourceModel model = pd.modelTable.find(out.node.reference.id)->second;
+            ResourceModel model
+                = pd.modelTable.find(out.node.reference.id)->second;
 
             out.node.description = model.description;
             out.node.parameters = model.parameters;
 
-            HeaderIterator modelContentTypeIt = std::find_if(model.headers.begin(),
-                model.headers.end(),
-                std::bind2nd(MatchFirstWith<Header, std::string>(), HTTPHeaderName::ContentType));
+            HeaderIterator modelContentTypeIt
+                = std::find_if(model.headers.begin(),
+                    model.headers.end(),
+                    std::bind2nd(MatchFirstWith<Header, std::string>(),
+                        HTTPHeaderName::ContentType));
 
             bool isPayloadContentType = !out.node.headers.empty();
             bool isModelContentType = modelContentTypeIt != model.headers.end();
 
             if (isPayloadContentType && isModelContentType) {
 
-                // WARN: Ignoring payload content-type, when referencing a model with headers
+                // WARN: Ignoring payload content-type, when referencing a model
+                // with headers
                 std::stringstream ss;
 
-                ss << "ignoring additional " << SectionName(pd.sectionContext()) << " header(s), ";
-                ss << "specify this header(s) in the referenced model definition instead";
+                ss << "ignoring additional " << SectionName(pd.sectionContext())
+                   << " header(s), ";
+                ss << "specify this header(s) in the referenced model "
+                      "definition instead";
 
-                mdp::CharactersRangeSet sourceMap = mdp::BytesRangeSetToCharactersRangeSet(
-                    out.node.reference.meta.node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                mdp::CharactersRangeSet sourceMap
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        out.node.reference.meta.node->sourceMap,
+                        pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), IgnoringWarning, sourceMap));
             }
 
             if (isPayloadContentType && !isModelContentType) {
-                out.node.headers.insert(out.node.headers.end(), model.headers.begin(), model.headers.end());
+                out.node.headers.insert(out.node.headers.end(),
+                    model.headers.begin(),
+                    model.headers.end());
             } else {
                 out.node.headers = model.headers;
             }
@@ -597,7 +679,8 @@ namespace snowcrash
                 out.sourceMap.schema = modelSM.schema;
 
                 if (isPayloadContentType && !isModelContentType) {
-                    out.sourceMap.headers.collection.insert(out.sourceMap.headers.collection.end(),
+                    out.sourceMap.headers.collection.insert(
+                        out.sourceMap.headers.collection.end(),
                         modelSM.headers.collection.begin(),
                         modelSM.headers.collection.end());
                 } else {
@@ -612,8 +695,9 @@ namespace snowcrash
          *  \param  pd       Section parser state
          *  \param  out      Processed output
          */
-        static void checkRequest(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Payload>& out)
+        static void checkRequest(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Payload>& out)
         {
 
             bool warnEmptyBody = false;
@@ -621,7 +705,9 @@ namespace snowcrash
             mdp::ByteBuffer contentLength;
             mdp::ByteBuffer transferEncoding;
 
-            for (HeaderIterator it = out.node.headers.begin(); it != out.node.headers.end(); ++it) {
+            for (HeaderIterator it = out.node.headers.begin();
+                 it != out.node.headers.end();
+                 ++it) {
 
                 if (it->first == HTTPHeaderName::ContentLength) {
                     contentLength = it->second;
@@ -635,30 +721,36 @@ namespace snowcrash
             if (out.node.body.empty() && out.node.attributes.empty()
                 && out.node.reference.meta.state != Reference::StatePending) {
 
-                // Warn when content-length or transfer-encoding is specified or headers, parameters and body are empty
+                // Warn when content-length or transfer-encoding is specified or
+                // headers, parameters and body are empty
                 if (out.node.headers.empty() && out.node.parameters.empty()) {
                     warnEmptyBody = true;
                 } else {
-                    warnEmptyBody = !contentLength.empty() || !transferEncoding.empty();
+                    warnEmptyBody
+                        = !contentLength.empty() || !transferEncoding.empty();
                 }
 
                 if (warnEmptyBody) {
 
                     // WARN: empty body
                     std::stringstream ss;
-                    ss << "empty " << SectionName(RequestSectionType) << " " << SectionName(BodySectionType);
+                    ss << "empty " << SectionName(RequestSectionType) << " "
+                       << SectionName(BodySectionType);
 
                     if (!contentLength.empty()) {
-                        ss << ", expected " << SectionName(BodySectionType) << " for '" << contentLength
-                           << "' Content-Length";
+                        ss << ", expected " << SectionName(BodySectionType)
+                           << " for '" << contentLength << "' Content-Length";
                     } else if (!transferEncoding.empty()) {
-                        ss << ", expected " << SectionName(BodySectionType) << " for '" << transferEncoding
+                        ss << ", expected " << SectionName(BodySectionType)
+                           << " for '" << transferEncoding
                            << "' Transfer-Encoding";
                     }
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
                 }
             }
         }
@@ -669,8 +761,9 @@ namespace snowcrash
          *  \param  pd       Section parser state
          *  \param  out      Processed output
          */
-        static void checkResponse(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Payload>& out)
+        static void checkResponse(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Payload>& out)
         {
 
             HTTPStatusCode code = 200;
@@ -686,11 +779,14 @@ namespace snowcrash
 
                 // WARN: not empty body
                 std::stringstream ss;
-                ss << "the " << code << " response MUST NOT include a " << SectionName(BodySectionType);
+                ss << "the " << code << " response MUST NOT include a "
+                   << SectionName(BodySectionType);
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), EmptyDefinitionWarning, sourceMap));
             }
         }
 
@@ -698,26 +794,32 @@ namespace snowcrash
          *  \brief  Find a request within given action.
          *  \param  transaction  A transaction to check.
          *  \param  request A request to look for.
-         *  \return Iterator pointing to the matching request within given method requests.
+         *  \return Iterator pointing to the matching request within given
+         * method requests.
          */
-        static RequestIterator findRequest(const TransactionExample& example, const Request& request)
+        static RequestIterator findRequest(
+            const TransactionExample& example, const Request& request)
         {
 
-            return std::find_if(
-                example.requests.begin(), example.requests.end(), std::bind2nd(MatchPayload(), request));
+            return std::find_if(example.requests.begin(),
+                example.requests.end(),
+                std::bind2nd(MatchPayload(), request));
         }
 
         /**
          *  \brief  Find a response within responses of a given action.
          *  \param  transaction  A transaction to check.
          *  \param  response A response to look for.
-         *  \return Iterator pointing to the matching response within given method requests.
+         *  \return Iterator pointing to the matching response within given
+         * method requests.
          */
-        static ResponseIterator findResponse(const TransactionExample& example, const Response& response)
+        static ResponseIterator findResponse(
+            const TransactionExample& example, const Response& response)
         {
 
-            return std::find_if(
-                example.responses.begin(), example.responses.end(), std::bind2nd(MatchPayload(), response));
+            return std::find_if(example.responses.begin(),
+                example.responses.end(),
+                std::bind2nd(MatchPayload(), response));
         }
     };
 

--- a/src/RegexMatch.h
+++ b/src/RegexMatch.h
@@ -19,16 +19,20 @@ namespace snowcrash
     // returns true if target string matches given expression, false otherwise
     bool RegexMatch(const std::string& target, const std::string& expression);
 
-    // Performs posix-regex and returns first captured group (excluding whole target)
-    std::string RegexCaptureFirst(const std::string& target, const std::string& expression);
+    // Performs posix-regex and returns first captured group (excluding whole
+    // target)
+    std::string RegexCaptureFirst(
+        const std::string& target, const std::string& expression);
 
     // Array of capture groups
     typedef std::vector<std::string> CaptureGroups;
 
     // Performs posix-regex
     // returns true if target string matches given expression, false otherwise
-    bool RegexCapture(
-        const std::string& target, const std::string& expression, CaptureGroups& captureGroups, size_t groupSize = 8);
+    bool RegexCapture(const std::string& target,
+        const std::string& expression,
+        CaptureGroups& captureGroups,
+        size_t groupSize = 8);
 }
 
 #endif

--- a/src/RelationParser.h
+++ b/src/RelationParser.h
@@ -21,7 +21,8 @@ namespace snowcrash
     /** Link Relation matching regex */
     const char* const RelationRegex = RELATION_REGEX;
 
-    const char* const RelationIdentifierRegex = RELATION_REGEX "[[:blank:]]*([a-z][a-z0-9.-]*)?[[:blank:]]*$";
+    const char* const RelationIdentifierRegex
+        = RELATION_REGEX "[[:blank:]]*([a-z][a-z0-9.-]*)?[[:blank:]]*$";
 
     /**
      *  Relation Section Processor
@@ -29,7 +30,8 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Relation> : public SectionProcessorBase<Relation> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -42,15 +44,18 @@ namespace snowcrash
             signature = GetFirstLine(node->text, remainingContent);
             TrimString(signature);
 
-            if (RegexCapture(signature, RelationIdentifierRegex, captureGroups, 3)) {
+            if (RegexCapture(
+                    signature, RelationIdentifierRegex, captureGroups, 3)) {
                 out.node.str = captureGroups[1];
                 TrimString(out.node.str);
             } else {
                 // WARN: Relation identifier contains illegal characters
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 out.report.warnings.push_back(
-                    Warning("relation identifier contains illegal characters (only lower case letters, numbers, '-' "
+                    Warning("relation identifier contains illegal characters "
+                            "(only lower case letters, numbers, '-' "
                             "and '.' allowed)",
                         FormattingWarning,
                         sourceMap));
@@ -68,9 +73,11 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
-                mdp::ByteBuffer remaining, subject = node->children().front().text;
+                mdp::ByteBuffer remaining,
+                    subject = node->children().front().text;
 
                 subject = GetFirstLine(subject, remaining);
                 TrimString(subject);

--- a/src/ResourceGroupParser.h
+++ b/src/ResourceGroupParser.h
@@ -16,21 +16,26 @@
 namespace snowcrash
 {
 
-    const char* const GroupHeaderRegex = "^[[:blank:]]*[Gg]roup[[:blank:]]+" SYMBOL_IDENTIFIER "[[:blank:]]*$";
+    const char* const GroupHeaderRegex
+        = "^[[:blank:]]*[Gg]roup[[:blank:]]+" SYMBOL_IDENTIFIER "[[:blank:]]*$";
 
     /** Internal type alias for Collection iterator of Resource */
     typedef Collection<ResourceGroup>::const_iterator ResourceGroupIterator;
 
-    /** Resource iterator pair: its containment group and resource iterator itself */
-    typedef std::pair<ResourceGroupIterator, ResourceIterator> ResourceIteratorPair;
+    /** Resource iterator pair: its containment group and resource iterator
+     * itself */
+    typedef std::pair<ResourceGroupIterator, ResourceIterator>
+        ResourceIteratorPair;
 
     /**
      * ResourceGroup Section processor
      */
     template <>
-    struct SectionProcessor<ResourceGroup> : public SectionProcessorBase<ResourceGroup> {
+    struct SectionProcessor<ResourceGroup>
+        : public SectionProcessorBase<ResourceGroup> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -60,7 +65,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processDescription(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<ResourceGroup>& out)
@@ -69,7 +75,8 @@ namespace snowcrash
             // Check for a description child element
             if (out.node.content.elements().empty()
                 || (!out.node.content.elements().empty()
-                       && out.node.content.elements().back().element != Element::CopyElement)) {
+                       && out.node.content.elements().back().element
+                           != Element::CopyElement)) {
 
                 Element description(Element::CopyElement);
                 out.node.content.elements().push_back(description);
@@ -77,7 +84,8 @@ namespace snowcrash
                 if (pd.exportSourceMap()) {
 
                     SourceMap<Element> descriptionSM(Element::CopyElement);
-                    out.sourceMap.content.elements().collection.push_back(descriptionSM);
+                    out.sourceMap.content.elements().collection.push_back(
+                        descriptionSM);
                 }
             }
 
@@ -85,11 +93,14 @@ namespace snowcrash
                 TwoNewLines(out.node.content.elements().back().content.copy);
             }
 
-            mdp::ByteBuffer content = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
+            mdp::ByteBuffer content
+                = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
             TrimString(content);
 
             if (pd.exportSourceMap() && !content.empty()) {
-                out.sourceMap.content.elements().collection.back().content.copy.sourceMap.append(node->sourceMap);
+                out.sourceMap.content.elements()
+                    .collection.back()
+                    .content.copy.sourceMap.append(node->sourceMap);
             }
 
             out.node.content.elements().back().content.copy += content;
@@ -97,7 +108,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<ResourceGroup>& out)
@@ -110,21 +122,25 @@ namespace snowcrash
                 IntermediateParseResult<Resource> resource(out.report);
                 cur = ResourceParser::parse(node, siblings, pd, resource);
 
-                bool duplicate = SectionProcessor<Resource>::isResourceDuplicate(
-                    out.node.content.elements(), resource.node.uriTemplate);
+                bool duplicate
+                    = SectionProcessor<Resource>::isResourceDuplicate(
+                        out.node.content.elements(), resource.node.uriTemplate);
                 bool globalDuplicate;
 
                 if (!duplicate) {
-                    globalDuplicate = isResourceDuplicate(pd.blueprint, resource.node.uriTemplate);
+                    globalDuplicate = isResourceDuplicate(
+                        pd.blueprint, resource.node.uriTemplate);
                 }
 
                 if (duplicate || globalDuplicate) {
 
                     // WARN: Duplicate resource
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     out.report.warnings.push_back(
-                        Warning("the resource '" + resource.node.uriTemplate + "' is already defined",
+                        Warning("the resource '" + resource.node.uriTemplate
+                                + "' is already defined",
                             DuplicateWarning,
                             sourceMap));
                 }
@@ -136,48 +152,59 @@ namespace snowcrash
 
                 if (pd.exportSourceMap()) {
 
-                    SourceMap<Element> resourceElementSM(Element::ResourceElement);
+                    SourceMap<Element> resourceElementSM(
+                        Element::ResourceElement);
                     resourceElementSM.content.resource = resource.sourceMap;
 
-                    out.sourceMap.content.elements().collection.push_back(resourceElementSM);
+                    out.sourceMap.content.elements().collection.push_back(
+                        resourceElementSM);
                 }
             }
 
             return cur;
         }
 
-        static MarkdownNodeIterator processUnexpectedNode(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processUnexpectedNode(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionType& lastSectionType,
             const ParseResultRef<ResourceGroup>& out)
         {
 
-            if (SectionProcessor<Action>::actionType(node) == DependentActionType
+            if (SectionProcessor<Action>::actionType(node)
+                    == DependentActionType
                 && isResourcePresent(out.node.content.elements())) {
 
                 mdp::ByteBuffer method, name, uriTemplate;
 
-                SectionProcessor<Action>::actionHTTPMethodAndName(node, method, name, uriTemplate);
+                SectionProcessor<Action>::actionHTTPMethodAndName(
+                    node, method, name, uriTemplate);
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
 
                 // WARN: Unexpected action
                 std::stringstream ss;
-                ss << "unexpected action '" << method << "', to define multiple actions for the '"
+                ss << "unexpected action '" << method
+                   << "', to define multiple actions for the '"
                    << lastResource(out.node.content.elements()).uriTemplate;
-                ss << "' resource omit the HTTP method in its definition, e.g. '# /resource'";
+                ss << "' resource omit the HTTP method in its definition, e.g. "
+                      "'# /resource'";
 
-                out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                out.report.warnings.push_back(
+                    Warning(ss.str(), IgnoringWarning, sourceMap));
 
                 return ++MarkdownNodeIterator(node);
             }
 
-            return SectionProcessorBase<ResourceGroup>::processUnexpectedNode(node, siblings, pd, lastSectionType, out);
+            return SectionProcessorBase<ResourceGroup>::processUnexpectedNode(
+                node, siblings, pd, lastSectionType, out);
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<ResourceGroup>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<ResourceGroup>& out)
         {
 
             out.node.element = Element::CategoryElement;
@@ -193,7 +220,8 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::HeaderMarkdownNodeType && !node->text.empty()) {
+            if (node->type == mdp::HeaderMarkdownNodeType
+                && !node->text.empty()) {
 
                 mdp::ByteBuffer subject = node->text;
                 TrimString(subject);
@@ -218,43 +246,53 @@ namespace snowcrash
             return { ResourceGroupSectionType, DataStructureGroupSectionType };
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
             mdp::ByteBuffer method;
 
-            if (SectionProcessor<Action>::actionType(node) == CompleteActionType) {
+            if (SectionProcessor<Action>::actionType(node)
+                == CompleteActionType) {
                 return false;
             }
 
-            return SectionProcessorBase<ResourceGroup>::isDescriptionNode(node, sectionType);
+            return SectionProcessorBase<ResourceGroup>::isDescriptionNode(
+                node, sectionType);
         }
 
-        static bool isUnexpectedNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isUnexpectedNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            if (SectionProcessor<Action>::actionType(node) == DependentActionType) {
+            if (SectionProcessor<Action>::actionType(node)
+                == DependentActionType) {
                 return true;
             }
 
-            return SectionProcessorBase<ResourceGroup>::isUnexpectedNode(node, sectionType);
+            return SectionProcessorBase<ResourceGroup>::isUnexpectedNode(
+                node, sectionType);
         }
 
         /**
-         * \brief Given a blueprint, Check if a resource already exists with the given uri template
+         * \brief Given a blueprint, Check if a resource already exists with the
+         * given uri template
          *
          * \param blueprint The blueprint which is formed until now
          * \param uri The resource uri template to be checked
          */
-        static bool isResourceDuplicate(const Blueprint& blueprint, const URITemplate& uri)
+        static bool isResourceDuplicate(
+            const Blueprint& blueprint, const URITemplate& uri)
         {
 
-            for (Elements::const_iterator it = blueprint.content.elements().begin();
+            for (Elements::const_iterator it
+                 = blueprint.content.elements().begin();
                  it != blueprint.content.elements().end();
                  ++it) {
 
                 if (it->element == Element::CategoryElement
-                    && SectionProcessor<Resource>::isResourceDuplicate(it->content.elements(), uri)) {
+                    && SectionProcessor<Resource>::isResourceDuplicate(
+                           it->content.elements(), uri)) {
 
                     return true;
                 }
@@ -264,14 +302,17 @@ namespace snowcrash
         }
 
         /**
-         * \brief Given list of elements, return true if none of them is a resource element
+         * \brief Given list of elements, return true if none of them is a
+         * resource element
          *
          * \param elements Collection of elements
          */
         static bool isResourcePresent(const Elements& elements)
         {
 
-            for (Elements::const_iterator it = elements.begin(); it != elements.end(); ++it) {
+            for (Elements::const_iterator it = elements.begin();
+                 it != elements.end();
+                 ++it) {
 
                 if (it->element == Element::ResourceElement) {
                     return false;
@@ -291,7 +332,9 @@ namespace snowcrash
 
             Resource last;
 
-            for (Elements::const_iterator it = elements.begin(); it != elements.end(); ++it) {
+            for (Elements::const_iterator it = elements.begin();
+                 it != elements.end();
+                 ++it) {
 
                 if (it->element == Element::ResourceElement) {
                     last = it->content.resource;
@@ -303,7 +346,8 @@ namespace snowcrash
     };
 
     /** ResourceGroup Section Parser */
-    typedef SectionParser<ResourceGroup, HeaderSectionAdapter> ResourceGroupParser;
+    typedef SectionParser<ResourceGroup, HeaderSectionAdapter>
+        ResourceGroupParser;
 }
 
 #endif

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -21,14 +21,18 @@ namespace snowcrash
 {
 
     /** Nameless resource matching regex */
-    const char* const ResourceHeaderRegex = "^[[:blank:]]*(" HTTP_REQUEST_METHOD "[[:blank:]]+)?" URI_TEMPLATE "$";
+    const char* const ResourceHeaderRegex = "^[[:blank:]]*(" HTTP_REQUEST_METHOD
+                                            "[[:blank:]]+)?" URI_TEMPLATE "$";
 
     /** Named resource matching regex */
-    const char* const NamedResourceHeaderRegex = "^[[:blank:]]*" SYMBOL_IDENTIFIER "[[:blank:]]+\\[" URI_TEMPLATE "]$";
+    const char* const NamedResourceHeaderRegex
+        = "^[[:blank:]]*" SYMBOL_IDENTIFIER "[[:blank:]]+\\[" URI_TEMPLATE "]$";
 
     /** Named endpoint matching regex */
     const char* const NamedEndpointHeaderRegex
-        = "^[[:blank:]]*" SYMBOL_IDENTIFIER "[[:blank:]]+\\[" HTTP_REQUEST_METHOD "[[:blank:]]+" URI_TEMPLATE "]$";
+        = "^[[:blank:]]*" SYMBOL_IDENTIFIER
+          "[[:blank:]]+\\[" HTTP_REQUEST_METHOD "[[:blank:]]+" URI_TEMPLATE
+          "]$";
 
     /** Internal type alias for Collection iterator of Resource */
     typedef Collection<Resource>::const_iterator ResourceIterator;
@@ -39,7 +43,8 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Resource> : public SectionProcessorBase<Resource> {
 
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -49,21 +54,27 @@ namespace snowcrash
             CaptureGroups captureGroups;
 
             // If Abbreviated resource section
-            if (RegexCapture(node->text, ResourceHeaderRegex, captureGroups, 4)) {
+            if (RegexCapture(
+                    node->text, ResourceHeaderRegex, captureGroups, 4)) {
 
                 out.node.uriTemplate = captureGroups[3];
 
                 // Make this section an action
                 if (!captureGroups[2].empty()) {
-                    return processNestedAction(node, node->parent().children(), pd, layout, out);
+                    return processNestedAction(
+                        node, node->parent().children(), pd, layout, out);
                 }
-            } else if (RegexCapture(node->text, NamedEndpointHeaderRegex, captureGroups, 5)) {
+            } else if (RegexCapture(node->text,
+                           NamedEndpointHeaderRegex,
+                           captureGroups,
+                           5)) {
 
                 out.node.name = captureGroups[1];
                 TrimString(out.node.name);
                 out.node.uriTemplate = captureGroups[3];
 
-                return processNestedAction(node, node->parent().children(), pd, layout, out);
+                return processNestedAction(
+                    node, node->parent().children(), pd, layout, out);
             } else {
                 matchNamedResourceHeader(node, out.node);
             }
@@ -81,7 +92,8 @@ namespace snowcrash
             return ++MarkdownNodeIterator(node);
         }
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Resource>& out)
@@ -99,8 +111,10 @@ namespace snowcrash
                     return processModel(node, siblings, pd, out);
 
                 case HeadersSectionType: {
-                    ParseResultRef<Headers> headers(out.report, out.node.headers, out.sourceMap.headers);
-                    return SectionProcessor<Action>::handleDeprecatedHeaders(node, siblings, pd, headers);
+                    ParseResultRef<Headers> headers(
+                        out.report, out.node.headers, out.sourceMap.headers);
+                    return SectionProcessor<Action>::handleDeprecatedHeaders(
+                        node, siblings, pd, headers);
                 }
 
                 case AttributesSectionType: {
@@ -109,25 +123,34 @@ namespace snowcrash
                         pd.namedTypeContext = out.node.name;
                     }
 
-                    ParseResultRef<Attributes> attributes(out.report, out.node.attributes, out.sourceMap.attributes);
-                    MarkdownNodeIterator cur = AttributesParser::parse(node, siblings, pd, attributes);
+                    ParseResultRef<Attributes> attributes(out.report,
+                        out.node.attributes,
+                        out.sourceMap.attributes);
+                    MarkdownNodeIterator cur = AttributesParser::parse(
+                        node, siblings, pd, attributes);
 
                     // Clear named type context
                     pd.namedTypeContext.clear();
 
                     if (!out.node.name.empty()) {
 
-                        if (SectionProcessor<DataStructureGroup>::isNamedTypeDuplicate(pd.blueprint, out.node.name)) {
+                        if (SectionProcessor<DataStructureGroup>::
+                                isNamedTypeDuplicate(
+                                    pd.blueprint, out.node.name)) {
 
                             // WARN: duplicate named type
                             std::stringstream ss;
-                            ss << "named type with name '" << out.node.name << "' already exists";
+                            ss << "named type with name '" << out.node.name
+                               << "' already exists";
 
                             mdp::CharactersRangeSet sourceMap
-                                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                            out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                                = mdp::BytesRangeSetToCharactersRangeSet(
+                                    node->sourceMap, pd.sourceCharacterIndex);
+                            out.report.warnings.push_back(
+                                Warning(ss.str(), DuplicateWarning, sourceMap));
 
-                            // Remove the attributes data from the AST since we are ignoring this
+                            // Remove the attributes data from the AST since we
+                            // are ignoring this
                             out.node.attributes = mson::NamedType();
 
                             return cur;
@@ -136,7 +159,8 @@ namespace snowcrash
                         attributes.node.name.symbol.literal = out.node.name;
 
                         if (pd.exportSourceMap()) {
-                            attributes.sourceMap.name.sourceMap = out.sourceMap.name.sourceMap;
+                            attributes.sourceMap.name.sourceMap
+                                = out.sourceMap.name.sourceMap;
                         }
                     }
 
@@ -150,61 +174,72 @@ namespace snowcrash
             return node;
         }
 
-        static MarkdownNodeIterator processUnexpectedNode(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processUnexpectedNode(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionType& sectionType,
             const ParseResultRef<Resource>& out)
         {
 
-            if ((node->type == mdp::ParagraphMarkdownNodeType || node->type == mdp::CodeMarkdownNodeType)
-                && (sectionType == ModelBodySectionType || sectionType == ModelSectionType)) {
+            if ((node->type == mdp::ParagraphMarkdownNodeType
+                    || node->type == mdp::CodeMarkdownNodeType)
+                && (sectionType == ModelBodySectionType
+                       || sectionType == ModelSectionType)) {
 
-                mdp::ByteBuffer content
-                    = CodeBlockUtility::addDanglingAsset(node, pd, sectionType, out.report, out.node.model.body);
+                mdp::ByteBuffer content = CodeBlockUtility::addDanglingAsset(
+                    node, pd, sectionType, out.report, out.node.model.body);
 
                 if (pd.exportSourceMap() && !content.empty()) {
                     out.sourceMap.model.body.sourceMap.append(node->sourceMap);
                 }
 
                 // Update model in the model table as well
-                ModelTable::iterator it = pd.modelTable.find(out.node.model.name);
+                ModelTable::iterator it
+                    = pd.modelTable.find(out.node.model.name);
 
                 if (it != pd.modelTable.end()) {
                     it->second.body = out.node.model.body;
 
                     if (pd.exportSourceMap()) {
-                        pd.modelSourceMapTable[out.node.model.name].body = out.sourceMap.model.body;
+                        pd.modelSourceMapTable[out.node.model.name].body
+                            = out.sourceMap.model.body;
                     }
                 }
 
                 return ++MarkdownNodeIterator(node);
             }
 
-            return SectionProcessorBase<Resource>::processUnexpectedNode(node, siblings, pd, sectionType, out);
+            return SectionProcessorBase<Resource>::processUnexpectedNode(
+                node, siblings, pd, sectionType, out);
         }
 
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
-            if (SectionProcessor<Action>::actionType(node) == CompleteActionType) {
+            if (SectionProcessor<Action>::actionType(node)
+                == CompleteActionType) {
                 return false;
             }
 
-            return SectionProcessorBase<Resource>::isDescriptionNode(node, sectionType);
+            return SectionProcessorBase<Resource>::isDescriptionNode(
+                node, sectionType);
         }
 
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::HeaderMarkdownNodeType && !node->text.empty()) {
+            if (node->type == mdp::HeaderMarkdownNodeType
+                && !node->text.empty()) {
 
                 CaptureGroups captureGroups;
                 mdp::ByteBuffer subject = node->text;
 
                 TrimString(subject);
 
-                if (RegexMatch(subject, NamedResourceHeaderRegex) || RegexMatch(subject, NamedEndpointHeaderRegex)
+                if (RegexMatch(subject, NamedResourceHeaderRegex)
+                    || RegexMatch(subject, NamedEndpointHeaderRegex)
                     || RegexMatch(subject, ResourceHeaderRegex)) {
                     return ResourceSectionType;
                 }
@@ -235,7 +270,8 @@ namespace snowcrash
             // Check if model section
             nestedType = SectionProcessor<Payload>::sectionType(node);
 
-            if (nestedType == ModelSectionType || nestedType == ModelBodySectionType) {
+            if (nestedType == ModelSectionType
+                || nestedType == ModelBodySectionType) {
 
                 return nestedType;
             }
@@ -254,7 +290,8 @@ namespace snowcrash
 
                 // Do not consider complete actions as nested
                 mdp::ByteBuffer method;
-                if (SectionProcessor<Action>::actionType(node) == CompleteActionType)
+                if (SectionProcessor<Action>::actionType(node)
+                    == CompleteActionType)
                     return UndefinedSectionType;
 
                 return nestedType;
@@ -265,11 +302,14 @@ namespace snowcrash
 
         static SectionTypes upperSectionTypes()
         {
-            return { ResourceGroupSectionType, ResourceSectionType, DataStructureGroupSectionType };
+            return { ResourceGroupSectionType,
+                ResourceSectionType,
+                DataStructureGroupSectionType };
         }
 
-        static void finalize(
-            const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<Resource>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<Resource>& out)
         {
 
             if (!out.node.uriTemplate.empty()) {
@@ -277,9 +317,11 @@ namespace snowcrash
                 URITemplateParser uriTemplateParser;
                 ParsedURITemplate parsedResult;
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
 
-                uriTemplateParser.parse(out.node.uriTemplate, sourceMap, parsedResult);
+                uriTemplateParser.parse(
+                    out.node.uriTemplate, sourceMap, parsedResult);
 
                 if (!parsedResult.report.warnings.empty()) {
                     out.report += parsedResult.report;
@@ -289,13 +331,19 @@ namespace snowcrash
             // Consolidate deprecated headers into subsequent payloads
             if (!out.node.headers.empty()) {
 
-                Collection<Action>::iterator actionIt = out.node.actions.begin();
-                Collection<SourceMap<Action> >::iterator actionSMIt = out.sourceMap.actions.collection.begin();
+                Collection<Action>::iterator actionIt
+                    = out.node.actions.begin();
+                Collection<SourceMap<Action> >::iterator actionSMIt
+                    = out.sourceMap.actions.collection.begin();
 
-                for (; actionIt != out.node.actions.end(); ++actionIt, ++actionSMIt) {
+                for (; actionIt != out.node.actions.end();
+                     ++actionIt, ++actionSMIt) {
 
-                    SectionProcessor<Headers>::injectDeprecatedHeaders(
-                        pd, out.node.headers, out.sourceMap.headers, actionIt->examples, actionSMIt->examples);
+                    SectionProcessor<Headers>::injectDeprecatedHeaders(pd,
+                        out.node.headers,
+                        out.sourceMap.headers,
+                        actionIt->examples,
+                        actionSMIt->examples);
                 }
 
                 out.node.headers.clear();
@@ -307,17 +355,20 @@ namespace snowcrash
         }
 
         /**
-         * \brief Given a named resource header, retrieve the name and uriTemplate
+         * \brief Given a named resource header, retrieve the name and
+         * uriTemplate
          *
          * \param node Markdown node to process
          * \param resource Resource data structure
          */
-        static void matchNamedResourceHeader(const MarkdownNodeIterator& node, Resource& resource)
+        static void matchNamedResourceHeader(
+            const MarkdownNodeIterator& node, Resource& resource)
         {
 
             CaptureGroups captureGroups;
 
-            if (RegexCapture(node->text, NamedResourceHeaderRegex, captureGroups, 4)) {
+            if (RegexCapture(
+                    node->text, NamedResourceHeaderRegex, captureGroups, 4)) {
 
                 resource.name = captureGroups[1];
                 TrimString(resource.name);
@@ -328,7 +379,8 @@ namespace snowcrash
         /**
          * \brief Parse the current node as an action
          */
-        static MarkdownNodeIterator processNestedAction(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedAction(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -336,7 +388,8 @@ namespace snowcrash
         {
 
             IntermediateParseResult<Action> action(out.report);
-            MarkdownNodeIterator cur = ActionParser::parse(node, siblings, pd, action);
+            MarkdownNodeIterator cur
+                = ActionParser::parse(node, siblings, pd, action);
 
             out.node.actions.push_back(action.node);
             layout = RedirectSectionLayout;
@@ -350,46 +403,58 @@ namespace snowcrash
         }
 
         /** Process Action section */
-        static MarkdownNodeIterator processAction(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processAction(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Resource>& out)
         {
 
             IntermediateParseResult<Action> action(out.report);
-            MarkdownNodeIterator cur = ActionParser::parse(node, siblings, pd, action);
+            MarkdownNodeIterator cur
+                = ActionParser::parse(node, siblings, pd, action);
 
-            ActionIterator duplicate = SectionProcessor<Action>::findAction(out.node.actions, action.node);
+            ActionIterator duplicate = SectionProcessor<Action>::findAction(
+                out.node.actions, action.node);
 
             if (duplicate != out.node.actions.end()) {
 
                 // WARN: duplicate method
                 std::stringstream ss;
-                ss << "action with method '" << action.node.method << "' already defined for resource '";
+                ss << "action with method '" << action.node.method
+                   << "' already defined for resource '";
                 ss << out.node.uriTemplate << "'";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), DuplicateWarning, sourceMap));
             }
 
             ActionIterator relationDuplicate
-                = SectionProcessor<Action>::findRelation(out.node.actions, action.node.relation);
+                = SectionProcessor<Action>::findRelation(
+                    out.node.actions, action.node.relation);
 
             if (relationDuplicate != out.node.actions.end()) {
 
                 // WARN: duplicate relation identifier
                 std::stringstream ss;
-                ss << "relation identifier '" << action.node.relation.str << "' already defined for resource '"
-                   << out.node.uriTemplate << "'";
+                ss << "relation identifier '" << action.node.relation.str
+                   << "' already defined for resource '" << out.node.uriTemplate
+                   << "'";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), DuplicateWarning, sourceMap));
             }
 
-            if (!action.node.parameters.empty() && action.node.uriTemplate.empty()) {
-                checkParametersEligibility<Resource>(node, pd, action.node.parameters, out);
+            if (!action.node.parameters.empty()
+                && action.node.uriTemplate.empty()) {
+                checkParametersEligibility<Resource>(
+                    node, pd, action.node.parameters, out);
             }
 
             out.node.actions.push_back(action.node);
@@ -402,7 +467,8 @@ namespace snowcrash
         }
 
         /** Process Parameters section */
-        static MarkdownNodeIterator processParameters(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processParameters(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Resource>& out)
@@ -410,15 +476,20 @@ namespace snowcrash
 
             IntermediateParseResult<Parameters> parameters(out.report);
 
-            MarkdownNodeIterator cur = ParametersParser::parse(node, siblings, pd, parameters);
+            MarkdownNodeIterator cur
+                = ParametersParser::parse(node, siblings, pd, parameters);
 
             if (!parameters.node.empty()) {
 
-                checkParametersEligibility<Resource>(node, pd, parameters.node, out);
-                out.node.parameters.insert(out.node.parameters.end(), parameters.node.begin(), parameters.node.end());
+                checkParametersEligibility<Resource>(
+                    node, pd, parameters.node, out);
+                out.node.parameters.insert(out.node.parameters.end(),
+                    parameters.node.begin(),
+                    parameters.node.end());
 
                 if (pd.exportSourceMap()) {
-                    out.sourceMap.parameters.collection.insert(out.sourceMap.parameters.collection.end(),
+                    out.sourceMap.parameters.collection.insert(
+                        out.sourceMap.parameters.collection.end(),
                         parameters.sourceMap.collection.begin(),
                         parameters.sourceMap.collection.end());
                 }
@@ -428,7 +499,8 @@ namespace snowcrash
         }
 
         /** Process Model section */
-        static MarkdownNodeIterator processModel(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processModel(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Resource>& out)
@@ -436,7 +508,8 @@ namespace snowcrash
 
             IntermediateParseResult<Payload> model(out.report);
 
-            MarkdownNodeIterator cur = PayloadParser::parse(node, siblings, pd, model);
+            MarkdownNodeIterator cur
+                = PayloadParser::parse(node, siblings, pd, model);
 
             // Check whether there isn't a model already
             if (!out.node.model.name.empty()) {
@@ -451,11 +524,14 @@ namespace snowcrash
                     ss << out.node.uriTemplate;
                 }
 
-                ss << "' resource, a resource can be represented by a single model only";
+                ss << "' resource, a resource can be represented by a single "
+                      "model only";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                out.report.warnings.push_back(Warning(ss.str(), DuplicateWarning, sourceMap));
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
+                out.report.warnings.push_back(
+                    Warning(ss.str(), DuplicateWarning, sourceMap));
             }
 
             if (model.node.name.empty()) {
@@ -470,11 +546,14 @@ namespace snowcrash
 
                     // ERR: No name specified for resource model
                     std::stringstream ss;
-                    ss << "resource model can be specified only for a named resource";
-                    ss << ", name your resource, e.g. '# <resource name> [" << out.node.uriTemplate << "]'";
+                    ss << "resource model can be specified only for a named "
+                          "resource";
+                    ss << ", name your resource, e.g. '# <resource name> ["
+                       << out.node.uriTemplate << "]'";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     out.report.error = Error(ss.str(), ModelError, sourceMap);
                 }
             }
@@ -495,7 +574,8 @@ namespace snowcrash
                 ss << "symbol '" << model.node.name << "' already defined";
 
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        node->sourceMap, pd.sourceCharacterIndex);
                 out.report.error = Error(ss.str(), ModelError, sourceMap);
             }
 
@@ -509,17 +589,22 @@ namespace snowcrash
         }
 
         /**
-         * \brief Given a list of elements, Check if a resource already exists with the given uri template
+         * \brief Given a list of elements, Check if a resource already exists
+         * with the given uri template
          *
          * \param elements Collection of elements
          * \param uri The resource uri template to be checked
          */
-        static bool isResourceDuplicate(const Elements& elements, const URITemplate& uri)
+        static bool isResourceDuplicate(
+            const Elements& elements, const URITemplate& uri)
         {
 
-            for (Elements::const_iterator it = elements.begin(); it != elements.end(); ++it) {
+            for (Elements::const_iterator it = elements.begin();
+                 it != elements.end();
+                 ++it) {
 
-                if (it->element == Element::ResourceElement && it->content.resource.uriTemplate == uri) {
+                if (it->element == Element::ResourceElement
+                    && it->content.resource.uriTemplate == uri) {
 
                     return true;
                 }

--- a/src/Section.h
+++ b/src/Section.h
@@ -19,40 +19,43 @@ namespace snowcrash
      */
     enum SectionType
     {
-        UndefinedSectionType = 0,       /// < Undefined section
-        BlueprintSectionType,           /// < Blueprint overview
-        DataStructureGroupSectionType,  /// < Data Structure Group
-        ResourceGroupSectionType,       /// < Resource group
-        ResourceSectionType,            /// < Resource
-        ActionSectionType,              /// < Action
-        RelationSectionType,            /// < Link Relation
-        RequestSectionType,             /// < Request
-        RequestBodySectionType,         /// < Request & Payload body combined (abbrev)
-        ResponseSectionType,            /// < Response
-        ResponseBodySectionType,        /// < Response & Body combined (abbrev)
-        AttributesSectionType,          /// < Attributes
-        ModelSectionType,               /// < Model
-        ModelBodySectionType,           /// < Model & Body combined (abbrev)
-        BodySectionType,                /// < Payload Body
-        DanglingBodySectionType,        /// < Dangling Body (unrecognised section considered to be Body)
-        SchemaSectionType,              /// < Payload Schema
-        DanglingSchemaSectionType,      /// < Dangling Schema (unrecognised section considered to be Schema)
-        HeadersSectionType,             /// < Headers
-        ForeignSectionType,             /// < Foreign, unexpected section
-        ParametersSectionType,          /// < Parameters
-        ParameterSectionType,           /// < One Parameter definition
-        MSONParameterSectionType,       /// < One Parameter definition using the MSON syntax
-        ValuesSectionType,              /// < Value enumeration
-        ValueSectionType,               /// < One Value
-        MSONMixinSectionType,           /// < MSON Mixin
-        MSONNamedTypeSectionType,       /// < MSON Named Type
-        MSONOneOfSectionType,           /// < MSON One Of
+        UndefinedSectionType = 0,      /// < Undefined section
+        BlueprintSectionType,          /// < Blueprint overview
+        DataStructureGroupSectionType, /// < Data Structure Group
+        ResourceGroupSectionType,      /// < Resource group
+        ResourceSectionType,           /// < Resource
+        ActionSectionType,             /// < Action
+        RelationSectionType,           /// < Link Relation
+        RequestSectionType,            /// < Request
+        RequestBodySectionType,  /// < Request & Payload body combined (abbrev)
+        ResponseSectionType,     /// < Response
+        ResponseBodySectionType, /// < Response & Body combined (abbrev)
+        AttributesSectionType,   /// < Attributes
+        ModelSectionType,        /// < Model
+        ModelBodySectionType,    /// < Model & Body combined (abbrev)
+        BodySectionType,         /// < Payload Body
+        DanglingBodySectionType, /// < Dangling Body (unrecognised section
+                                 /// considered to be Body)
+        SchemaSectionType,       /// < Payload Schema
+        DanglingSchemaSectionType, /// < Dangling Schema (unrecognised section
+                                   /// considered to be Schema)
+        HeadersSectionType,        /// < Headers
+        ForeignSectionType,        /// < Foreign, unexpected section
+        ParametersSectionType,     /// < Parameters
+        ParameterSectionType,      /// < One Parameter definition
+        MSONParameterSectionType,  /// < One Parameter definition using the MSON
+                                   /// syntax
+        ValuesSectionType,         /// < Value enumeration
+        ValueSectionType,          /// < One Value
+        MSONMixinSectionType,      /// < MSON Mixin
+        MSONNamedTypeSectionType,  /// < MSON Named Type
+        MSONOneOfSectionType,      /// < MSON One Of
         MSONPropertyMemberSectionType,  /// < MSON Property Member Type
         MSONSampleDefaultSectionType,   /// < MSON Sample/Default Type Section
         MSONPropertyMembersSectionType, /// < MSON Property Members Type Section
         MSONValueMembersSectionType,    /// < MSON Value Members Type Section
         MSONValueMemberSectionType,     /// < MSON Value Member Type
-        MSONSectionType                 /// < MSON Property Member or Value Member
+        MSONSectionType /// < MSON Property Member or Value Member
     };
 
     /** \return Human readable name for given %SectionType */

--- a/src/SectionParser.h
+++ b/src/SectionParser.h
@@ -37,11 +37,13 @@ namespace snowcrash
 
             SectionLayout layout = DefaultSectionLayout;
             MarkdownNodeIterator cur = Adapter::startingNode(node, pd);
-            const MarkdownNodes& collection = Adapter::startingNodeSiblings(node, siblings);
+            const MarkdownNodes& collection
+                = Adapter::startingNodeSiblings(node, siblings);
 
             // Signature node
             MarkdownNodeIterator lastCur = cur;
-            cur = SectionProcessor<T>::processSignature(cur, collection, pd, layout, out);
+            cur = SectionProcessor<T>::processSignature(
+                cur, collection, pd, layout, out);
 
             // Exclusive Nested Sections Layout
             if (layout == ExclusiveNestedSectionLayout) {
@@ -65,20 +67,26 @@ namespace snowcrash
                 return Adapter::nextStartingNode(node, siblings, cur);
 
             // Description nodes
-            while (cur != collection.end() && SectionProcessor<T>::isDescriptionNode(cur, pd.sectionContext())) {
+            while (cur != collection.end()
+                && SectionProcessor<T>::isDescriptionNode(
+                       cur, pd.sectionContext())) {
 
                 lastCur = cur;
-                cur = SectionProcessor<T>::processDescription(cur, collection, pd, out);
+                cur = SectionProcessor<T>::processDescription(
+                    cur, collection, pd, out);
 
                 if (lastCur == cur)
                     return Adapter::nextStartingNode(node, siblings, cur);
             }
 
             // Content nodes
-            while (cur != collection.end() && SectionProcessor<T>::isContentNode(cur, pd.sectionContext())) {
+            while (
+                cur != collection.end() && SectionProcessor<T>::isContentNode(
+                                               cur, pd.sectionContext())) {
 
                 lastCur = cur;
-                cur = SectionProcessor<T>::processContent(cur, collection, pd, out);
+                cur = SectionProcessor<T>::processContent(
+                    cur, collection, pd, out);
 
                 if (lastCur == cur)
                     return Adapter::nextStartingNode(node, siblings, cur);
@@ -93,7 +101,8 @@ namespace snowcrash
         }
 
         /** Parse nested sections */
-        static MarkdownNodeIterator parseNestedSections(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator parseNestedSections(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& collection,
             SectionParserData& pd,
             const ParseResultRef<T>& out)
@@ -104,27 +113,33 @@ namespace snowcrash
 
             SectionType lastSectionType = UndefinedSectionType;
 
-            SectionProcessor<T>::preprocessNestedSections(node, collection, pd, out);
+            SectionProcessor<T>::preprocessNestedSections(
+                node, collection, pd, out);
 
             // Nested sections
             while (cur != collection.end()) {
 
                 lastCur = cur;
-                SectionType nestedType = SectionProcessor<T>::nestedSectionType(cur);
+                SectionType nestedType
+                    = SectionProcessor<T>::nestedSectionType(cur);
 
                 pd.sectionsContext.push_back(nestedType);
 
                 if (nestedType != UndefinedSectionType) {
-                    cur = SectionProcessor<T>::processNestedSection(cur, collection, pd, out);
+                    cur = SectionProcessor<T>::processNestedSection(
+                        cur, collection, pd, out);
                 } else if (Adapter::nextSkipsUnexpected
-                    || SectionProcessor<T>::isUnexpectedNode(cur, pd.sectionContext())) {
+                    || SectionProcessor<T>::isUnexpectedNode(
+                           cur, pd.sectionContext())) {
 
-                    cur = SectionProcessor<T>::processUnexpectedNode(cur, collection, pd, lastSectionType, out);
+                    cur = SectionProcessor<T>::processUnexpectedNode(
+                        cur, collection, pd, lastSectionType, out);
                 }
 
-                if (cur != collection.end() && (pd.sectionContext() != UndefinedSectionType
-                                                   || (cur->type != mdp::ParagraphMarkdownNodeType
-                                                          && cur->type != mdp::CodeMarkdownNodeType))) {
+                if (cur != collection.end()
+                    && (pd.sectionContext() != UndefinedSectionType
+                           || (cur->type != mdp::ParagraphMarkdownNodeType
+                                  && cur->type != mdp::CodeMarkdownNodeType))) {
 
                     lastSectionType = pd.sectionContext();
                 }
@@ -143,13 +158,17 @@ namespace snowcrash
     struct HeaderSectionAdapter {
 
         /** \return Node to start parsing with */
-        static const MarkdownNodeIterator startingNode(const MarkdownNodeIterator& seed, const SectionParserData& pd)
+        static const MarkdownNodeIterator startingNode(
+            const MarkdownNodeIterator& seed, const SectionParserData& pd)
         {
             if (seed->type != mdp::HeaderMarkdownNodeType) {
                 // ERR: Expected header
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(seed->sourceMap, pd.sourceCharacterIndex);
-                throw Error("expected header block, e.g. '# <text>'", BusinessError, sourceMap);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        seed->sourceMap, pd.sourceCharacterIndex);
+                throw Error("expected header block, e.g. '# <text>'",
+                    BusinessError,
+                    sourceMap);
             }
 
             return seed;
@@ -164,7 +183,9 @@ namespace snowcrash
 
         /** \return Starting node for next parsing */
         static const MarkdownNodeIterator nextStartingNode(
-            const MarkdownNodeIterator& seed, const MarkdownNodes& siblings, const MarkdownNodeIterator& cur)
+            const MarkdownNodeIterator& seed,
+            const MarkdownNodes& siblings,
+            const MarkdownNodeIterator& cur)
         {
             return cur;
         }
@@ -172,9 +193,11 @@ namespace snowcrash
         /**
          *  \brief Adapter Markdown node skipping behavior trait.
          *
-         *  Adapter trait signalizing that the adapter can possibly skip some Markdown nodes on a nextStartingNode()
+         *  Adapter trait signalizing that the adapter can possibly skip some
+         * Markdown nodes on a nextStartingNode()
          * call.
-         *  If set to true, a call to nextStartingNode() can skip some nodes causing some information loss. False
+         *  If set to true, a call to nextStartingNode() can skip some nodes
+         * causing some information loss. False
          * otherwise.
          */
         static const bool nextSkipsUnexpected = false;
@@ -183,16 +206,22 @@ namespace snowcrash
     /** Parser Adapter for parsing list-defined sections */
     struct ListSectionAdapter {
 
-        static const MarkdownNodeIterator startingNode(const MarkdownNodeIterator& seed, const SectionParserData& pd)
+        static const MarkdownNodeIterator startingNode(
+            const MarkdownNodeIterator& seed, const SectionParserData& pd)
         {
             if (seed->type != mdp::ListItemMarkdownNodeType) {
                 // ERR: Expected list item
                 mdp::CharactersRangeSet sourceMap
-                    = mdp::BytesRangeSetToCharactersRangeSet(seed->sourceMap, pd.sourceCharacterIndex);
-                throw Error("expected list item block, e.g. '+ <text>'", BusinessError, sourceMap);
+                    = mdp::BytesRangeSetToCharactersRangeSet(
+                        seed->sourceMap, pd.sourceCharacterIndex);
+                throw Error("expected list item block, e.g. '+ <text>'",
+                    BusinessError,
+                    sourceMap);
             }
 
-            for (auto it = seed->children().begin(); it != seed->children().end(); ++it) {
+            for (auto it = seed->children().begin();
+                 it != seed->children().end();
+                 ++it) {
                 if (it->sourceMap.begin()->length != 0) {
                     return it;
                 }
@@ -209,7 +238,9 @@ namespace snowcrash
         }
 
         static const MarkdownNodeIterator nextStartingNode(
-            const MarkdownNodeIterator& seed, const MarkdownNodes& siblings, const MarkdownNodeIterator& cur)
+            const MarkdownNodeIterator& seed,
+            const MarkdownNodes& siblings,
+            const MarkdownNodeIterator& cur)
         {
             if (seed == siblings.end())
                 return seed;
@@ -224,7 +255,8 @@ namespace snowcrash
     struct BlueprintSectionAdapter {
 
         /** \return Node to start parsing with */
-        static const MarkdownNodeIterator startingNode(const MarkdownNodeIterator& seed, const SectionParserData& pd)
+        static const MarkdownNodeIterator startingNode(
+            const MarkdownNodeIterator& seed, const SectionParserData& pd)
         {
             return seed;
         }
@@ -238,7 +270,9 @@ namespace snowcrash
 
         /** \return Starting node for next parsing */
         static const MarkdownNodeIterator nextStartingNode(
-            const MarkdownNodeIterator& seed, const MarkdownNodes& siblings, const MarkdownNodeIterator& cur)
+            const MarkdownNodeIterator& seed,
+            const MarkdownNodes& siblings,
+            const MarkdownNodeIterator& cur)
         {
             return cur;
         }

--- a/src/SectionParserData.h
+++ b/src/SectionParserData.h
@@ -23,9 +23,11 @@ namespace snowcrash
      */
     enum BlueprintParserOption
     {
-        RenderDescriptionsOption = (1 << 0),   /// < Render Markdown in description.
-        RequireBlueprintNameOption = (1 << 1), /// < Treat missing blueprint name as error
-        ExportSourcemapOption = (1 << 2)       /// < Export source maps AST
+        RenderDescriptionsOption
+        = (1 << 0), /// < Render Markdown in description.
+        RequireBlueprintNameOption
+        = (1 << 1), /// < Treat missing blueprint name as error
+        ExportSourcemapOption = (1 << 2) /// < Export source maps AST
     };
 
     typedef unsigned int BlueprintParserOptions;
@@ -36,7 +38,9 @@ namespace snowcrash
      *  State of the parser.
      */
     struct SectionParserData {
-        SectionParserData(BlueprintParserOptions opts, const mdp::ByteBuffer& src, const Blueprint& bp)
+        SectionParserData(BlueprintParserOptions opts,
+            const mdp::ByteBuffer& src,
+            const Blueprint& bp)
             : options(opts), sourceData(src), blueprint(bp)
         {
         }
@@ -68,7 +72,8 @@ namespace snowcrash
         /** Source Data */
         const mdp::ByteBuffer& sourceData;
 
-        /** Source - map of bytes to character position - performance optimalization */
+        /** Source - map of bytes to character position - performance
+         * optimalization */
         mdp::ByteBufferCharacterIndex sourceCharacterIndex;
 
         /** AST being parsed **/
@@ -81,7 +86,8 @@ namespace snowcrash
         /** \returns Actual Section Context */
         SectionType sectionContext() const
         {
-            return (sectionsContext.empty()) ? UndefinedSectionType : sectionsContext.back();
+            return (sectionsContext.empty()) ? UndefinedSectionType :
+                                               sectionsContext.back();
         }
 
         /** \returns Parent Section Context */

--- a/src/SectionProcessor.h
+++ b/src/SectionProcessor.h
@@ -14,18 +14,20 @@
 #include "Signature.h"
 
 // Use the following macro whenever a section doesn't have description
-#define NO_SECTION_DESCRIPTION(T)                                                                                      \
-    static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,                                   \
-        const MarkdownNodes& siblings,                                                                                 \
-        SectionParserData& pd,                                                                                         \
-        const ParseResultRef<T>& out)                                                                                  \
-    {                                                                                                                  \
-        return node;                                                                                                   \
-    }                                                                                                                  \
-                                                                                                                       \
-    static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)                           \
-    {                                                                                                                  \
-        return false;                                                                                                  \
+#define NO_SECTION_DESCRIPTION(T)                                              \
+    static MarkdownNodeIterator processDescription(                            \
+        const MarkdownNodeIterator& node,                                      \
+        const MarkdownNodes& siblings,                                         \
+        SectionParserData& pd,                                                 \
+        const ParseResultRef<T>& out)                                          \
+    {                                                                          \
+        return node;                                                           \
+    }                                                                          \
+                                                                               \
+    static bool isDescriptionNode(                                             \
+        const MarkdownNodeIterator& node, SectionType sectionType)             \
+    {                                                                          \
+        return false;                                                          \
     }
 
 namespace snowcrash
@@ -42,9 +44,12 @@ namespace snowcrash
      */
     enum SectionLayout
     {
-        DefaultSectionLayout,         /// Default Section Layout: Signature > Description > Content > Nested
-        ExclusiveNestedSectionLayout, /// Section is composed of nested sections only
-        RedirectSectionLayout         /// Section should be parsed by another parser as whole
+        DefaultSectionLayout,         /// Default Section Layout: Signature >
+                                      /// Description > Content > Nested
+        ExclusiveNestedSectionLayout, /// Section is composed of nested sections
+                                      /// only
+        RedirectSectionLayout /// Section should be parsed by another parser as
+                              /// whole
     };
 
     /**
@@ -94,12 +99,16 @@ namespace snowcrash
     struct ParseResultRef {
 
         ParseResultRef(ParseResult<T>& parseResult)
-            : report(parseResult.report), node(parseResult.node), sourceMap(parseResult.sourceMap)
+            : report(parseResult.report)
+            , node(parseResult.node)
+            , sourceMap(parseResult.sourceMap)
         {
         }
 
         ParseResultRef(IntermediateParseResult<T>& parseResult)
-            : report(parseResult.report), node(parseResult.node), sourceMap(parseResult.sourceMap)
+            : report(parseResult.report)
+            , node(parseResult.node)
+            , sourceMap(parseResult.sourceMap)
         {
         }
 
@@ -140,7 +149,8 @@ namespace snowcrash
          *  \param out      Processed output
          *  \return Result of the process operation
          */
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionLayout& layout,
@@ -151,7 +161,8 @@ namespace snowcrash
         }
 
         /** Process section description Markdown node */
-        static MarkdownNodeIterator processDescription(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processDescription(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<T>& out)
@@ -161,7 +172,8 @@ namespace snowcrash
                 TwoNewLines(out.node.description);
             }
 
-            mdp::ByteBuffer content = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
+            mdp::ByteBuffer content
+                = mdp::MapBytesRangeSet(node->sourceMap, pd.sourceData);
 
             if (pd.exportSourceMap() && !content.empty()) {
                 out.sourceMap.description.sourceMap.append(node->sourceMap);
@@ -174,7 +186,8 @@ namespace snowcrash
         }
 
         /** Process section-specific content Markdown node */
-        static MarkdownNodeIterator processContent(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processContent(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<T>& out)
@@ -184,7 +197,8 @@ namespace snowcrash
         }
 
         /**
-         * Pre-process for nested sections, basically a look-ahead before processing nested sections
+         * Pre-process for nested sections, basically a look-ahead before
+         * processing nested sections
          * Only used by BlueprintParser for now
          */
         static void preprocessNestedSections(const MarkdownNodeIterator& node,
@@ -202,7 +216,8 @@ namespace snowcrash
          *  \param report   Process log report
          *  \param out      Processed output
          */
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<T>& out)
@@ -212,7 +227,8 @@ namespace snowcrash
         }
 
         /** Process unexpected Markdown node */
-        static MarkdownNodeIterator processUnexpectedNode(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processUnexpectedNode(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             SectionType& lastSectionType,
@@ -222,31 +238,39 @@ namespace snowcrash
             // WARN: Ignoring unexpected node
             std::stringstream ss;
             mdp::CharactersRangeSet sourceMap
-                = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                = mdp::BytesRangeSetToCharactersRangeSet(
+                    node->sourceMap, pd.sourceCharacterIndex);
 
             if (node->type == mdp::HeaderMarkdownNodeType) {
-                ss << "unexpected header block, expected a group, resource or an action definition";
-                ss << ", e.g. '# Group <name>', '# <resource name> [<URI>]' or '# <HTTP method> <URI>'";
+                ss << "unexpected header block, expected a group, resource or "
+                      "an action definition";
+                ss << ", e.g. '# Group <name>', '# <resource name> [<URI>]' or "
+                      "'# <HTTP method> <URI>'";
             } else {
                 ss << "ignoring unrecognized block";
             }
 
-            out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+            out.report.warnings.push_back(
+                Warning(ss.str(), IgnoringWarning, sourceMap));
 
             return ++MarkdownNodeIterator(node);
         }
 
         /** Final validation after processing */
-        static void finalize(const MarkdownNodeIterator& node, SectionParserData& pd, const ParseResultRef<T>& out)
+        static void finalize(const MarkdownNodeIterator& node,
+            SectionParserData& pd,
+            const ParseResultRef<T>& out)
         {
         }
 
         /** \return True if the node is a section description node */
-        static bool isDescriptionNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isDescriptionNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
             if (SectionProcessor<T>::isContentNode(node, sectionType)
-                || SectionProcessor<T>::nestedSectionType(node) != UndefinedSectionType) {
+                || SectionProcessor<T>::nestedSectionType(node)
+                    != UndefinedSectionType) {
                 return false;
             }
 
@@ -258,8 +282,11 @@ namespace snowcrash
 
             SectionTypes upperTypes = SectionProcessor<T>::upperSectionTypes();
 
-            if (std::find(upperTypes.begin(), upperTypes.end(), keywordSectionType) != upperTypes.end()) {
-                // Node is a keyword defined section defined in an upper level section
+            if (std::find(
+                    upperTypes.begin(), upperTypes.end(), keywordSectionType)
+                != upperTypes.end()) {
+                // Node is a keyword defined section defined in an upper level
+                // section
                 return false;
             }
 
@@ -267,19 +294,23 @@ namespace snowcrash
         }
 
         /** \return True if the node is a section-specific content node */
-        static bool isContentNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isContentNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
             return false;
         }
 
         /** \return True if the node is unexpected in the current context */
-        static bool isUnexpectedNode(const MarkdownNodeIterator& node, SectionType sectionType)
+        static bool isUnexpectedNode(
+            const MarkdownNodeIterator& node, SectionType sectionType)
         {
 
             SectionType keywordSectionType = SectionKeywordSignature(node);
             SectionTypes upperTypes = SectionProcessor<T>::upperSectionTypes();
 
-            if (std::find(upperTypes.begin(), upperTypes.end(), keywordSectionType) == upperTypes.end()) {
+            if (std::find(
+                    upperTypes.begin(), upperTypes.end(), keywordSectionType)
+                == upperTypes.end()) {
                 // Node is not a section that is upper level
                 return true;
             }

--- a/src/Signature.cc
+++ b/src/Signature.cc
@@ -20,12 +20,14 @@
 
 using namespace snowcrash;
 
-#define TYPECHECK(T)                                                                                                   \
-    if ((type = SectionProcessor<T>::sectionType(node)) != UndefinedSectionType) {                                     \
-        return type;                                                                                                   \
+#define TYPECHECK(T)                                                           \
+    if ((type = SectionProcessor<T>::sectionType(node))                        \
+        != UndefinedSectionType) {                                             \
+        return type;                                                           \
     }
 
-SectionType snowcrash::SectionKeywordSignature(const mdp::MarkdownNodeIterator& node)
+SectionType snowcrash::SectionKeywordSignature(
+    const mdp::MarkdownNodeIterator& node)
 {
     // Note: Every-keyword defined section should be listed here...
     SectionType type = UndefinedSectionType;
@@ -44,7 +46,8 @@ SectionType snowcrash::SectionKeywordSignature(const mdp::MarkdownNodeIterator& 
     /*
      *  NOTE: Order is important. Resource MUST preceed the Action.
      *
-     *  This is because an HTTP Request Method + URI is recognized as both %ActionSectionType and %ResourceSectionType.
+     *  This is because an HTTP Request Method + URI is recognized as both
+     * %ActionSectionType and %ResourceSectionType.
      *  This is not optimal and should be addressed in the future.
      */
     TYPECHECK(Resource)
@@ -55,7 +58,8 @@ SectionType snowcrash::SectionKeywordSignature(const mdp::MarkdownNodeIterator& 
     return type;
 }
 
-SectionType snowcrash::RecognizeCodeBlockFirstLine(const mdp::ByteBuffer& subject)
+SectionType snowcrash::RecognizeCodeBlockFirstLine(
+    const mdp::ByteBuffer& subject)
 {
     SectionType type = UndefinedSectionType;
 

--- a/src/Signature.h
+++ b/src/Signature.h
@@ -18,16 +18,20 @@ namespace snowcrash
     /**
      *  \brief Query whether a node has keyword-defined signature.
      *  \param node     A Markdown AST node to check.
-     *  \return Type of the node if it has a recognized keyword signature, UndefinedType otherwise
+     *  \return Type of the node if it has a recognized keyword signature,
+     * UndefinedType otherwise
      */
-    extern SectionType SectionKeywordSignature(const mdp::MarkdownNodeIterator& node);
+    extern SectionType SectionKeywordSignature(
+        const mdp::MarkdownNodeIterator& node);
 
     /**
-     *  \brief Recognize the type of section given the first line from a code block
+     *  \brief Recognize the type of section given the first line from a code
+     * block
      *  \param subject  The first line that needs to be recognized
      *  \return SectionType Type of the section if the line contains a keyword
      */
-    extern SectionType RecognizeCodeBlockFirstLine(const mdp::ByteBuffer& subject);
+    extern SectionType RecognizeCodeBlockFirstLine(
+        const mdp::ByteBuffer& subject);
 }
 
 namespace scpl
@@ -44,8 +48,9 @@ namespace scpl
         std::vector<mdp::ByteBuffer> values;     // Signature Values
         std::vector<mdp::ByteBuffer> attributes; // Signature Attributes
 
-        mdp::ByteBuffer content;          // Signature content before newline character
-        mdp::ByteBuffer remainingContent; // Signature content after newline character
+        mdp::ByteBuffer content; // Signature content before newline character
+        mdp::ByteBuffer
+            remainingContent; // Signature content after newline character
     };
 
     /**
@@ -61,8 +66,10 @@ namespace scpl
         static const char AttributesEndDelimiter = ')';
         static const char AttributeDelimiter = ',';
 
-        Delimiters(char valuesDelimiter_ = ':', std::string contentDelimiter_ = "-")
-            : valuesDelimiter(valuesDelimiter_), contentDelimiter(contentDelimiter_)
+        Delimiters(
+            char valuesDelimiter_ = ':', std::string contentDelimiter_ = "-")
+            : valuesDelimiter(valuesDelimiter_)
+            , contentDelimiter(contentDelimiter_)
         {
         }
     };
@@ -77,9 +84,11 @@ namespace scpl
         enum Trait
         {
             IdentifierTrait = (1 << 0), // Expect an identifier in the signature
-            ValuesTrait = (1 << 1),     // Expect a (list of) value in the signature
-            AttributesTrait = (1 << 2), // Expect a list of attributes in the signature
-            ContentTrait = (1 << 3)     // Expect inline description in the signature
+            ValuesTrait = (1 << 1), // Expect a (list of) value in the signature
+            AttributesTrait
+            = (1 << 2), // Expect a list of attributes in the signature
+            ContentTrait
+            = (1 << 3) // Expect inline description in the signature
         };
 
         typedef unsigned int Traits;
@@ -91,7 +100,8 @@ namespace scpl
 
         Delimiters delimiters;
 
-        SignatureTraits(Traits traits_ = 0, Delimiters delimiters_ = Delimiters())
+        SignatureTraits(
+            Traits traits_ = 0, Delimiters delimiters_ = Delimiters())
             : identifierTrait(traits_ & IdentifierTrait)
             , valuesTrait(traits_ & ValuesTrait)
             , attributesTrait(traits_ & AttributesTrait)

--- a/src/SignatureSectionProcessor.h
+++ b/src/SignatureSectionProcessor.h
@@ -23,10 +23,12 @@ namespace scpl
     /**
      * \brief Signature Section Processor Base
      *
-     * Defines default behaviours for Section Processor interface for Signature sections
+     * Defines default behaviours for Section Processor interface for Signature
+     * sections
      */
     template <typename T>
-    struct SignatureSectionProcessorBase : public snowcrash::SectionProcessorBase<T> {
+    struct SignatureSectionProcessorBase
+        : public snowcrash::SectionProcessorBase<T> {
 
         /**
          * \brief Signature traits of the section
@@ -43,7 +45,8 @@ namespace scpl
         /**
          * \brief Process section signature markdown node (Default)
          */
-        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processSignature(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             snowcrash::SectionParserData& pd,
             snowcrash::SectionLayout& layout,
@@ -51,13 +54,17 @@ namespace scpl
         {
 
             // Get the signature traits of the section
-            SignatureTraits signatureTraits = snowcrash::SectionProcessor<T>::signatureTraits();
+            SignatureTraits signatureTraits
+                = snowcrash::SectionProcessor<T>::signatureTraits();
 
             // Parse Signature
-            Signature signature = snowcrash::SectionProcessor<T>::parseSignature(node, pd, signatureTraits, out.report);
+            Signature signature
+                = snowcrash::SectionProcessor<T>::parseSignature(
+                    node, pd, signatureTraits, out.report);
 
             // Do section specific logic using the signature data
-            return snowcrash::SectionProcessor<T>::finalizeSignature(node, pd, signature, out);
+            return snowcrash::SectionProcessor<T>::finalizeSignature(
+                node, pd, signature, out);
         };
 
         /**
@@ -83,7 +90,8 @@ namespace scpl
 
             if (subject.empty()) {
 
-                subject = snowcrash::GetFirstLine(node->text, signature.remainingContent);
+                subject = snowcrash::GetFirstLine(
+                    node->text, signature.remainingContent);
                 snowcrash::TrimString(subject);
             }
 
@@ -95,16 +103,21 @@ namespace scpl
 
                     // WARN: Empty identifier
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
                     report.warnings.push_back(
-                        snowcrash::Warning("no identifier specified", snowcrash::EmptyDefinitionWarning, sourceMap));
+                        snowcrash::Warning("no identifier specified",
+                            snowcrash::EmptyDefinitionWarning,
+                            sourceMap));
                 }
             }
 
             // Make sure values exist
-            if (traits.valuesTrait && !subject.empty() && subject[0] != Delimiters::AttributesBeginDelimiter) {
+            if (traits.valuesTrait && !subject.empty()
+                && subject[0] != Delimiters::AttributesBeginDelimiter) {
 
-                // When subject starts with values, add a ':' for easier processing
+                // When subject starts with values, add a ':' for easier
+                // processing
                 if (!traits.identifierTrait) {
                     subject = traits.delimiters.valuesDelimiter + subject;
                 }
@@ -117,25 +130,31 @@ namespace scpl
 
                         // WARN: Empty values
                         mdp::CharactersRangeSet sourceMap
-                            = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
+                            = mdp::BytesRangeSetToCharactersRangeSet(
+                                node->sourceMap, pd.sourceCharacterIndex);
                         report.warnings.push_back(
-                            snowcrash::Warning("no value(s) specified", snowcrash::EmptyDefinitionWarning, sourceMap));
+                            snowcrash::Warning("no value(s) specified",
+                                snowcrash::EmptyDefinitionWarning,
+                                sourceMap));
                     }
                 }
             }
 
             if (traits.attributesTrait && !subject.empty()
-                && subject.substr(0, traits.delimiters.contentDelimiter.length())
+                && subject.substr(
+                       0, traits.delimiters.contentDelimiter.length())
                     != traits.delimiters.contentDelimiter) {
 
                 parseSignatureAttributes(report, subject, signature);
             }
 
             if (traits.contentTrait && !subject.empty()
-                && subject.substr(0, traits.delimiters.contentDelimiter.length())
+                && subject.substr(
+                       0, traits.delimiters.contentDelimiter.length())
                     == traits.delimiters.contentDelimiter) {
 
-                subject = subject.substr(traits.delimiters.contentDelimiter.length());
+                subject = subject.substr(
+                    traits.delimiters.contentDelimiter.length());
                 snowcrash::TrimString(subject);
 
                 signature.content = subject;
@@ -154,7 +173,8 @@ namespace scpl
          *
          * \return Result of process operation
          */
-        static MarkdownNodeIterator finalizeSignature(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator finalizeSignature(
+            const MarkdownNodeIterator& node,
             snowcrash::SectionParserData& pd,
             const Signature& signature,
             const snowcrash::ParseResultRef<T>& out)
@@ -172,8 +192,10 @@ namespace scpl
          *                (which will be stripped of the parsed characters)
          * \param out Signature data structure
          */
-        static void parseSignatureIdentifier(
-            const SignatureTraits& traits, snowcrash::Report& report, mdp::ByteBuffer& subject, Signature& out)
+        static void parseSignatureIdentifier(const SignatureTraits& traits,
+            snowcrash::Report& report,
+            mdp::ByteBuffer& subject,
+            Signature& out)
         {
 
             snowcrash::TrimString(subject);
@@ -189,8 +211,10 @@ namespace scpl
 
                 if (escapeCharacters.find(subject[i]) != std::string::npos) {
 
-                    // If escaped string, retrieve it and strip it from the subject
-                    mdp::ByteBuffer escapedString = snowcrash::RetrieveEscaped(subject, i);
+                    // If escaped string, retrieve it and strip it from the
+                    // subject
+                    mdp::ByteBuffer escapedString
+                        = snowcrash::RetrieveEscaped(subject, i);
 
                     if (!escapedString.empty()) {
                         identifier += escapedString;
@@ -199,10 +223,15 @@ namespace scpl
                         identifier += subject[i];
                         i++;
                     }
-                } else if ((traits.valuesTrait && subject[i] == traits.delimiters.valuesDelimiter)
-                    || (traits.attributesTrait && subject[i] == Delimiters::AttributesBeginDelimiter)
+                } else if ((traits.valuesTrait
+                               && subject[i]
+                                   == traits.delimiters.valuesDelimiter)
+                    || (traits.attributesTrait
+                           && subject[i]
+                               == Delimiters::AttributesBeginDelimiter)
                     || (traits.contentTrait
-                           && subject.substr(i, traits.delimiters.contentDelimiter.length())
+                           && subject.substr(i,
+                                  traits.delimiters.contentDelimiter.length())
                                == traits.delimiters.contentDelimiter)) {
 
                     // If identifier ends, strip it from the subject
@@ -223,7 +252,8 @@ namespace scpl
                 out.identifier = identifier;
             }
 
-            // If the subject ended with the identifier, strip it from the subject
+            // If the subject ended with the identifier, strip it from the
+            // subject
             if (i == subject.length()) {
                 subject = "";
             }
@@ -240,8 +270,10 @@ namespace scpl
          *                (which will be stripped of the parsed characters)
          * \param out Signature data structure
          */
-        static void parseSignatureValues(
-            const SignatureTraits& traits, snowcrash::Report& report, mdp::ByteBuffer& subject, Signature& out)
+        static void parseSignatureValues(const SignatureTraits& traits,
+            snowcrash::Report& report,
+            mdp::ByteBuffer& subject,
+            Signature& out)
         {
 
             // Remove leading delimiter
@@ -259,7 +291,8 @@ namespace scpl
                 if (subject[i] == EscapeCharacter) {
 
                     // If escaped string, retrieve it and strip it from subject
-                    mdp::ByteBuffer escapedString = snowcrash::RetrieveEscaped(subject, i);
+                    mdp::ByteBuffer escapedString
+                        = snowcrash::RetrieveEscaped(subject, i);
 
                     if (!escapedString.empty()) {
                         value += escapedString;
@@ -270,7 +303,8 @@ namespace scpl
                     }
                 } else if (subject[i] == Delimiters::ValueDelimiter) {
 
-                    // If found value delimiter, add the value and strip it from subject
+                    // If found value delimiter, add the value and strip it from
+                    // subject
                     subject = subject.substr(i + 1);
                     snowcrash::TrimString(subject);
 
@@ -279,9 +313,12 @@ namespace scpl
 
                     value = "";
                     i = 0;
-                } else if ((traits.attributesTrait && subject[i] == Delimiters::AttributesBeginDelimiter)
+                } else if ((traits.attributesTrait
+                               && subject[i]
+                                   == Delimiters::AttributesBeginDelimiter)
                     || (traits.contentTrait
-                           && subject.substr(i, traits.delimiters.contentDelimiter.length())
+                           && subject.substr(i,
+                                  traits.delimiters.contentDelimiter.length())
                                == traits.delimiters.contentDelimiter)) {
 
                     // If values section ends, strip it from subject
@@ -302,15 +339,18 @@ namespace scpl
                 out.values.push_back(value);
             }
 
-            // If the subject ended with the values, strip the last value from the subject
+            // If the subject ended with the values, strip the last value from
+            // the subject
             if (i == subject.length()) {
                 subject = "";
             }
 
             snowcrash::TrimString(subject);
 
-            // Fill signature value with the string which was stripped from subject
-            out.value = out.value.substr(0, out.value.length() - subject.length());
+            // Fill signature value with the string which was stripped from
+            // subject
+            out.value
+                = out.value.substr(0, out.value.length() - subject.length());
 
             snowcrash::TrimString(out.value);
             out.value = snowcrash::StripBackticks(out.value);
@@ -324,7 +364,8 @@ namespace scpl
          *                (which will be stripped of the parsed characters)
          * \param out Signature data structure
          */
-        static void parseSignatureAttributes(snowcrash::Report& report, mdp::ByteBuffer& subject, Signature& out)
+        static void parseSignatureAttributes(
+            snowcrash::Report& report, mdp::ByteBuffer& subject, Signature& out)
         {
 
             if (subject[0] != Delimiters::AttributesBeginDelimiter) {
@@ -337,10 +378,12 @@ namespace scpl
             while (attributesNotFinished) {
 
                 // Retrieve attribute
-                mdp::ByteBuffer attribute = matchBrackets(subject, 0, Delimiters::AttributesEndDelimiter, true);
+                mdp::ByteBuffer attribute = matchBrackets(
+                    subject, 0, Delimiters::AttributesEndDelimiter, true);
                 size_t length = attribute.size();
 
-                // If the last char is not an attribute delimiter, attributes are finished
+                // If the last char is not an attribute delimiter, attributes
+                // are finished
                 if (attribute[length - 1] != Delimiters::AttributeDelimiter) {
                     attributesNotFinished = false;
                 } else {
@@ -361,16 +404,22 @@ namespace scpl
         };
 
         /**
-         * \brief Find the matching bracket while ignoring any nested brackets and return the string
-         *        enclosed by them, while also stripping the string that needs to be parsed
+         * \brief Find the matching bracket while ignoring any nested brackets
+         * and return the string
+         *        enclosed by them, while also stripping the string that needs
+         * to be parsed
          *
          * \param subject The string that needs to be parsed
-         * \param begin Character index representing the beginning of the bracket that needs to be matched
+         * \param begin Character index representing the beginning of the
+         * bracket that needs to be matched
          * \param endBracket The type of bracket that needs to be matched
-         * \param splitByAttribute If this is true, we need to return when we find a top-level attribute delimiter
-         * \param clearAtEnd If this is true, the string will be cleared at the end of parsing
+         * \param splitByAttribute If this is true, we need to return when we
+         * find a top-level attribute delimiter
+         * \param clearAtEnd If this is true, the string will be cleared at the
+         * end of parsing
          *
-         * \return String inside the given brackets. If not splitting by comma, append the brackets too
+         * \return String inside the given brackets. If not splitting by comma,
+         * append the brackets too
          */
         static mdp::ByteBuffer matchBrackets(mdp::ByteBuffer& subject,
             size_t begin,
@@ -392,7 +441,8 @@ namespace scpl
                 if (subject[i] == EscapeCharacter) {
 
                     // If escaped string, retrieve it and strip it from subject
-                    mdp::ByteBuffer escapedString = snowcrash::RetrieveEscaped(subject, i);
+                    mdp::ByteBuffer escapedString
+                        = snowcrash::RetrieveEscaped(subject, i);
 
                     if (!escapedString.empty()) {
                         returnString += escapedString;
@@ -419,7 +469,8 @@ namespace scpl
                     subject = subject.substr(i + 1);
                     i = 0;
                     break;
-                } else if (splitByAttribute && subject[i] == Delimiters::AttributeDelimiter) {
+                } else if (splitByAttribute
+                    && subject[i] == Delimiters::AttributeDelimiter) {
 
                     // Return when encountering comma
                     returnString += subject[i];

--- a/src/SourceAnnotation.h
+++ b/src/SourceAnnotation.h
@@ -154,14 +154,16 @@ namespace snowcrash
     struct Report {
 
         /**
-         *  \brief Append a report to this one, replacing the error source annotation.
+         *  \brief Append a report to this one, replacing the error source
+         * annotation.
          *
          *  NOTE: A binding does not need to wrap this action.
          */
         Report& operator+=(const Report& rhs)
         {
             error = rhs.error;
-            warnings.insert(warnings.end(), rhs.warnings.begin(), rhs.warnings.end());
+            warnings.insert(
+                warnings.end(), rhs.warnings.begin(), rhs.warnings.end());
             return *this;
         }
 

--- a/src/StringUtility.h
+++ b/src/StringUtility.h
@@ -27,7 +27,8 @@ namespace snowcrash
     // Check a character not to be an space of any kind
     inline bool isSpace(const std::string::value_type i)
     {
-        if (i == ' ' || i == '\t' || i == '\n' || i == '\v' || i == '\f' || i == '\r')
+        if (i == ' ' || i == '\t' || i == '\n' || i == '\v' || i == '\f'
+            || i == '\r')
             return true;
         return false;
     }
@@ -35,14 +36,18 @@ namespace snowcrash
     // Trim string from start
     inline std::string& TrimStringStart(std::string& s)
     {
-        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun(isSpace))));
+        s.erase(s.begin(),
+            std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun(isSpace))));
         return s;
     }
 
     // Trim string from end
     inline std::string& TrimStringEnd(std::string& s)
     {
-        s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun(isSpace))).base(), s.end());
+        s.erase(
+            std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun(isSpace)))
+                .base(),
+            s.end());
         return s;
     }
 
@@ -53,24 +58,29 @@ namespace snowcrash
     }
 
     // <position form begin, lenght of string>
-    typedef std::tuple<std::string::const_iterator::difference_type, std::string::const_iterator::difference_type>
+    typedef std::tuple<std::string::const_iterator::difference_type,
+        std::string::const_iterator::difference_type>
         TrimRange;
 
     // Get Trim Info
-    inline TrimRange GetTrimInfo(std::string::const_iterator begin, std::string::const_iterator end)
+    inline TrimRange GetTrimInfo(
+        std::string::const_iterator begin, std::string::const_iterator end)
     {
         std::string::const_reverse_iterator rbegin(end);
         std::string::const_reverse_iterator rend(begin);
 
-        std::string::const_iterator trim = std::find_if(begin, end, std::not1(std::ptr_fun(isSpace)));
-        std::string::const_reverse_iterator rtrim = std::find_if(rbegin, rend, std::not1(std::ptr_fun(isSpace)));
+        std::string::const_iterator trim
+            = std::find_if(begin, end, std::not1(std::ptr_fun(isSpace)));
+        std::string::const_reverse_iterator rtrim
+            = std::find_if(rbegin, rend, std::not1(std::ptr_fun(isSpace)));
 
-        return std::make_tuple(
-            std::distance(begin, trim), std::distance(rtrim, std::string::const_reverse_iterator(trim)));
+        return std::make_tuple(std::distance(begin, trim),
+            std::distance(rtrim, std::string::const_reverse_iterator(trim)));
     }
 
     // Split string by delim
-    inline std::vector<std::string>& Split(const std::string& s, char delim, std::vector<std::string>& elems)
+    inline std::vector<std::string>& Split(
+        const std::string& s, char delim, std::vector<std::string>& elems)
     {
         std::stringstream ss(s);
         std::string item;
@@ -89,7 +99,8 @@ namespace snowcrash
     }
 
     // Split string on the first occurrence of delim
-    inline std::vector<std::string> SplitOnFirst(const std::string& s, char delim)
+    inline std::vector<std::string> SplitOnFirst(
+        const std::string& s, char delim)
     {
         std::string::size_type pos = s.find(delim);
         std::vector<std::string> elems;
@@ -124,7 +135,9 @@ namespace snowcrash
      *  \param  replace A string to replace with.
      *  \return A copy of %s with all occurrences of %find replaced by %replace.
      */
-    inline std::string ReplaceString(const std::string& s, const std::string& find, const std::string& replace)
+    inline std::string ReplaceString(const std::string& s,
+        const std::string& find,
+        const std::string& replace)
     {
         size_t pos = 0;
         std::string target(s);
@@ -193,7 +206,8 @@ namespace snowcrash
      */
 
     template <typename T1, typename T2, typename Predicate>
-    inline bool MatchContainers(const T1& arg1, const T2& arg2, const Predicate& predicate)
+    inline bool MatchContainers(
+        const T1& arg1, const T2& arg2, const Predicate& predicate)
     {
         if (arg1.length() != arg2.length()) {
             return false;
@@ -218,20 +232,26 @@ namespace snowcrash
     };
 
     /**
-     * \brief Retrieve the string enclosed by the given matching escaping characters
+     * \brief Retrieve the string enclosed by the given matching escaping
+     * characters
      *
-     *        Please note that the subject will be stripped of the escaped string
+     *        Please note that the subject will be stripped of the escaped
+     * string
      *        and the characters before it
      *
      * \param subject String that needs to be parsed
      * \param begin Character representing the beginning of the escaped string
-     * \param stripEscapeChars If true, strip the escape characters from the result string
+     * \param stripEscapeChars If true, strip the escape characters from the
+     * result string
      *
      * \return Returns the escaped string
      *
-     * \example (begin = 1, subject = "a```b```cd") ----> (return = "```b```", subject = "cd")
+     * \example (begin = 1, subject = "a```b```cd") ----> (return = "```b```",
+     * subject = "cd")
      */
-    inline std::string RetrieveEscaped(std::string& subject, size_t begin = 0, const bool stripEscapeChars = false)
+    inline std::string RetrieveEscaped(std::string& subject,
+        size_t begin = 0,
+        const bool stripEscapeChars = false)
     {
 
         size_t levels = 0;
@@ -265,7 +285,8 @@ namespace snowcrash
     /**
      * \brief Strip the enclosing backticks and return the string in the middle.
      *
-     *        If there are no matching enclosing bacticks, return the whole string.
+     *        If there are no matching enclosing bacticks, return the whole
+     * string.
      *
      * \param subject String that needs to be stripped of enclosing backticks
      *
@@ -292,7 +313,8 @@ namespace snowcrash
     }
 
     /**
-     * \brief If the given string is a markdown link, return the string which is being linked
+     * \brief If the given string is a markdown link, return the string which is
+     * being linked
      *
      *        If there is no link, return the whole string
      *
@@ -308,7 +330,8 @@ namespace snowcrash
             return subject;
         }
 
-        std::string linkedString = RegexCaptureFirst(subject, mdp::MarkdownLinkRegex);
+        std::string linkedString
+            = RegexCaptureFirst(subject, mdp::MarkdownLinkRegex);
         TrimString(linkedString);
 
         return linkedString;
@@ -320,7 +343,8 @@ namespace snowcrash
 
         // we are not able to reconstruct correctly headers
         // there is missing info about spacing on both sides
-        // node.sourceMap - contain length, but we dont now count of space on both sides
+        // node.sourceMap - contain length, but we dont now count of space on
+        // both sides
         // it we are not able to distinguis between "a  ", " a " and "  a".
         //
         // Solution - we strictly strip whitespace

--- a/src/UriTemplateParser.cc
+++ b/src/UriTemplateParser.cc
@@ -51,7 +51,8 @@ static bool HasNestedCurlyBrackets(const URITemplate& uriTemplate)
 
 static bool PathContainsSquareBrackets(const URITemplate& uriTemplate)
 {
-    return (uriTemplate.find('[') != std::string::npos || uriTemplate.find(']') != std::string::npos);
+    return (uriTemplate.find('[') != std::string::npos
+        || uriTemplate.find(']') != std::string::npos);
 }
 
 static Expressions GetUriTemplateExpressions(const URITemplate& uriTemplate)
@@ -60,13 +61,15 @@ static Expressions GetUriTemplateExpressions(const URITemplate& uriTemplate)
     size_t expressionStartPos = 0;
     size_t expressionEndPos = 0;
 
-    while (expressionStartPos != std::string::npos && expressionEndPos != std::string::npos
+    while (expressionStartPos != std::string::npos
+        && expressionEndPos != std::string::npos
         && expressionStartPos < uriTemplate.length()) {
         expressionStartPos = uriTemplate.find("{", expressionStartPos);
         expressionEndPos = uriTemplate.find("}", expressionStartPos);
-        if (expressionStartPos != std::string::npos && expressionEndPos > expressionStartPos) {
-            expressions.push_back(
-                uriTemplate.substr(expressionStartPos + 1, (expressionEndPos - expressionStartPos) - 1));
+        if (expressionStartPos != std::string::npos
+            && expressionEndPos > expressionStartPos) {
+            expressions.push_back(uriTemplate.substr(expressionStartPos + 1,
+                (expressionEndPos - expressionStartPos) - 1));
         }
         expressionStartPos++;
     }
@@ -107,12 +110,14 @@ static ClassifiedExpression ClassifyExpression(const Expression& expression)
         return pathSegmentExpansionExpression;
     }
 
-    PathStyleParameterExpansionExpression pathStyleParameterExpansionExpression(expression);
+    PathStyleParameterExpansionExpression pathStyleParameterExpansionExpression(
+        expression);
     if (pathStyleParameterExpansionExpression.IsExpressionType()) {
         return pathSegmentExpansionExpression;
     }
 
-    FormStyleQueryContinuationExpression formStyleQueryContinuationExpression(expression);
+    FormStyleQueryContinuationExpression formStyleQueryContinuationExpression(
+        expression);
     if (formStyleQueryContinuationExpression.IsExpressionType()) {
         return formStyleQueryContinuationExpression;
     }
@@ -122,8 +127,9 @@ static ClassifiedExpression ClassifyExpression(const Expression& expression)
     return undefinedExpression;
 }
 
-void URITemplateParser::parse(
-    const URITemplate& uri, const mdp::CharactersRangeSet& sourceBlock, ParsedURITemplate& result)
+void URITemplateParser::parse(const URITemplate& uri,
+    const mdp::CharactersRangeSet& sourceBlock,
+    ParsedURITemplate& result)
 {
     CaptureGroups groups;
     Expressions expressions;
@@ -138,22 +144,27 @@ void URITemplateParser::parse(
         result.path = groups[4];
 
         if (HasMismatchedCurlyBrackets(result.path)) {
-            result.report.warnings.push_back(
-                Warning("The URI template contains mismatched expression brackets", URIWarning, sourceBlock));
+            result.report.warnings.push_back(Warning(
+                "The URI template contains mismatched expression brackets",
+                URIWarning,
+                sourceBlock));
             return;
         }
 
         if (HasNestedCurlyBrackets(result.path)) {
             result.report.warnings.push_back(
-                Warning("The URI template contains nested expression brackets", URIWarning, sourceBlock));
+                Warning("The URI template contains nested expression brackets",
+                    URIWarning,
+                    sourceBlock));
             return;
         }
 
         if (PathContainsSquareBrackets(result.path)) {
-            result.report.warnings.push_back(Warning(
-                "The URI template contains square brackets, please percent encode square brackets as %5B and %5D",
-                URIWarning,
-                sourceBlock));
+            result.report.warnings.push_back(
+                Warning("The URI template contains square brackets, please "
+                        "percent encode square brackets as %5B and %5D",
+                    URIWarning,
+                    sourceBlock));
         }
 
         expressions = GetUriTemplateExpressions(result.path);
@@ -162,54 +173,70 @@ void URITemplateParser::parse(
 
         while (currentExpression != expressions.end()) {
 
-            ClassifiedExpression classifiedExpression = ClassifyExpression(*currentExpression);
+            ClassifiedExpression classifiedExpression
+                = ClassifyExpression(*currentExpression);
 
             if (classifiedExpression.IsSupportedExpressionType()) {
                 bool hasIllegalCharacters = false;
 
                 if (classifiedExpression.ContainsSpaces()) {
                     std::stringstream ss;
-                    ss << "URI template expression \"" << classifiedExpression.innerExpression
-                       << "\" contains spaces. Allowed characters for expressions are A-Z a-z 0-9 _ and percent "
+                    ss << "URI template expression \""
+                       << classifiedExpression.innerExpression
+                       << "\" contains spaces. Allowed characters for "
+                          "expressions are A-Z a-z 0-9 _ and percent "
                           "encoded characters";
-                    result.report.warnings.push_back(Warning(ss.str(), URIWarning, sourceBlock));
+                    result.report.warnings.push_back(
+                        Warning(ss.str(), URIWarning, sourceBlock));
                     hasIllegalCharacters = true;
                 }
 
                 if (classifiedExpression.ContainsHyphens()) {
                     std::stringstream ss;
-                    ss << "URI template expression \"" << classifiedExpression.innerExpression
-                       << "\" contains hyphens. Allowed characters for expressions are A-Z a-z 0-9 _ and percent "
+                    ss << "URI template expression \""
+                       << classifiedExpression.innerExpression
+                       << "\" contains hyphens. Allowed characters for "
+                          "expressions are A-Z a-z 0-9 _ and percent "
                           "encoded characters";
-                    result.report.warnings.push_back(Warning(ss.str(), URIWarning, sourceBlock));
+                    result.report.warnings.push_back(
+                        Warning(ss.str(), URIWarning, sourceBlock));
                     hasIllegalCharacters = true;
                 }
 
                 if (classifiedExpression.ContainsAssignment()) {
                     std::stringstream ss;
-                    ss << "URI template expression \"" << classifiedExpression.innerExpression
-                       << "\" contains assignment. Allowed characters for expressions are A-Z a-z 0-9 _ and percent "
+                    ss << "URI template expression \""
+                       << classifiedExpression.innerExpression
+                       << "\" contains assignment. Allowed characters for "
+                          "expressions are A-Z a-z 0-9 _ and percent "
                           "encoded characters";
-                    result.report.warnings.push_back(Warning(ss.str(), URIWarning, sourceBlock));
+                    result.report.warnings.push_back(
+                        Warning(ss.str(), URIWarning, sourceBlock));
                     hasIllegalCharacters = true;
                 }
 
                 if (!hasIllegalCharacters) {
                     if (classifiedExpression.IsInvalidExpressionName()) {
                         std::stringstream ss;
-                        ss << "URI template expression \"" << classifiedExpression.innerExpression
-                           << "\" contains invalid characters. Allowed characters for expressions are A-Z a-z 0-9 _ "
+                        ss << "URI template expression \""
+                           << classifiedExpression.innerExpression
+                           << "\" contains invalid characters. Allowed "
+                              "characters for expressions are A-Z a-z 0-9 _ "
                               "and percent encoded characters";
-                        result.report.warnings.push_back(Warning(ss.str(), URIWarning, sourceBlock));
+                        result.report.warnings.push_back(
+                            Warning(ss.str(), URIWarning, sourceBlock));
                     }
                 }
             } else {
                 result.report.warnings.push_back(
-                    Warning(classifiedExpression.unsupportedWarningText, URIWarning, sourceBlock));
+                    Warning(classifiedExpression.unsupportedWarningText,
+                        URIWarning,
+                        sourceBlock));
             }
             currentExpression++;
         }
     } else {
-        result.report.error = Error("Failed to parse URI Template", ApplicationError);
+        result.report.error
+            = Error("Failed to parse URI Template", ApplicationError);
     }
 }

--- a/src/UriTemplateParser.h
+++ b/src/UriTemplateParser.h
@@ -15,7 +15,8 @@
 
 #define URI_REGEX "^(http|https|ftp|file)?(://)?([^/]*)?(.*)$"
 #define URI_TEMPLATE_OPERATOR_REGEX "([+|#|.|/|;|?|&])"
-#define URI_TEMPLATE_EXPRESSION_REGEX "^([?|#|+|&]?(([A-Z|a-z|0-9|_|,])*|(%[A-F|a-f|0-9]{2})*)*\\*?)$"
+#define URI_TEMPLATE_EXPRESSION_REGEX                                          \
+    "^([?|#|+|&]?(([A-Z|a-z|0-9|_|,])*|(%[A-F|a-f|0-9]{2})*)*\\*?)$"
 
 namespace snowcrash
 {
@@ -93,7 +94,8 @@ namespace snowcrash
                 return true;
 
             size_t start_pos = 0;
-            while ((start_pos = tmpExpression.find(".", start_pos)) != std::string::npos) {
+            while ((start_pos = tmpExpression.find(".", start_pos))
+                != std::string::npos) {
                 tmpExpression.replace(start_pos, 1, "_");
                 start_pos++;
             }
@@ -113,14 +115,16 @@ namespace snowcrash
     class VariableExpression : public ClassifiedExpression
     {
     public:
-        VariableExpression(const std::string& expression) : ClassifiedExpression(expression)
+        VariableExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
             isSupported = true;
         }
 
         bool IsExpressionType() const
         {
-            return !RegexMatch(innerExpression.substr(0, 1), URI_TEMPLATE_OPERATOR_REGEX);
+            return !RegexMatch(
+                innerExpression.substr(0, 1), URI_TEMPLATE_OPERATOR_REGEX);
         }
     };
 
@@ -130,7 +134,8 @@ namespace snowcrash
     class QueryStringExpression : public ClassifiedExpression
     {
     public:
-        QueryStringExpression(const std::string& expression) : ClassifiedExpression(expression)
+        QueryStringExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
             isSupported = true;
         }
@@ -147,7 +152,8 @@ namespace snowcrash
     class FragmentExpression : public ClassifiedExpression
     {
     public:
-        FragmentExpression(const std::string& expression) : ClassifiedExpression(expression)
+        FragmentExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
             isSupported = true;
         }
@@ -164,7 +170,8 @@ namespace snowcrash
     class ReservedExpansionExpression : public ClassifiedExpression
     {
     public:
-        ReservedExpansionExpression(const std::string& expression) : ClassifiedExpression(expression)
+        ReservedExpansionExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
             isSupported = true;
         }
@@ -181,9 +188,11 @@ namespace snowcrash
     class LabelExpansionExpression : public ClassifiedExpression
     {
     public:
-        LabelExpansionExpression(const std::string& expression) : ClassifiedExpression(expression)
+        LabelExpansionExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
-            unsupportedWarningText = "URI template label expansion is not supported";
+            unsupportedWarningText
+                = "URI template label expansion is not supported";
         }
 
         bool IsExpressionType() const
@@ -198,9 +207,11 @@ namespace snowcrash
     class PathSegmentExpansionExpression : public ClassifiedExpression
     {
     public:
-        PathSegmentExpansionExpression(const std::string& expression) : ClassifiedExpression(expression)
+        PathSegmentExpansionExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
-            unsupportedWarningText = "URI template path segment expansion is not supported";
+            unsupportedWarningText
+                = "URI template path segment expansion is not supported";
         }
 
         bool IsExpressionType() const
@@ -210,14 +221,18 @@ namespace snowcrash
     };
 
     /**
-    *  \brief level three path style parameter expansion URI template expression.
+    *  \brief level three path style parameter expansion URI template
+    * expression.
     */
     class PathStyleParameterExpansionExpression : public ClassifiedExpression
     {
     public:
-        PathStyleParameterExpansionExpression(const std::string& expression) : ClassifiedExpression(expression)
+        PathStyleParameterExpansionExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
-            unsupportedWarningText = "URI template path style parameter expansion is not supported";
+            unsupportedWarningText
+                = "URI template path style parameter expansion is not "
+                  "supported";
         }
 
         bool IsExpressionType() const
@@ -227,12 +242,14 @@ namespace snowcrash
     };
 
     /**
-    *  \brief level three form style query continuation expansion URI template expression.
+    *  \brief level three form style query continuation expansion URI template
+    * expression.
     */
     class FormStyleQueryContinuationExpression : public ClassifiedExpression
     {
     public:
-        FormStyleQueryContinuationExpression(const std::string& expression) : ClassifiedExpression(expression)
+        FormStyleQueryContinuationExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
             isSupported = true;
         }
@@ -249,7 +266,8 @@ namespace snowcrash
     class UndefinedExpression : public ClassifiedExpression
     {
     public:
-        UndefinedExpression(const std::string& expression) : ClassifiedExpression(expression)
+        UndefinedExpression(const std::string& expression)
+            : ClassifiedExpression(expression)
         {
             unsupportedWarningText = "Unidentified expression";
         }
@@ -268,13 +286,15 @@ namespace snowcrash
     {
     public:
         /**
-        *  \brief Parse the URI template into scheme, host and path and then parse for supported URI template
+        *  \brief Parse the URI template into scheme, host and path and then
+        * parse for supported URI template
         * expressions
         *
         *  \param uri        A uri to be parsed.
         */
-        static void parse(
-            const URITemplate& uri, const mdp::CharactersRangeSet& sourceBlock, ParsedURITemplate& result);
+        static void parse(const URITemplate& uri,
+            const mdp::CharactersRangeSet& sourceBlock,
+            ParsedURITemplate& result);
     };
 }
 

--- a/src/ValuesParser.h
+++ b/src/ValuesParser.h
@@ -28,7 +28,8 @@ namespace snowcrash
     template <>
     struct SectionProcessor<Values> : public SectionProcessorBase<Values> {
 
-        static MarkdownNodeIterator processNestedSection(const MarkdownNodeIterator& node,
+        static MarkdownNodeIterator processNestedSection(
+            const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             SectionParserData& pd,
             const ParseResultRef<Values>& out)
@@ -58,8 +59,10 @@ namespace snowcrash
                     ss << ", expected '`" << content << "`'";
 
                     mdp::CharactersRangeSet sourceMap
-                        = mdp::BytesRangeSetToCharactersRangeSet(node->sourceMap, pd.sourceCharacterIndex);
-                    out.report.warnings.push_back(Warning(ss.str(), IgnoringWarning, sourceMap));
+                        = mdp::BytesRangeSetToCharactersRangeSet(
+                            node->sourceMap, pd.sourceCharacterIndex);
+                    out.report.warnings.push_back(
+                        Warning(ss.str(), IgnoringWarning, sourceMap));
                 }
 
                 return ++MarkdownNodeIterator(node);
@@ -73,7 +76,8 @@ namespace snowcrash
         static SectionType sectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 mdp::ByteBuffer subject = node->children().front().text;
                 TrimString(subject);
@@ -89,7 +93,8 @@ namespace snowcrash
         static SectionType nestedSectionType(const MarkdownNodeIterator& node)
         {
 
-            if (node->type == mdp::ListItemMarkdownNodeType && !node->children().empty()) {
+            if (node->type == mdp::ListItemMarkdownNodeType
+                && !node->children().empty()) {
 
                 mdp::ByteBuffer subject = node->children().front().text;
                 TrimString(subject);

--- a/src/posix/RegexMatch.cc
+++ b/src/posix/RegexMatch.cc
@@ -12,7 +12,8 @@
 
 // FIXME: Migrate to C++11.
 // Naive implementation of regex matching using POSIX regex
-bool snowcrash::RegexMatch(const std::string& target, const std::string& expression)
+bool snowcrash::RegexMatch(
+    const std::string& target, const std::string& expression)
 {
     if (target.empty() || expression.empty())
         return false;
@@ -42,7 +43,8 @@ bool snowcrash::RegexMatch(const std::string& target, const std::string& express
     return false;
 }
 
-std::string snowcrash::RegexCaptureFirst(const std::string& target, const std::string& expression)
+std::string snowcrash::RegexCaptureFirst(
+    const std::string& target, const std::string& expression)
 {
     CaptureGroups groups;
     if (!RegexCapture(target, expression, groups) || groups.size() < 2)
@@ -51,8 +53,10 @@ std::string snowcrash::RegexCaptureFirst(const std::string& target, const std::s
     return groups[1];
 }
 
-bool snowcrash::RegexCapture(
-    const std::string& target, const std::string& expression, CaptureGroups& captureGroups, size_t groupSize)
+bool snowcrash::RegexCapture(const std::string& target,
+    const std::string& expression,
+    CaptureGroups& captureGroups,
+    size_t groupSize)
 {
     if (target.empty() || expression.empty())
         return false;
@@ -76,7 +80,9 @@ bool snowcrash::RegexCapture(
                 if (pmatch[i].rm_so == -1 || pmatch[i].rm_eo == -1)
                     captureGroups.push_back(std::string());
                 else
-                    captureGroups.push_back(std::string(target, pmatch[i].rm_so, pmatch[i].rm_eo - pmatch[i].rm_so));
+                    captureGroups.push_back(std::string(target,
+                        pmatch[i].rm_so,
+                        pmatch[i].rm_eo - pmatch[i].rm_so));
             }
 
             delete[] pmatch;

--- a/src/snowcrash.cc
+++ b/src/snowcrash.cc
@@ -26,7 +26,9 @@ static bool CheckSource(const mdp::ByteBuffer& source, Report& report)
 
         mdp::BytesRangeSet rangeSet;
         rangeSet.push_back(mdp::BytesRange(pos, 1));
-        report.error = Error("the use of tab(s) '\\t' in source data isn't currently supported, please contact makers",
+        report.error = Error(
+            "the use of tab(s) '\\t' in source data isn't currently supported, "
+            "please contact makers",
             BusinessError,
             mdp::BytesRangeSetToCharactersRangeSet(rangeSet, source));
         return false;
@@ -39,7 +41,8 @@ static bool CheckSource(const mdp::ByteBuffer& source, Report& report)
         mdp::BytesRangeSet rangeSet;
         rangeSet.push_back(mdp::BytesRange(pos, 1));
         report.error = Error(
-            "the use of carriage return(s) '\\r' in source data isn't currently supported, please contact makers",
+            "the use of carriage return(s) '\\r' in source data isn't "
+            "currently supported, please contact makers",
             BusinessError,
             mdp::BytesRangeSetToCharactersRangeSet(rangeSet, source));
         return false;
@@ -48,8 +51,9 @@ static bool CheckSource(const mdp::ByteBuffer& source, Report& report)
     return true;
 }
 
-int snowcrash::parse(
-    const mdp::ByteBuffer& source, BlueprintParserOptions options, const ParseResultRef<Blueprint>& out)
+int snowcrash::parse(const mdp::ByteBuffer& source,
+    BlueprintParserOptions options,
+    const ParseResultRef<Blueprint>& out)
 {
     try {
 
@@ -71,7 +75,8 @@ int snowcrash::parse(
         mdp::BuildCharacterIndex(pd.sourceCharacterIndex, source);
 
         // Parse Blueprint
-        BlueprintParser::parse(markdownAST.children().begin(), markdownAST.children(), pd, out);
+        BlueprintParser::parse(
+            markdownAST.children().begin(), markdownAST.children(), pd, out);
     } catch (const Error& e) {
         out.report.error = e;
     } catch (const std::exception& e) {
@@ -80,7 +85,8 @@ int snowcrash::parse(
         ss << "parser exception: '" << e.what() << "'";
         out.report.error = Error(ss.str(), ApplicationError);
     } catch (...) {
-        out.report.error = Error("parser exception has occured", ApplicationError);
+        out.report.error
+            = Error("parser exception has occured", ApplicationError);
     }
 
     return out.report.error.code;

--- a/src/snowcrash.h
+++ b/src/snowcrash.h
@@ -30,14 +30,17 @@ namespace snowcrash
 {
 
     /**
-     *  \brief Parse the source data into a blueprint abstract source tree (AST).
+     *  \brief Parse the source data into a blueprint abstract source tree
+     * (AST).
      *
      *  \param source       A textual source data to be parsed.
      *  \param options      Parser options. Use 0 for no additional options.
      *  \param out          Output buffer to store parsing result into.
      *  \return Error status code. Zero represents success, non-zero a failure.
      */
-    int parse(const mdp::ByteBuffer& source, BlueprintParserOptions options, const ParseResultRef<Blueprint>& out);
+    int parse(const mdp::ByteBuffer& source,
+        BlueprintParserOptions options,
+        const ParseResultRef<Blueprint>& out);
 }
 
 #endif

--- a/src/win/RegexMatch.cc
+++ b/src/win/RegexMatch.cc
@@ -34,7 +34,8 @@ bool snowcrash::RegexMatch(const string& target, const string& expression)
     return false;
 }
 
-string snowcrash::RegexCaptureFirst(const string& target, const string& expression)
+string snowcrash::RegexCaptureFirst(
+    const string& target, const string& expression)
 {
     CaptureGroups groups;
     if (!RegexCapture(target, expression, groups) || groups.size() < 2)
@@ -43,8 +44,10 @@ string snowcrash::RegexCaptureFirst(const string& target, const string& expressi
     return groups[1];
 }
 
-bool snowcrash::RegexCapture(
-    const string& target, const string& expression, CaptureGroups& captureGroups, size_t groupSize)
+bool snowcrash::RegexCapture(const string& target,
+    const string& expression,
+    CaptureGroups& captureGroups,
+    size_t groupSize)
 {
     if (target.empty() || expression.empty())
         return false;
@@ -58,7 +61,10 @@ bool snowcrash::RegexCapture(
         if (!regex_search(target, result, pattern))
             return false;
 
-        for (match_results<string::const_iterator>::const_iterator it = result.begin(); it != result.end(); ++it) {
+        for (match_results<string::const_iterator>::const_iterator it
+             = result.begin();
+             it != result.end();
+             ++it) {
 
             captureGroups.push_back(*it);
         }

--- a/test/performance/perf-snowcrash.cc
+++ b/test/performance/perf-snowcrash.cc
@@ -57,7 +57,8 @@ int gettimeofday(struct timeval* tv, struct timezone* tz)
     if (tz) {
         rez = GetTimeZoneInformation(&tz_winapi);
         tz->tz_dsttime = (rez == 2) ? true : false;
-        tz->tz_minuteswest = tz_winapi.Bias + ((rez == 2) ? tz_winapi.DaylightBias : 0);
+        tz->tz_minuteswest
+            = tz_winapi.Bias + ((rez == 2) ? tz_winapi.DaylightBias : 0);
     }
 
     return 0;
@@ -72,7 +73,8 @@ int gettimeofday(struct timeval* tv, struct timezone* tz)
  *  \param  stddev  Standard deviation.
  *  \return Result code of snowcrash::parse operation.
  */
-static int testfunc(const std::string& input, double& total, double& mean, double& stddev)
+static int testfunc(
+    const std::string& input, double& total, double& mean, double& stddev)
 {
     struct timeval stime, etime;
     double t = 0, sum = 0, sum2 = 0;
@@ -98,7 +100,8 @@ static int testfunc(const std::string& input, double& total, double& mean, doubl
         resultCode = blueprint.report.error.code;
 
         // Compute the time taken and add it to the sums.
-        t = (etime.tv_sec - stime.tv_sec) + (etime.tv_usec - stime.tv_usec) / 1000000.0;
+        t = (etime.tv_sec - stime.tv_sec)
+            + (etime.tv_usec - stime.tv_usec) / 1000000.0;
         sum += t;
         sum2 += t * t;
     }
@@ -112,8 +115,10 @@ static int testfunc(const std::string& input, double& total, double& mean, doubl
 
 void help()
 {
-    std::cout << "usage: perf-snowcrash [options] ... <input file>" << std::endl << std::endl;
-    std::cout << "API Blueprint Parser Performance Test Tool" << std::endl << std::endl;
+    std::cout << "usage: perf-snowcrash [options] ... <input file>" << std::endl
+              << std::endl;
+    std::cout << "API Blueprint Parser Performance Test Tool" << std::endl
+              << std::endl;
     std::cout << "options:" << std::endl << std::endl;
     std::cout << "  -h, --help    display this help message" << std::endl;
     exit(0);
@@ -143,7 +148,8 @@ int main(int argc, const char* argv[])
     std::string inputFileName = argv[1];
     inputFileStream.open(inputFileName.c_str());
     if (!inputFileStream.is_open()) {
-        std::cerr << "fatal: unable to open input file '" << inputFileName << "'\n";
+        std::cerr << "fatal: unable to open input file '" << inputFileName
+                  << "'\n";
         exit(EXIT_FAILURE);
     }
 
@@ -156,8 +162,10 @@ int main(int argc, const char* argv[])
     double mean = 0, total = 0, stddev = 0;
     int result = testfunc(inputStream.str(), total, mean, stddev);
 
-    std::cout << "parsing '" << inputFileName << "' " << TestRunCount << "-times (" << result << "):\n";
-    std::cout << "total: " << total << "s mean: " << mean << " +/- " << stddev << "s\n";
+    std::cout << "parsing '" << inputFileName << "' " << TestRunCount
+              << "-times (" << result << "):\n";
+    std::cout << "total: " << total << "s mean: " << mean << " +/- " << stddev
+              << "s\n";
 
     // FIXME: Intstrumetns helper
     //::sleep(20);

--- a/test/snowcrashtest.h
+++ b/test/snowcrashtest.h
@@ -61,13 +61,21 @@ namespace snowcrashtest
 
             pd.sectionsContext.push_back(type);
 
-            pd.modelTable.insert(models.modelTable.begin(), models.modelTable.end());
-            pd.modelSourceMapTable.insert(models.modelSourceMapTable.begin(), models.modelSourceMapTable.end());
+            pd.modelTable.insert(
+                models.modelTable.begin(), models.modelTable.end());
+            pd.modelSourceMapTable.insert(models.modelSourceMapTable.begin(),
+                models.modelSourceMapTable.end());
 
-            pd.namedTypeBaseTable.insert(namedTypes.baseTable.begin(), namedTypes.baseTable.end());
-            pd.namedTypeDependencyTable.insert(namedTypes.dependencyTable.begin(), namedTypes.dependencyTable.end());
+            pd.namedTypeBaseTable.insert(
+                namedTypes.baseTable.begin(), namedTypes.baseTable.end());
+            pd.namedTypeDependencyTable.insert(
+                namedTypes.dependencyTable.begin(),
+                namedTypes.dependencyTable.end());
 
-            PARSER::parse(markdownAST.children().begin(), markdownAST.children(), pd, out);
+            PARSER::parse(markdownAST.children().begin(),
+                markdownAST.children(),
+                pd,
+                out);
         }
 
         static void parseMSON(const mdp::ByteBuffer& source,
@@ -107,7 +115,9 @@ namespace snowcrashtest
     struct NamedTypeHelper {
 
         /** Builds an named type entry for testing purposes */
-        static void build(const mson::Literal& literal, const mson::BaseType& baseType, NamedTypes& namedTypes)
+        static void build(const mson::Literal& literal,
+            const mson::BaseType& baseType,
+            NamedTypes& namedTypes)
         {
 
             namedTypes.baseTable[literal] = baseType;
@@ -144,8 +154,12 @@ namespace snowcrashtest
             scpl::Signature signature;
             scpl::SignatureTraits signatureTraits(traits);
 
-            signature = scpl::SignatureSectionProcessorBase<snowcrash::Blueprint>::parseSignature(
-                markdownAST.children().begin(), pd, signatureTraits, out.report);
+            signature
+                = scpl::SignatureSectionProcessorBase<snowcrash::Blueprint>::
+                    parseSignature(markdownAST.children().begin(),
+                        pd,
+                        signatureTraits,
+                        out.report);
 
             return signature;
         }
@@ -158,12 +172,15 @@ namespace snowcrashtest
 
         /**
          * If 'nth' is not given, check that the given sourceMap is of size 1
-         * and also check the first row of the given sourceMap with the given location & length.
+         * and also check the first row of the given sourceMap with the given
+         * location & length.
          *
-         * If 'nth' is given, check that particular row of the given sourceMap with the
+         * If 'nth' is given, check that particular row of the given sourceMap
+         * with the
          * given location & length.
          */
-        static void check(mdp::BytesRangeSet& sourceMap, int loc, int len, size_t nth = 0)
+        static void check(
+            mdp::BytesRangeSet& sourceMap, int loc, int len, size_t nth = 0)
         {
 
             if (nth == 0) {
@@ -179,7 +196,11 @@ namespace snowcrashtest
         /**
          * Test a sourcemap which is of size 2
          */
-        static void check(mdp::BytesRangeSet& sourceMap, int loc1, int len1, int loc2, int len2)
+        static void check(mdp::BytesRangeSet& sourceMap,
+            int loc1,
+            int len1,
+            int loc2,
+            int len2)
         {
 
             REQUIRE(sourceMap.size() == 2);

--- a/test/test-ActionParser.cc
+++ b/test/test-ActionParser.cc
@@ -27,20 +27,23 @@ TEST_CASE("Method block classifier", "[action]")
     markdownParser.parse(ActionFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Action>::sectionType(markdownAST.children().begin());
+    sectionType
+        = SectionProcessor<Action>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == ActionSectionType);
 
     // Nameless method
     markdownAST.children().front().text = "GET";
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Action>::sectionType(markdownAST.children().begin());
+    sectionType
+        = SectionProcessor<Action>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == ActionSectionType);
 }
 
 TEST_CASE("Parsing action", "[action]")
 {
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(ActionFixture, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        ActionFixture, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -56,21 +59,40 @@ TEST_CASE("Parsing action", "[action]")
     REQUIRE(action.node.examples.front().responses[0].name == "200");
     REQUIRE(action.node.examples.front().responses[0].body == "OK.\n");
     REQUIRE(action.node.examples.front().responses[0].headers.size() == 1);
-    REQUIRE(action.node.examples.front().responses[0].headers[0].first == "Content-Type");
-    REQUIRE(action.node.examples.front().responses[0].headers[0].second == "text/plain");
+    REQUIRE(action.node.examples.front().responses[0].headers[0].first
+        == "Content-Type");
+    REQUIRE(action.node.examples.front().responses[0].headers[0].second
+        == "text/plain");
 
     SourceMapHelper::check(action.sourceMap.name.sourceMap, 0, 19);
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 19);
     SourceMapHelper::check(action.sourceMap.description.sourceMap, 19, 20);
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 
-    SourceMapHelper::check(action.sourceMap.examples.collection[0].responses.collection[0].body.sourceMap, 72, 7);
-    SourceMapHelper::check(action.sourceMap.examples.collection[0].responses.collection[0].name.sourceMap, 41, 27);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection[0].headers.collection.size() == 1);
-    SourceMapHelper::check(
-        action.sourceMap.examples.collection[0].responses.collection[0].headers.collection[0].sourceMap, 41, 27);
+    SourceMapHelper::check(action.sourceMap.examples.collection[0]
+                               .responses.collection[0]
+                               .body.sourceMap,
+        72,
+        7);
+    SourceMapHelper::check(action.sourceMap.examples.collection[0]
+                               .responses.collection[0]
+                               .name.sourceMap,
+        41,
+        27);
+    REQUIRE(action.sourceMap.examples.collection[0]
+                .responses.collection[0]
+                .headers.collection.size()
+        == 1);
+    SourceMapHelper::check(action.sourceMap.examples.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[0]
+                               .sourceMap,
+        41,
+        27);
 }
 
 TEST_CASE("Parse named action with () in title", "[action]")
@@ -80,7 +102,8 @@ TEST_CASE("Parse named action with () in title", "[action]")
           "+ Response 204\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -96,7 +119,8 @@ TEST_CASE("Parse named action with path including () in title", "[action]")
           "+ Response 204\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -113,7 +137,8 @@ TEST_CASE("Parse named action with [] in title", "[action]")
           "+ Response 204\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -132,7 +157,8 @@ TEST_CASE("Parse Action description with list", "[action]")
           "+ Response 204\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     CHECK(action.report.warnings.empty());
@@ -148,8 +174,10 @@ TEST_CASE("Parse Action description with list", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 6);
     SourceMapHelper::check(action.sourceMap.description.sourceMap, 6, 26);
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Parse method with multiple requests and responses", "[action]")
@@ -174,10 +202,12 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
           "            J\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
-    REQUIRE(action.report.warnings.size() == 1); // warn responses with the same name
+    REQUIRE(action.report.warnings.size()
+        == 1); // warn responses with the same name
 
     REQUIRE(action.node.name.empty());
     REQUIRE(action.node.method == "PUT");
@@ -221,8 +251,10 @@ TEST_CASE("Parse method with multiple requests and responses", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 6);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 2);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 2);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 2);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 2);
 }
 
 TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
@@ -235,10 +267,12 @@ TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
           "+ Response 200\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
-    REQUIRE(action.report.warnings.size() == 2); // empty asset & preformatted asset
+    REQUIRE(
+        action.report.warnings.size() == 2); // empty asset & preformatted asset
     REQUIRE(action.report.warnings[0].code == EmptyDefinitionWarning);
     REQUIRE(action.report.warnings[1].code == IndentationWarning);
 
@@ -267,8 +301,10 @@ TEST_CASE("Parse method with multiple incomplete requests", "[action][blocks]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 9);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 2);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 2);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Parse method with foreign item", "[action]")
@@ -282,7 +318,8 @@ TEST_CASE("Parse method with foreign item", "[action]")
           "+ Response 200\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -306,8 +343,10 @@ TEST_CASE("Parse method with foreign item", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 8);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Parse method with a HR", "[action]")
@@ -319,7 +358,8 @@ TEST_CASE("Parse method with a HR", "[action]")
           "B\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // no response
@@ -340,7 +380,8 @@ TEST_CASE("Parse method without name", "[action]")
     mdp::ByteBuffer source = "# GET";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1); // no response
@@ -366,7 +407,8 @@ TEST_CASE("Parse action with parameters", "[action]")
           "\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -383,10 +425,13 @@ TEST_CASE("Parse action with parameters", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 21);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.parameters.collection.size() == 1);
-    SourceMapHelper::check(action.sourceMap.parameters.collection[0].name.sourceMap, 40, 44);
+    SourceMapHelper::check(
+        action.sourceMap.parameters.collection[0].name.sourceMap, 40, 44);
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
@@ -397,7 +442,8 @@ TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
           "        {}\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -411,8 +457,10 @@ TEST_CASE("Give a warning when 2xx CONNECT has a body", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 13);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
@@ -423,7 +471,8 @@ TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
           "        {}\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -438,8 +487,10 @@ TEST_CASE("Give a warning when response to HEAD has a body", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 10);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Missing 'LINK' HTTP request method", "[action]")
@@ -449,7 +500,8 @@ TEST_CASE("Missing 'LINK' HTTP request method", "[action]")
           "+ Response 204\n\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -462,8 +514,10 @@ TEST_CASE("Missing 'LINK' HTTP request method", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 10);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
 }
 
 TEST_CASE("Warn when request is not followed by a response", "[action]")
@@ -479,7 +533,8 @@ TEST_CASE("Warn when request is not followed by a response", "[action]")
           "        A\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -495,13 +550,18 @@ TEST_CASE("Warn when request is not followed by a response", "[action]")
     SourceMapHelper::check(action.sourceMap.method.sourceMap, 0, 9);
     REQUIRE(action.sourceMap.description.sourceMap.empty());
     REQUIRE(action.sourceMap.examples.collection.size() == 2);
-    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size() == 0);
-    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[1].requests.collection.size() == 1);
-    REQUIRE(action.sourceMap.examples.collection[1].responses.collection.size() == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].requests.collection.size()
+        == 0);
+    REQUIRE(action.sourceMap.examples.collection[0].responses.collection.size()
+        == 1);
+    REQUIRE(action.sourceMap.examples.collection[1].requests.collection.size()
+        == 1);
+    REQUIRE(action.sourceMap.examples.collection[1].responses.collection.size()
+        == 0);
 }
 
-// TODO: This test is failing because of a bug in action attributes. Need to fix the bug.
+// TODO: This test is failing because of a bug in action attributes. Need to fix
+// the bug.
 // TEST_CASE("Parse action attributes", "[action]")
 // {
 //    mdp::ByteBuffer source = \
@@ -517,19 +577,22 @@ TEST_CASE("Warn when request is not followed by a response", "[action]")
 //    NamedTypes namedTypes;
 
 //    NamedTypeHelper::build("Coupon", mson::ObjectBaseType, namedTypes);
-//    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption,
+//    SectionParserHelper<Action, ActionParser>::parse(source,
+//    ActionSectionType, action, ExportSourcemapOption,
 //    Models(), NULL, namedTypes);
 
 //    REQUIRE(action.report.error.code == Error::OK);
 //    REQUIRE(action.report.warnings.empty());
 
-//    REQUIRE(action.node.attributes.source.typeDefinition.typeSpecification.name.symbol.literal == "Coupon");
+//    REQUIRE(action.node.attributes.source.typeDefinition.typeSpecification.name.symbol.literal
+//    == "Coupon");
 //    REQUIRE(action.node.examples.size() == 2);
 //    REQUIRE(action.node.examples[0].requests.size() == 1);
 //    REQUIRE(action.node.examples[0].requests[0].attributes.source.empty());
 //    REQUIRE(action.node.examples[0].responses.size() == 1);
 //    REQUIRE(action.node.examples[1].requests.size() == 1);
-//    REQUIRE(action.node.examples[1].requests[0].attributes.source.typeDefinition.typeSpecification.name.base ==
+//    REQUIRE(action.node.examples[1].requests[0].attributes.source.typeDefinition.typeSpecification.name.base
+//    ==
 //    mson::StringTypeName);
 //    REQUIRE(action.node.examples[1].responses.size() == 1);
 // }
@@ -550,11 +613,19 @@ TEST_CASE("Named Endpoint", "[named_endpoint]")
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.name == "My Named Endpoint");
     REQUIRE(resource.uriTemplate == "/test/endpoint");
     REQUIRE(resource.actions.size() == 1);
@@ -583,12 +654,20 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     REQUIRE(blueprint.report.warnings.at(1).code == DuplicateWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 3);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 3);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
     {
-        Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+        Resource resource = blueprint.node.content.elements()
+                                .at(0)
+                                .content.elements()
+                                .at(0)
+                                .content.resource;
         REQUIRE(resource.name == "Endpoint 1");
         REQUIRE(resource.uriTemplate == "/e1");
         REQUIRE(resource.actions.size() == 1);
@@ -598,7 +677,11 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     }
 
     {
-        Resource resource = blueprint.node.content.elements().at(0).content.elements().at(1).content.resource;
+        Resource resource = blueprint.node.content.elements()
+                                .at(0)
+                                .content.elements()
+                                .at(1)
+                                .content.resource;
         REQUIRE(resource.name == "Endpoint 2");
         REQUIRE(resource.uriTemplate == "/e1");
         REQUIRE(resource.actions.size() == 1);
@@ -608,7 +691,11 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     }
 
     {
-        Resource resource = blueprint.node.content.elements().at(0).content.elements().at(2).content.resource;
+        Resource resource = blueprint.node.content.elements()
+                                .at(0)
+                                .content.elements()
+                                .at(2)
+                                .content.resource;
         REQUIRE(resource.name == "Endpoint 3");
         REQUIRE(resource.uriTemplate == "/e1");
         REQUIRE(resource.actions.size() == 1);
@@ -618,7 +705,8 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     }
 }
 
-TEST_CASE("Action section containing properties keyword under it", "[action][127]")
+TEST_CASE(
+    "Action section containing properties keyword under it", "[action][127]")
 {
     const mdp::ByteBuffer source
         = "# A [GET /]\n"
@@ -626,7 +714,8 @@ TEST_CASE("Action section containing properties keyword under it", "[action][127
           "+ Response 204";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -643,7 +732,8 @@ TEST_CASE("Miss leading slash in URI", "[action][350]")
     snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
     snowcrash::SectionParserData pd(0, source, blueprint.node);
     MarkdownNodes nodes;
-    nodes.push_back(mdp::MarkdownNode(mdp::HeaderMarkdownNodeType, NULL, mdp::ByteBuffer(source)));
+    nodes.push_back(mdp::MarkdownNode(
+        mdp::HeaderMarkdownNodeType, NULL, mdp::ByteBuffer(source)));
     Report report;
     SectionProcessor<Action>::checkForTypoMistake(nodes.begin(), pd, report);
 
@@ -654,7 +744,8 @@ TEST_CASE("Miss leading slash in URI", "[action][350]")
         == "URI path in 'A [GET {param}]' is not absolute, it should have a leading forward slash");
 }
 
-TEST_CASE("Detect invalid reference to URI Template parameters in Action", "[action]")
+TEST_CASE(
+    "Detect invalid reference to URI Template parameters in Action", "[action]")
 {
     mdp::ByteBuffer source
         = "## List [GET /orders{?abc}]\n\n"
@@ -665,7 +756,8 @@ TEST_CASE("Detect invalid reference to URI Template parameters in Action", "[act
           "+ Response 200";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action, ExportSourcemapOption);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action, ExportSourcemapOption);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 3);

--- a/test/test-AssetParser.cc
+++ b/test/test-AssetParser.cc
@@ -29,7 +29,8 @@ TEST_CASE("Recognize explicit body signature", "[asset]")
     markdownParser.parse(BodyAssetFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
+    SectionType sectionType
+        = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == BodySectionType);
 }
 
@@ -44,7 +45,8 @@ TEST_CASE("Recognize body with content on signature", "[asset]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
+    SectionType sectionType
+        = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == BodySectionType);
 }
 
@@ -55,14 +57,16 @@ TEST_CASE("Recognize schema signature", "[asset]")
     markdownParser.parse(SchemaAssetFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
+    SectionType sectionType
+        = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == SchemaSectionType);
 }
 
 TEST_CASE("Parse body asset", "[asset]")
 {
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(BodyAssetFixture, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        BodyAssetFixture, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -74,7 +78,8 @@ TEST_CASE("Parse body asset", "[asset]")
 TEST_CASE("Parse schema asset", "[asset]")
 {
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(SchemaAssetFixture, SchemaSectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        SchemaAssetFixture, SchemaSectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -91,7 +96,8 @@ TEST_CASE("Foreign block inside", "[asset]")
     "    Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -109,7 +115,8 @@ TEST_CASE("Nested list block inside", "[asset]")
     "    + Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -128,7 +135,8 @@ TEST_CASE("Multiline signature", "[asset]")
           "        Hello World!\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 1);
@@ -153,7 +161,8 @@ TEST_CASE("Multiple blocks", "[asset]")
           "    Block 3\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.size() == 2);
@@ -175,7 +184,8 @@ TEST_CASE("Extra spaces before signature", "[asset]")
           "        Lorem Ipsum\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());
@@ -192,7 +202,8 @@ TEST_CASE("Asset parser greediness", "[asset]")
     "+ Another Block\n";
 
     ParseResult<Asset> asset;
-    SectionParserHelper<Asset, AssetParser>::parse(source, BodySectionType, asset, ExportSourcemapOption);
+    SectionParserHelper<Asset, AssetParser>::parse(
+        source, BodySectionType, asset, ExportSourcemapOption);
 
     REQUIRE(asset.report.error.code == Error::OK);
     REQUIRE(asset.report.warnings.empty());

--- a/test/test-AttributesParser.cc
+++ b/test/test-AttributesParser.cc
@@ -12,7 +12,8 @@
 using namespace snowcrash;
 using namespace snowcrashtest;
 
-const mdp::ByteBuffer AttributesFixture = "+ Attributes (array[[Coupon](#coupon)])";
+const mdp::ByteBuffer AttributesFixture
+    = "+ Attributes (array[[Coupon](#coupon)])";
 
 TEST_CASE("Recognize explicit attributes signature", "[attributes]")
 {
@@ -22,15 +23,18 @@ TEST_CASE("Recognize explicit attributes signature", "[attributes]")
     markdownParser.parse(AttributesFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Attributes>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Attributes>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == AttributesSectionType);
 }
 
 TEST_CASE("Parse canonical attributes", "[attributes]")
 {
     ParseResult<Attributes> attributes;
-    SectionParserHelper<Attributes, AttributesParser>::parse(
-        AttributesFixture, AttributesSectionType, attributes, ExportSourcemapOption);
+    SectionParserHelper<Attributes, AttributesParser>::parse(AttributesFixture,
+        AttributesSectionType,
+        attributes,
+        ExportSourcemapOption);
 
     REQUIRE(attributes.report.error.code == Error::OK);
     REQUIRE(attributes.report.warnings.empty());
@@ -38,13 +42,18 @@ TEST_CASE("Parse canonical attributes", "[attributes]")
     REQUIRE(attributes.node.name.empty());
     REQUIRE(attributes.node.sections.empty());
     REQUIRE(attributes.node.typeDefinition.attributes == 0);
-    REQUIRE(attributes.node.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(attributes.node.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(attributes.node.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(attributes.node.typeDefinition.typeSpecification.name.base
+        == mson::ArrayTypeName);
+    REQUIRE(attributes.node.typeDefinition.typeSpecification.nestedTypes.size()
+        == 1);
+    REQUIRE(attributes.node.typeDefinition.typeSpecification.nestedTypes[0]
+                .symbol.literal
+        == "Coupon");
     REQUIRE(attributes.node.typeDefinition.baseType == mson::ValueBaseType);
 
     REQUIRE(attributes.sourceMap.name.sourceMap.empty());
-    SourceMapHelper::check(attributes.sourceMap.typeDefinition.sourceMap, 2, 37);
+    SourceMapHelper::check(
+        attributes.sourceMap.typeDefinition.sourceMap, 2, 37);
     REQUIRE(attributes.sourceMap.sections.collection.empty());
 }
 
@@ -64,42 +73,54 @@ TEST_CASE("Parse attributes with nested members", "[attributes]")
 
     REQUIRE(attributes.node.name.empty());
     REQUIRE(attributes.node.typeDefinition.empty());
-    REQUIRE(attributes.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(attributes.node.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
     REQUIRE(attributes.node.sections.size() == 1);
-    REQUIRE(attributes.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(attributes.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(attributes.node.sections[0].content.elements().size() == 2);
 
-    mson::Element element = attributes.node.sections[0].content.elements().at(0);
+    mson::Element element
+        = attributes.node.sections[0].content.elements().at(0);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "message");
     REQUIRE(element.content.property.description == "The blog post article");
     REQUIRE(element.content.property.valueDefinition.values.empty());
-    REQUIRE(
-        element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::StringTypeName);
 
     element = attributes.node.sections[0].content.elements().at(1);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "author");
     REQUIRE(element.content.property.description == "Author of the blog post");
     REQUIRE(element.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(element.content.property.valueDefinition.values[0].literal == "john@appleseed.com");
-    REQUIRE(
-        element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+    REQUIRE(element.content.property.valueDefinition.values[0].literal
+        == "john@appleseed.com");
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::StringTypeName);
 
     REQUIRE(attributes.sourceMap.name.sourceMap.empty());
     REQUIRE(attributes.sourceMap.typeDefinition.sourceMap.empty());
     REQUIRE(attributes.sourceMap.sections.collection.size() == 1);
-    REQUIRE(attributes.sourceMap.sections.collection[0].elements().collection.size() == 2);
+    REQUIRE(
+        attributes.sourceMap.sections.collection[0].elements().collection.size()
+        == 2);
 
-    SourceMap<mson::Element> elementSM = attributes.sourceMap.sections.collection[0].elements().collection[0];
+    SourceMap<mson::Element> elementSM
+        = attributes.sourceMap.sections.collection[0].elements().collection[0];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 18, 41);
     SourceMapHelper::check(elementSM.property.description.sourceMap, 18, 41);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 18, 41);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 18, 41);
 
-    elementSM = attributes.sourceMap.sections.collection[0].elements().collection[1];
+    elementSM
+        = attributes.sourceMap.sections.collection[0].elements().collection[1];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 65, 61);
     SourceMapHelper::check(elementSM.property.description.sourceMap, 65, 61);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 65, 61);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 65, 61);
 }
 
 TEST_CASE("Parse attributes with block description", "[attributes]")
@@ -120,20 +141,38 @@ TEST_CASE("Parse attributes with block description", "[attributes]")
 
     REQUIRE(attributes.node.name.empty());
     REQUIRE(attributes.node.typeDefinition.empty());
-    REQUIRE(attributes.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(attributes.node.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
     REQUIRE(attributes.node.sections.size() == 2);
-    REQUIRE(attributes.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(attributes.node.sections[0].content.description == "Awesome description\n\n+ With list");
-    REQUIRE(attributes.node.sections[1].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(attributes.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(attributes.node.sections[0].content.description
+        == "Awesome description\n\n+ With list");
+    REQUIRE(attributes.node.sections[1].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(attributes.node.sections[1].content.elements().size() == 1);
 
     REQUIRE(attributes.sourceMap.name.sourceMap.empty());
     REQUIRE(attributes.sourceMap.typeDefinition.sourceMap.empty());
     REQUIRE(attributes.sourceMap.sections.collection.size() == 2);
-    SourceMapHelper::check(attributes.sourceMap.sections.collection[0].description.sourceMap, 2, 11, 1);
-    SourceMapHelper::check(attributes.sourceMap.sections.collection[0].description.sourceMap, 17, 20, 2);
-    SourceMapHelper::check(attributes.sourceMap.sections.collection[0].description.sourceMap, 42, 12, 3);
-    REQUIRE(attributes.sourceMap.sections.collection[1].elements().collection.size() == 1);
+    SourceMapHelper::check(
+        attributes.sourceMap.sections.collection[0].description.sourceMap,
+        2,
+        11,
+        1);
+    SourceMapHelper::check(
+        attributes.sourceMap.sections.collection[0].description.sourceMap,
+        17,
+        20,
+        2);
+    SourceMapHelper::check(
+        attributes.sourceMap.sections.collection[0].description.sourceMap,
+        42,
+        12,
+        3);
+    REQUIRE(
+        attributes.sourceMap.sections.collection[1].elements().collection.size()
+        == 1);
 }
 
 TEST_CASE("Parse type attributes on attributes section", "[attributes]")
@@ -152,7 +191,9 @@ TEST_CASE("Parse type attributes on attributes section", "[attributes]")
     REQUIRE(attributes.node.name.empty());
     REQUIRE(attributes.node.typeDefinition.attributes == 4);
     REQUIRE(attributes.node.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(attributes.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(attributes.node.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
     REQUIRE(attributes.node.sections.size() == 1);
-    REQUIRE(attributes.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(attributes.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
 }

--- a/test/test-BlueprintParser.cc
+++ b/test/test-BlueprintParser.cc
@@ -33,27 +33,33 @@ TEST_CASE("Blueprint block classifier", "[blueprint]")
     REQUIRE(!markdownAST.children().empty());
 
     // meta: verse
-    sectionType = SectionProcessor<Blueprint>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Blueprint>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == BlueprintSectionType);
 
     // # Snowcrash API
-    sectionType = SectionProcessor<Blueprint>::sectionType(markdownAST.children().begin() + 1);
+    sectionType = SectionProcessor<Blueprint>::sectionType(
+        markdownAST.children().begin() + 1);
     REQUIRE(sectionType == BlueprintSectionType);
 
     // ## Character
-    sectionType = SectionProcessor<Blueprint>::sectionType(markdownAST.children().begin() + 2);
+    sectionType = SectionProcessor<Blueprint>::sectionType(
+        markdownAST.children().begin() + 2);
     REQUIRE(sectionType == BlueprintSectionType);
 
     // Uncle Enzo
-    sectionType = SectionProcessor<Blueprint>::sectionType(markdownAST.children().begin() + 3);
+    sectionType = SectionProcessor<Blueprint>::sectionType(
+        markdownAST.children().begin() + 3);
     REQUIRE(sectionType == BlueprintSectionType);
 }
 
 TEST_CASE("Parse canonical blueprint", "[blueprint]")
 {
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        BlueprintFixture, BlueprintSectionType, blueprint, ExportSourcemapOption);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(BlueprintFixture,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -67,21 +73,41 @@ TEST_CASE("Parse canonical blueprint", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().size() == 2);
 
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name == "First");
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.copy == "p1");
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.copy
+        == "p1");
 
-    REQUIRE(blueprint.node.content.elements().at(1).attributes.name == "Second");
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.copy == "p2");
+    REQUIRE(
+        blueprint.node.content.elements().at(1).attributes.name == "Second");
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.copy
+        == "p2");
 
     SourceMapHelper::check(blueprint.sourceMap.name.sourceMap, 13, 17);
     SourceMapHelper::check(blueprint.sourceMap.description.sourceMap, 30, 25);
     REQUIRE(blueprint.sourceMap.metadata.collection.size() == 1);
-    SourceMapHelper::check(blueprint.sourceMap.metadata.collection[0].sourceMap, 0, 13);
+    SourceMapHelper::check(
+        blueprint.sourceMap.metadata.collection[0].sourceMap, 0, 13);
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 2);
 }
 
@@ -108,22 +134,43 @@ TEST_CASE("Parse blueprint with multiple metadata sections", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().size() == 2);
 
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name == "First");
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.copy == "p1");
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.copy
+        == "p1");
 
-    REQUIRE(blueprint.node.content.elements().at(1).attributes.name == "Second");
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.copy == "p2");
+    REQUIRE(
+        blueprint.node.content.elements().at(1).attributes.name == "Second");
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.copy
+        == "p2");
 
     SourceMapHelper::check(blueprint.sourceMap.name.sourceMap, 25, 17);
     SourceMapHelper::check(blueprint.sourceMap.description.sourceMap, 42, 25);
     REQUIRE(blueprint.sourceMap.metadata.collection.size() == 2);
-    SourceMapHelper::check(blueprint.sourceMap.metadata.collection[0].sourceMap, 0, 12);
-    SourceMapHelper::check(blueprint.sourceMap.metadata.collection[1].sourceMap, 12, 13);
+    SourceMapHelper::check(
+        blueprint.sourceMap.metadata.collection[0].sourceMap, 0, 12);
+    SourceMapHelper::check(
+        blueprint.sourceMap.metadata.collection[1].sourceMap, 12, 13);
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 2);
 }
 
@@ -149,16 +196,25 @@ TEST_CASE("Parse API with Name and abbreviated resource", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().size() == 1);
 
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions.front().examples.size() == 1);
     REQUIRE(resource.actions.front().examples.front().responses.size() == 1);
-    REQUIRE(resource.actions.front().examples.front().responses.front().body == "{}\n");
+    REQUIRE(resource.actions.front().examples.front().responses.front().body
+        == "{}\n");
 
     SourceMapHelper::check(blueprint.sourceMap.name.sourceMap, 0, 6);
     SourceMapHelper::check(blueprint.sourceMap.description.sourceMap, 6, 2);
@@ -228,13 +284,16 @@ TEST_CASE("Parse two groups with the same name", "[blueprint]")
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
-    REQUIRE(blueprint.report.warnings.size() == 2); // groups with same name & no response
+    REQUIRE(blueprint.report.warnings.size()
+        == 2); // groups with same name & no response
 
     REQUIRE(blueprint.node.content.elements().size() == 2);
 
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name == "Name");
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
 
     REQUIRE(blueprint.node.content.elements().at(1).attributes.name == "Name");
     REQUIRE(blueprint.node.content.elements().at(1).content.elements().empty());
@@ -251,7 +310,8 @@ TEST_CASE("Test parser options - required blueprint name", "[blueprint]")
 
     ParseResult<Blueprint> blueprint;
 
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(
+        source, BlueprintSectionType, blueprint);
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
     REQUIRE(blueprint.report.warnings[0].code == APINameWarning);
@@ -261,7 +321,8 @@ TEST_CASE("Test parser options - required blueprint name", "[blueprint]")
     REQUIRE(blueprint.report.error.code != Error::OK);
 }
 
-TEST_CASE("Test required blueprint name on blueprint that starts with metadata", "[blueprint]")
+TEST_CASE("Test required blueprint name on blueprint that starts with metadata",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "meta: data\n"
@@ -306,7 +367,8 @@ TEST_CASE("Should parse paragraph without final newline", "[blueprint]")
           "Lorem Ipsum";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(source, BlueprintSectionType, blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(
+        source, BlueprintSectionType, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -316,7 +378,8 @@ TEST_CASE("Should parse paragraph without final newline", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().empty());
 }
 
-TEST_CASE("Blueprint starting with Resource Group should be parsed", "[blueprint]")
+TEST_CASE(
+    "Blueprint starting with Resource Group should be parsed", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Group Posts\n"
@@ -333,9 +396,16 @@ TEST_CASE("Blueprint starting with Resource Group should be parsed", "[blueprint
     REQUIRE(blueprint.node.description.empty());
     REQUIRE(blueprint.node.content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name == "Posts");
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.resource.uriTemplate == "/posts");
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.resource.uriTemplate
+        == "/posts");
 
     REQUIRE(blueprint.sourceMap.name.sourceMap.empty());
     REQUIRE(blueprint.sourceMap.description.sourceMap.empty());
@@ -358,9 +428,16 @@ TEST_CASE("Blueprint starting with Resource should be parsed", "[blueprint]")
     REQUIRE(blueprint.node.description.empty());
     REQUIRE(blueprint.node.content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.resource.uriTemplate == "/posts");
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.resource.uriTemplate
+        == "/posts");
 
     REQUIRE(blueprint.sourceMap.name.sourceMap.empty());
     REQUIRE(blueprint.sourceMap.description.sourceMap.empty());
@@ -368,7 +445,8 @@ TEST_CASE("Blueprint starting with Resource should be parsed", "[blueprint]")
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 1);
 }
 
-TEST_CASE("Checking a resource with global resources for duplicates", "[blueprint]")
+TEST_CASE(
+    "Checking a resource with global resources for duplicates", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# /posts\n"
@@ -378,34 +456,70 @@ TEST_CASE("Checking a resource with global resources for duplicates", "[blueprin
           "### List posts [GET]\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
-    REQUIRE(blueprint.report.warnings.size() == 3); // 2x no response & duplicate resource
+    REQUIRE(blueprint.report.warnings.size()
+        == 3); // 2x no response & duplicate resource
 
     REQUIRE(blueprint.node.name.empty());
     REQUIRE(blueprint.node.description.empty());
     REQUIRE(blueprint.node.content.elements().size() == 2);
 
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.resource.uriTemplate == "/posts");
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.resource.actions.empty());
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.resource.uriTemplate
+        == "/posts");
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.resource.actions.empty());
 
     REQUIRE(blueprint.node.content.elements().at(1).attributes.name == "Posts");
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.uriTemplate == "/posts");
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.actions.size() == 2);
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.resource.uriTemplate
+        == "/posts");
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.resource.actions.size()
+        == 2);
 
     REQUIRE(blueprint.sourceMap.name.sourceMap.empty());
     REQUIRE(blueprint.sourceMap.description.sourceMap.empty());
     REQUIRE(blueprint.sourceMap.metadata.collection.size() == 0);
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 2);
-    REQUIRE(blueprint.sourceMap.content.elements().collection[0].content.elements().collection.size() == 1);
-    REQUIRE(blueprint.sourceMap.content.elements().collection[1].content.elements().collection.size() == 1);
+    REQUIRE(blueprint.sourceMap.content.elements()
+                .collection[0]
+                .content.elements()
+                .collection.size()
+        == 1);
+    REQUIRE(blueprint.sourceMap.content.elements()
+                .collection[1]
+                .content.elements()
+                .collection.size()
+        == 1);
 }
 
 TEST_CASE("Parsing unexpected blocks", "[blueprint]")
@@ -440,10 +554,16 @@ TEST_CASE("Parsing unexpected blocks", "[blueprint]")
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.uriTemplate == "/");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "GET");
@@ -451,7 +571,8 @@ TEST_CASE("Parsing unexpected blocks", "[blueprint]")
     SourceMapHelper::check(blueprint.sourceMap.name.sourceMap, 12, 5);
     SourceMapHelper::check(blueprint.sourceMap.description.sourceMap, 17, 30);
     REQUIRE(blueprint.sourceMap.metadata.collection.size() == 1);
-    SourceMapHelper::check(blueprint.sourceMap.metadata.collection[0].sourceMap, 0, 12);
+    SourceMapHelper::check(
+        blueprint.sourceMap.metadata.collection[0].sourceMap, 0, 12);
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 1);
 }
 
@@ -536,10 +657,12 @@ TEST_CASE("Parsing blueprint with mson data structures", "[blueprint]")
     markdownParser.parse(source, markdownAST);
     REQUIRE(!markdownAST.children().empty());
 
-    snowcrash::SectionParserData pd(ExportSourcemapOption, source, blueprint.node);
+    snowcrash::SectionParserData pd(
+        ExportSourcemapOption, source, blueprint.node);
     pd.sectionsContext.push_back(BlueprintSectionType);
 
-    BlueprintParser::parse(markdownAST.children().begin(), markdownAST.children(), pd, blueprint);
+    BlueprintParser::parse(
+        markdownAST.children().begin(), markdownAST.children(), pd, blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -565,16 +688,28 @@ TEST_CASE("Parsing blueprint with mson data structures", "[blueprint]")
     REQUIRE(inheritanceIt->second.first == "Plan Base");
 
     REQUIRE(blueprint.node.content.elements().size() == 3);
-    REQUIRE(blueprint.node.content.elements().at(2).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(2).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.dataStructure.name.symbol.literal
+    REQUIRE(blueprint.node.content.elements().at(2).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(2).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 2);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.dataStructure.name.symbol.literal
         == "Plan Base");
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(1).content.dataStructure.name.symbol.literal
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(1)
+                .content.dataStructure.name.symbol.literal
         == "Timestamp");
 }
 
-TEST_CASE("Parse blueprint with two named types having the same name", "[blueprint]")
+TEST_CASE(
+    "Parse blueprint with two named types having the same name", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -586,23 +721,40 @@ TEST_CASE("Parse blueprint with two named types having the same name", "[bluepri
           "    - name - Coupon name";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint);
 
     REQUIRE(blueprint.report.error.code == MSONError);
     REQUIRE(blueprint.report.warnings.size() == 1);
     REQUIRE(blueprint.report.warnings[0].code == DuplicateWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.attributes.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.resource.attributes.empty());
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
 }
 
-TEST_CASE("Parser blueprint correctly when having a big chain of inheritance in data structures", "[blueprint]")
+TEST_CASE(
+    "Parser blueprint correctly when having a big chain of inheritance in data "
+    "structures",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "## GET /\n"
@@ -630,24 +782,55 @@ TEST_CASE("Parser blueprint correctly when having a big chain of inheritance in 
 
     REQUIRE(blueprint.node.content.elements().size() == 2);
     REQUIRE(blueprint.node.content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.resource.attributes.empty());
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 3);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.dataStructure.name.symbol.literal
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.resource.attributes.empty());
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 3);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.dataStructure.name.symbol.literal
         == "Timestamps");
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(1).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(1).content.dataStructure.name.symbol.literal
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(1).element
+        == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(1)
+                .content.dataStructure.name.symbol.literal
         == "Coupon Base");
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(2).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(2).content.dataStructure.name.symbol.literal
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(2).element
+        == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(2)
+                .content.dataStructure.name.symbol.literal
         == "Coupon A");
 }
 
-TEST_CASE("Report error when coming across a super type reference to non existent named type", "[blueprint]")
+TEST_CASE(
+    "Report error when coming across a super type reference to non existent "
+    "named type",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -670,7 +853,8 @@ TEST_CASE("Report error when coming across a super type reference to non existen
     SourceMapHelper::check(blueprint.report.error.location, 62, 27);
 }
 
-TEST_CASE("Report error when a Data Structure inherits from itself", "[blueprint]")
+TEST_CASE(
+    "Report error when a Data Structure inherits from itself", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -686,7 +870,8 @@ TEST_CASE("Report error when a Data Structure inherits from itself", "[blueprint
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
 }
 
-TEST_CASE("Report error when named type inherits a sub type in array", "[blueprint]")
+TEST_CASE(
+    "Report error when named type inherits a sub type in array", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -702,7 +887,8 @@ TEST_CASE("Report error when named type inherits a sub type in array", "[bluepri
     SourceMapHelper::check(blueprint.report.error.location, 35, 9);
 }
 
-TEST_CASE("Report error when data Structure inheritance graph contains a cycle", "[blueprint]")
+TEST_CASE("Report error when data Structure inheritance graph contains a cycle",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -719,7 +905,10 @@ TEST_CASE("Report error when data Structure inheritance graph contains a cycle",
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
 }
 
-TEST_CASE("Report error when data Structure inheritance graph with only a few of them forming a cycle", "[blueprint]")
+TEST_CASE(
+    "Report error when data Structure inheritance graph with only a few of "
+    "them forming a cycle",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -738,7 +927,9 @@ TEST_CASE("Report error when data Structure inheritance graph with only a few of
     SourceMapHelper::check(blueprint.report.error.location, 37, 9);
 }
 
-TEST_CASE("Do not report error when named sub type is referenced in nested members", "[blueprint]")
+TEST_CASE(
+    "Do not report error when named sub type is referenced in nested members",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -754,32 +945,53 @@ TEST_CASE("Do not report error when named sub type is referenced in nested membe
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(1).element == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::DataStructureElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(1).element
+        == Element::DataStructureElement);
 
-    DataStructure dsA = blueprint.node.content.elements().at(0).content.elements().at(0).content.dataStructure;
+    DataStructure dsA = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.dataStructure;
     REQUIRE(dsA.name.symbol.literal == "A");
     REQUIRE(dsA.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsA.typeDefinition.typeSpecification.name.symbol.literal == "B");
 
-    DataStructure dsB = blueprint.node.content.elements().at(0).content.elements().at(1).content.dataStructure;
+    DataStructure dsB = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(1)
+                            .content.dataStructure;
     REQUIRE(dsB.name.symbol.literal == "B");
     REQUIRE(dsB.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsB.typeDefinition.empty());
     REQUIRE(dsB.sections.size() == 1);
     REQUIRE(dsB.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dsB.sections[0].content.elements().size() == 1);
-    REQUIRE(dsB.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(dsB.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember person = dsB.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember person
+        = dsB.sections[0].content.elements().at(0).content.property;
     REQUIRE(person.name.literal == "person");
-    REQUIRE(person.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(person.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal == "A");
+    REQUIRE(person.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(person.valueDefinition.typeDefinition.typeSpecification.name.symbol
+                .literal
+        == "A");
 }
 
-TEST_CASE("Do not report error when there are circular references in nested members", "[blueprint]")
+TEST_CASE(
+    "Do not report error when there are circular references in nested members",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -798,47 +1010,79 @@ TEST_CASE("Do not report error when there are circular references in nested memb
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 3);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(1).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(2).element == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 3);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::DataStructureElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(1).element
+        == Element::DataStructureElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(2).element
+        == Element::DataStructureElement);
 
-    DataStructure dsB = blueprint.node.content.elements().at(0).content.elements().at(0).content.dataStructure;
+    DataStructure dsB = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.dataStructure;
     REQUIRE(dsB.name.symbol.literal == "B");
     REQUIRE(dsB.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsB.typeDefinition.typeSpecification.name.symbol.literal == "C");
 
-    DataStructure dsC = blueprint.node.content.elements().at(0).content.elements().at(1).content.dataStructure;
+    DataStructure dsC = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(1)
+                            .content.dataStructure;
     REQUIRE(dsC.name.symbol.literal == "C");
     REQUIRE(dsC.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsC.typeDefinition.empty());
     REQUIRE(dsC.sections.size() == 1);
     REQUIRE(dsC.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dsC.sections[0].content.elements().size() == 1);
-    REQUIRE(dsC.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(dsC.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember idC = dsC.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember idC
+        = dsC.sections[0].content.elements().at(0).content.property;
     REQUIRE(idC.name.literal == "id");
-    REQUIRE(idC.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(idC.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal == "A");
+    REQUIRE(idC.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        idC.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal
+        == "A");
 
-    DataStructure dsA = blueprint.node.content.elements().at(0).content.elements().at(2).content.dataStructure;
+    DataStructure dsA = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(2)
+                            .content.dataStructure;
     REQUIRE(dsA.name.symbol.literal == "A");
     REQUIRE(dsA.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsA.typeDefinition.empty());
     REQUIRE(dsA.sections.size() == 1);
     REQUIRE(dsA.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dsA.sections[0].content.elements().size() == 1);
-    REQUIRE(dsA.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(dsA.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember idA = dsA.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember idA
+        = dsA.sections[0].content.elements().at(0).content.property;
     REQUIRE(idA.name.literal == "id");
-    REQUIRE(idA.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(idA.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal == "B");
+    REQUIRE(idA.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        idA.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal
+        == "B");
 }
 
-TEST_CASE("Do not report error when named sub type is referenced in nested members when reference happens first",
+TEST_CASE(
+    "Do not report error when named sub type is referenced in nested members "
+    "when reference happens first",
     "[blueprint]")
 {
     mdp::ByteBuffer source
@@ -856,33 +1100,54 @@ TEST_CASE("Do not report error when named sub type is referenced in nested membe
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::DataStructureElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(1).element == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::DataStructureElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(1).element
+        == Element::DataStructureElement);
 
-    DataStructure dsB = blueprint.node.content.elements().at(0).content.elements().at(0).content.dataStructure;
+    DataStructure dsB = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.dataStructure;
     REQUIRE(dsB.name.symbol.literal == "B");
     REQUIRE(dsB.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsB.typeDefinition.empty());
     REQUIRE(dsB.sections.size() == 1);
     REQUIRE(dsB.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dsB.sections[0].content.elements().size() == 1);
-    REQUIRE(dsB.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(dsB.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember person = dsB.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember person
+        = dsB.sections[0].content.elements().at(0).content.property;
     REQUIRE(person.name.literal == "person");
-    REQUIRE(person.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(person.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal == "A");
+    REQUIRE(person.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(person.valueDefinition.typeDefinition.typeSpecification.name.symbol
+                .literal
+        == "A");
 
-    DataStructure dsA = blueprint.node.content.elements().at(0).content.elements().at(1).content.dataStructure;
+    DataStructure dsA = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(1)
+                            .content.dataStructure;
     REQUIRE(dsA.name.symbol.literal == "A");
     REQUIRE(dsA.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsA.typeDefinition.typeSpecification.name.symbol.literal == "B");
 }
 
 TEST_CASE(
-    "Do not report error when a resource attributes type is circularly referenced in nested members", "[blueprint]")
+    "Do not report error when a resource attributes type is circularly "
+    "referenced in nested members",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Post [/]\n"
@@ -902,43 +1167,71 @@ TEST_CASE(
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
     REQUIRE(blueprint.node.content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource r = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource r = blueprint.node.content.elements()
+                     .at(0)
+                     .content.elements()
+                     .at(0)
+                     .content.resource;
     REQUIRE(r.name == "Post");
-    REQUIRE(r.attributes.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(r.attributes.typeDefinition.typeSpecification.name.symbol.literal == "B");
+    REQUIRE(
+        r.attributes.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(r.attributes.typeDefinition.typeSpecification.name.symbol.literal
+        == "B");
     REQUIRE(r.attributes.sections.size() == 1);
-    REQUIRE(r.attributes.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        r.attributes.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(r.attributes.sections[0].content.elements().size() == 1);
-    REQUIRE(r.attributes.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(r.attributes.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember id = r.attributes.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember id
+        = r.attributes.sections[0].content.elements().at(0).content.property;
     REQUIRE(id.name.literal == "id");
-    REQUIRE(id.valueDefinition.typeDefinition.baseType == mson::ImplicitPrimitiveBaseType);
+    REQUIRE(id.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitPrimitiveBaseType);
 
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::DataStructureElement);
 
-    DataStructure dsB = blueprint.node.content.elements().at(1).content.elements().at(0).content.dataStructure;
+    DataStructure dsB = blueprint.node.content.elements()
+                            .at(1)
+                            .content.elements()
+                            .at(0)
+                            .content.dataStructure;
     REQUIRE(dsB.name.symbol.literal == "B");
     REQUIRE(dsB.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsB.typeDefinition.empty());
     REQUIRE(dsB.sections.size() == 1);
     REQUIRE(dsB.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dsB.sections[0].content.elements().size() == 1);
-    REQUIRE(dsB.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(dsB.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember posts = dsB.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember posts
+        = dsB.sections[0].content.elements().at(0).content.property;
     REQUIRE(posts.name.literal == "posts");
-    REQUIRE(posts.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(posts.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal == "Post");
+    REQUIRE(posts.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(posts.valueDefinition.typeDefinition.typeSpecification.name.symbol
+                .literal
+        == "Post");
 }
 
-TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint]")
+TEST_CASE(
+    "Report error when named sub type is referenced as mixin", "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -955,7 +1248,10 @@ TEST_CASE("Report error when named sub type is referenced as mixin", "[blueprint
     SourceMapHelper::check(blueprint.report.error.location, 35, 10);
 }
 
-TEST_CASE("Report error when named sub type is referenced as mixin when reference happens first", "[blueprint]")
+TEST_CASE(
+    "Report error when named sub type is referenced as mixin when reference "
+    "happens first",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -992,7 +1288,8 @@ TEST_CASE("Report error when circular reference in mixins", "[blueprint]")
     SourceMapHelper::check(blueprint.report.error.location, 45, 10);
 }
 
-TEST_CASE("Do not report error when named type references itself in array", "[blueprint]")
+TEST_CASE("Do not report error when named type references itself in array",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1008,31 +1305,51 @@ TEST_CASE("Do not report error when named type references itself in array", "[bl
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::DataStructureElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::DataStructureElement);
 
-    DataStructure dsComment = blueprint.node.content.elements().at(0).content.elements().at(0).content.dataStructure;
+    DataStructure dsComment = blueprint.node.content.elements()
+                                  .at(0)
+                                  .content.elements()
+                                  .at(0)
+                                  .content.dataStructure;
     REQUIRE(dsComment.name.symbol.literal == "Comment");
     REQUIRE(dsComment.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dsComment.typeDefinition.empty());
     REQUIRE(dsComment.sections.size() == 1);
     REQUIRE(dsComment.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dsComment.sections[0].content.elements().size() == 2);
-    REQUIRE(dsComment.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(dsComment.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember user = dsComment.sections[0].content.elements().at(0).content.property;
+    mson::PropertyMember user
+        = dsComment.sections[0].content.elements().at(0).content.property;
     REQUIRE(user.name.literal == "user");
-    REQUIRE(user.valueDefinition.typeDefinition.baseType == mson::PrimitiveBaseType);
+    REQUIRE(user.valueDefinition.typeDefinition.baseType
+        == mson::PrimitiveBaseType);
 
-    mson::PropertyMember children = dsComment.sections[0].content.elements().at(1).content.property;
+    mson::PropertyMember children
+        = dsComment.sections[0].content.elements().at(1).content.property;
     REQUIRE(children.name.literal == "children");
-    REQUIRE(children.valueDefinition.typeDefinition.baseType == mson::ValueBaseType);
-    REQUIRE(children.valueDefinition.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(children.valueDefinition.typeDefinition.typeSpecification.nestedTypes.at(0).symbol.literal == "Comment");
+    REQUIRE(children.valueDefinition.typeDefinition.baseType
+        == mson::ValueBaseType);
+    REQUIRE(children.valueDefinition.typeDefinition.typeSpecification
+                .nestedTypes.size()
+        == 1);
+    REQUIRE(
+        children.valueDefinition.typeDefinition.typeSpecification.nestedTypes
+            .at(0)
+            .symbol.literal
+        == "Comment");
 }
 
-TEST_CASE("Report error when a named type is defined twice with inheritance", "[blueprint]")
+TEST_CASE("Report error when a named type is defined twice with inheritance",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1050,7 +1367,8 @@ TEST_CASE("Report error when a named type is defined twice with inheritance", "[
     SourceMapHelper::check(blueprint.report.error.location, 19, 9);
 }
 
-TEST_CASE("Report error when a named type is defined twice with base type", "[blueprint]")
+TEST_CASE("Report error when a named type is defined twice with base type",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1066,7 +1384,10 @@ TEST_CASE("Report error when a named type is defined twice with base type", "[bl
     SourceMapHelper::check(blueprint.report.error.location, 33, 14);
 }
 
-TEST_CASE("Report error when a named type is defined twice, once with base type and other inheritance", "[blueprint]")
+TEST_CASE(
+    "Report error when a named type is defined twice, once with base type and "
+    "other inheritance",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1083,7 +1404,8 @@ TEST_CASE("Report error when a named type is defined twice, once with base type 
     SourceMapHelper::check(blueprint.report.error.location, 28, 14);
 }
 
-TEST_CASE("Parse mson signature attributes with mismatched square brackets", "[blueprint]")
+TEST_CASE("Parse mson signature attributes with mismatched square brackets",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# /\n"
@@ -1096,7 +1418,8 @@ TEST_CASE("Parse mson signature attributes with mismatched square brackets", "[b
     REQUIRE(blueprint.report.error.code == Error::OK);
 }
 
-TEST_CASE("Parse named type mson signature attributes with no closing bracket", "[blueprint]")
+TEST_CASE("Parse named type mson signature attributes with no closing bracket",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1107,10 +1430,14 @@ TEST_CASE("Parse named type mson signature attributes with no closing bracket", 
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    REQUIRE(blueprint.report.error.message == "base type 'A(' is not defined in the document");
+    REQUIRE(blueprint.report.error.message
+        == "base type 'A(' is not defined in the document");
 }
 
-TEST_CASE("Parse correctly when a resource named type is non-circularly referenced in action attributes", "[blueprint]")
+TEST_CASE(
+    "Parse correctly when a resource named type is non-circularly referenced "
+    "in action attributes",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Question [/question]\n"
@@ -1129,7 +1456,8 @@ TEST_CASE("Parse correctly when a resource named type is non-circularly referenc
     REQUIRE(blueprint.report.error.code == Error::OK);
 }
 
-TEST_CASE("Report error when not finding a super type of the nested member", "[blueprint]")
+TEST_CASE("Report error when not finding a super type of the nested member",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1141,10 +1469,13 @@ TEST_CASE("Report error when not finding a super type of the nested member", "[b
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    REQUIRE(blueprint.report.error.message == "base type 'B' is not defined in the document");
+    REQUIRE(blueprint.report.error.message
+        == "base type 'B' is not defined in the document");
 }
 
-TEST_CASE("Report error when not finding a nested super type of the nested member", "[blueprint]")
+TEST_CASE(
+    "Report error when not finding a nested super type of the nested member",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -1156,7 +1487,8 @@ TEST_CASE("Report error when not finding a nested super type of the nested membe
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    REQUIRE(blueprint.report.error.message == "base type 'B' is not defined in the document");
+    REQUIRE(blueprint.report.error.message
+        == "base type 'B' is not defined in the document");
 }
 
 TEST_CASE("Report error when not finding a mixin type", "[blueprint]")
@@ -1171,7 +1503,8 @@ TEST_CASE("Report error when not finding a mixin type", "[blueprint]")
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    REQUIRE(blueprint.report.error.message == "base type 'B' is not defined in the document");
+    REQUIRE(blueprint.report.error.message
+        == "base type 'B' is not defined in the document");
 }
 
 TEST_CASE("When an object contains a mixin of array type", "[blueprint]")
@@ -1189,8 +1522,13 @@ TEST_CASE("When an object contains a mixin of array type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint,
+        namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1213,8 +1551,13 @@ TEST_CASE("When an array contains a mixin of object type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint,
+        namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1237,8 +1580,13 @@ TEST_CASE("When an object member contains a mixin of array type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint,
+        namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1261,8 +1609,13 @@ TEST_CASE("When an array member contains a mixin of object type", "[blueprint]")
     NamedTypeHelper::build("B", mson::ValueBaseType, namedTypes);
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint, namedTypes);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint,
+        namedTypes);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -1270,7 +1623,10 @@ TEST_CASE("When an array member contains a mixin of object type", "[blueprint]")
     SourceMapHelper::check(blueprint.report.warnings[0].location, 39, 12);
 }
 
-TEST_CASE("Any named type data structure should be able to be overridden when referenced", "[blueprint]")
+TEST_CASE(
+    "Any named type data structure should be able to be overridden when "
+    "referenced",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# Tesla\n"
@@ -1295,12 +1651,21 @@ TEST_CASE("Any named type data structure should be able to be overridden when re
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).category == Element::ResourceGroupCategory);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(blueprint.node.content.elements().at(1).category
+        == Element::ResourceGroupCategory);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(1).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(1)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
 
     REQUIRE(resource.uriTemplate == "/sample");
     REQUIRE(resource.actions.size() == 1);
@@ -1313,35 +1678,50 @@ TEST_CASE("Any named type data structure should be able to be overridden when re
 
     REQUIRE(response.name == "200");
     REQUIRE(response.attributes.sections.size() == 1);
-    REQUIRE(response.attributes.sections.at(0).klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(response.attributes.sections.at(0).klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(response.attributes.sections.at(0).content.elements().size() == 1);
-    REQUIRE(response.attributes.sections.at(0).content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(response.attributes.sections.at(0).content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember property1 = response.attributes.sections.at(0).content.elements().at(0).content.property;
+    mson::PropertyMember property1 = response.attributes.sections.at(0)
+                                         .content.elements()
+                                         .at(0)
+                                         .content.property;
 
     REQUIRE(property1.name.literal == "data");
     REQUIRE(property1.sections.size() == 1);
-    REQUIRE(property1.sections.at(0).klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        property1.sections.at(0).klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(property1.sections.at(0).content.elements().size() == 1);
-    REQUIRE(property1.sections.at(0).content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(property1.sections.at(0).content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember property2 = property1.sections.at(0).content.elements().at(0).content.property;
+    mson::PropertyMember property2
+        = property1.sections.at(0).content.elements().at(0).content.property;
 
     REQUIRE(property2.name.literal == "users");
     REQUIRE(property2.sections.size() == 1);
-    REQUIRE(property2.sections.at(0).klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        property2.sections.at(0).klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(property2.sections.at(0).content.elements().size() == 1);
-    REQUIRE(property2.sections.at(0).content.elements().at(0).klass == mson::Element::ValueClass);
+    REQUIRE(property2.sections.at(0).content.elements().at(0).klass
+        == mson::Element::ValueClass);
 
-    mson::ValueMember value = property2.sections.at(0).content.elements().at(0).content.value;
+    mson::ValueMember value
+        = property2.sections.at(0).content.elements().at(0).content.value;
 
-    REQUIRE(value.valueDefinition.typeDefinition.typeSpecification.name.symbol.literal == "User");
+    REQUIRE(value.valueDefinition.typeDefinition.typeSpecification.name.symbol
+                .literal
+        == "User");
     REQUIRE(value.sections.size() == 1);
     REQUIRE(value.sections.at(0).klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(value.sections.at(0).content.elements().size() == 1);
-    REQUIRE(value.sections.at(0).content.elements().at(0).klass == mson::Element::PropertyClass);
+    REQUIRE(value.sections.at(0).content.elements().at(0).klass
+        == mson::Element::PropertyClass);
 
-    mson::PropertyMember property3 = value.sections.at(0).content.elements().at(0).content.property;
+    mson::PropertyMember property3
+        = value.sections.at(0).content.elements().at(0).content.property;
 
     REQUIRE(property3.name.literal == "relation");
     REQUIRE(property3.sections.empty());
@@ -1350,7 +1730,9 @@ TEST_CASE("Any named type data structure should be able to be overridden when re
     REQUIRE(property3.valueDefinition.typeDefinition.empty());
 }
 
-TEST_CASE("Parse attributes with mixin and no base type mentioned for attributes", "[blueprint][362]")
+TEST_CASE(
+    "Parse attributes with mixin and no base type mentioned for attributes",
+    "[blueprint][362]")
 {
     mdp::ByteBuffer source
         = "# GET /\n"
@@ -1372,7 +1754,8 @@ TEST_CASE("Parse attributes with mixin and no base type mentioned for attributes
     REQUIRE(blueprint.node.content.elements().size() == 2);
 }
 
-TEST_CASE("Parse attributes with mixin and no base type mentioned for mixin", "[blueprint]")
+TEST_CASE("Parse attributes with mixin and no base type mentioned for mixin",
+    "[blueprint]")
 {
     mdp::ByteBuffer source
         = "# GET /\n"
@@ -1394,7 +1777,10 @@ TEST_CASE("Parse attributes with mixin and no base type mentioned for mixin", "[
     REQUIRE(blueprint.node.content.elements().size() == 2);
 }
 
-TEST_CASE("Report error when not finding a super type of the nested member from attributes", "[blueprint][354]")
+TEST_CASE(
+    "Report error when not finding a super type of the nested member from "
+    "attributes",
+    "[blueprint][354]")
 {
     mdp::ByteBuffer source
         = "# GET /\n"
@@ -1407,11 +1793,13 @@ TEST_CASE("Report error when not finding a super type of the nested member from 
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    REQUIRE(blueprint.report.error.message == "base type 'A' is not defined in the document");
+    REQUIRE(blueprint.report.error.message
+        == "base type 'A' is not defined in the document");
     REQUIRE(blueprint.report.warnings.empty());
 }
 
-TEST_CASE("Report error when not finding a super type of the attributes", "[blueprint][354]")
+TEST_CASE("Report error when not finding a super type of the attributes",
+    "[blueprint][354]")
 {
     mdp::ByteBuffer source
         = "# GET /\n"
@@ -1423,7 +1811,8 @@ TEST_CASE("Report error when not finding a super type of the attributes", "[blue
         source, BlueprintSectionType, blueprint, ExportSourcemapOption);
 
     REQUIRE(blueprint.report.error.code == MSONError);
-    REQUIRE(blueprint.report.error.message == "base type 'A' is not defined in the document");
+    REQUIRE(blueprint.report.error.message
+        == "base type 'A' is not defined in the document");
     REQUIRE(blueprint.report.warnings.empty());
 }
 
@@ -1439,19 +1828,33 @@ TEST_CASE("Parse blueprint with escaped datastructure", "[blueprint]")
           "    + Attributes(Test)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 0);
 
     REQUIRE(blueprint.node.content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.attributes.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.resource.attributes.empty());
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
 }
 
 TEST_CASE("Parse blueprint with escaped datastructure reference", "[blueprint]")
@@ -1466,17 +1869,31 @@ TEST_CASE("Parse blueprint with escaped datastructure reference", "[blueprint]")
           "    + Attributes(`Test`)\n";
 
     ParseResult<Blueprint> blueprint;
-    SectionParserHelper<Blueprint, BlueprintParser>::parse(
-        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(source,
+        BlueprintSectionType,
+        blueprint,
+        ExportSourcemapOption,
+        Models(),
+        &blueprint);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 0);
 
     REQUIRE(blueprint.node.content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(1).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(blueprint.node.content.elements().at(1).content.elements().at(0).content.resource.attributes.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(blueprint.node.content.elements().at(1).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(1).content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(1)
+                .content.elements()
+                .at(0)
+                .content.resource.attributes.empty());
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
 }

--- a/test/test-BlueprintUtility.cc
+++ b/test/test-BlueprintUtility.cc
@@ -12,7 +12,8 @@
 using namespace snowcrash;
 using namespace snowcrashtest;
 
-TEST_CASE("Match action with same uri template and same http method", "[blueprint_utility]")
+TEST_CASE("Match action with same uri template and same http method",
+    "[blueprint_utility]")
 {
     Action action1, action2;
 
@@ -22,7 +23,8 @@ TEST_CASE("Match action with same uri template and same http method", "[blueprin
     REQUIRE(MatchAction()(action1, action2));
 }
 
-TEST_CASE("Match action with same uri template and different http method", "[blueprint_utility]")
+TEST_CASE("Match action with same uri template and different http method",
+    "[blueprint_utility]")
 {
     Action action1, action2;
 
@@ -35,7 +37,8 @@ TEST_CASE("Match action with same uri template and different http method", "[blu
     REQUIRE_FALSE(MatchAction()(action1, action2));
 }
 
-TEST_CASE("Match action with different uri template and same http method", "[blueprint_utility]")
+TEST_CASE("Match action with different uri template and same http method",
+    "[blueprint_utility]")
 {
     Action action1, action2;
 

--- a/test/test-DataStructureGroupParser.cc
+++ b/test/test-DataStructureGroupParser.cc
@@ -14,7 +14,8 @@ using namespace snowcrashtest;
 
 const mdp::ByteBuffer DataStructuresFixture = "# Data structure";
 
-TEST_CASE("Recognize explicit data structures signature", "[data_structure_group]")
+TEST_CASE(
+    "Recognize explicit data structures signature", "[data_structure_group]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
@@ -22,7 +23,8 @@ TEST_CASE("Recognize explicit data structures signature", "[data_structure_group
     markdownParser.parse(DataStructuresFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<DataStructureGroup>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<DataStructureGroup>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == DataStructureGroupSectionType);
 }
 
@@ -37,41 +39,60 @@ TEST_CASE("Parse canonical data structures", "[data_structure_group]")
 
     ParseResult<DataStructureGroup> dataStructureGroup;
     SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(
-        source, DataStructureGroupSectionType, dataStructureGroup, ExportSourcemapOption);
+        source,
+        DataStructureGroupSectionType,
+        dataStructureGroup,
+        ExportSourcemapOption);
 
     REQUIRE(dataStructureGroup.report.error.code == Error::OK);
     REQUIRE(dataStructureGroup.report.warnings.empty());
 
     REQUIRE(dataStructureGroup.node.element == Element::CategoryElement);
     REQUIRE(dataStructureGroup.node.content.elements().size() == 2);
-    REQUIRE(dataStructureGroup.node.content.elements().at(0).element == Element::DataStructureElement);
-    REQUIRE(dataStructureGroup.node.content.elements().at(1).element == Element::DataStructureElement);
+    REQUIRE(dataStructureGroup.node.content.elements().at(0).element
+        == Element::DataStructureElement);
+    REQUIRE(dataStructureGroup.node.content.elements().at(1).element
+        == Element::DataStructureElement);
 
-    DataStructure dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
+    DataStructure dataStructure = dataStructureGroup.node.content.elements()
+                                      .at(0)
+                                      .content.dataStructure;
     REQUIRE(dataStructure.name.symbol.literal == "User");
-    REQUIRE(dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dataStructure.typeDefinition.empty());
     REQUIRE(dataStructure.sections.size() == 1);
-    REQUIRE(dataStructure.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        dataStructure.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dataStructure.sections[0].content.elements().size() == 2);
 
-    dataStructure = dataStructureGroup.node.content.elements().at(1).content.dataStructure;
+    dataStructure = dataStructureGroup.node.content.elements()
+                        .at(1)
+                        .content.dataStructure;
     REQUIRE(dataStructure.name.symbol.literal == "Email");
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base
+        == mson::ArrayTypeName);
+    REQUIRE(
+        dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
 
     SourceMap<DataStructure> dataStructureSM
-        = dataStructureGroup.sourceMap.content.elements().collection[0].content.dataStructure;
+        = dataStructureGroup.sourceMap.content.elements()
+              .collection[0]
+              .content.dataStructure;
     SourceMapHelper::check(dataStructureSM.name.sourceMap, 19, 9);
     REQUIRE(dataStructureSM.typeDefinition.sourceMap.empty());
-    REQUIRE(dataStructureSM.sections.collection[0].elements().collection.size() == 2);
+    REQUIRE(dataStructureSM.sections.collection[0].elements().collection.size()
+        == 2);
 
-    dataStructureSM = dataStructureGroup.sourceMap.content.elements().collection[1].content.dataStructure;
+    dataStructureSM = dataStructureGroup.sourceMap.content.elements()
+                          .collection[1]
+                          .content.dataStructure;
     SourceMapHelper::check(dataStructureSM.name.sourceMap, 54, 24);
     SourceMapHelper::check(dataStructureSM.typeDefinition.sourceMap, 54, 24);
 }
 
-TEST_CASE("Parse multiple data structures with type sections", "[data_structure_group]")
+TEST_CASE("Parse multiple data structures with type sections",
+    "[data_structure_group]")
 {
     mdp::ByteBuffer source
         = "# Data Structures\n"
@@ -89,39 +110,60 @@ TEST_CASE("Parse multiple data structures with type sections", "[data_structure_
 
     ParseResult<DataStructureGroup> dataStructureGroup;
     SectionParserHelper<DataStructureGroup, DataStructureGroupParser>::parse(
-        source, DataStructureGroupSectionType, dataStructureGroup, ExportSourcemapOption);
+        source,
+        DataStructureGroupSectionType,
+        dataStructureGroup,
+        ExportSourcemapOption);
 
     REQUIRE(dataStructureGroup.report.error.code == Error::OK);
     REQUIRE(dataStructureGroup.report.warnings.empty());
 
     REQUIRE(dataStructureGroup.node.element == Element::CategoryElement);
     REQUIRE(dataStructureGroup.node.content.elements().size() == 2);
-    REQUIRE(dataStructureGroup.node.content.elements().at(0).element == Element::DataStructureElement);
-    REQUIRE(dataStructureGroup.node.content.elements().at(1).element == Element::DataStructureElement);
+    REQUIRE(dataStructureGroup.node.content.elements().at(0).element
+        == Element::DataStructureElement);
+    REQUIRE(dataStructureGroup.node.content.elements().at(1).element
+        == Element::DataStructureElement);
 
-    DataStructure dataStructure = dataStructureGroup.node.content.elements().at(0).content.dataStructure;
+    DataStructure dataStructure = dataStructureGroup.node.content.elements()
+                                      .at(0)
+                                      .content.dataStructure;
     REQUIRE(dataStructure.name.symbol.literal == "User");
-    REQUIRE(dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        dataStructure.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(dataStructure.typeDefinition.empty());
     REQUIRE(dataStructure.sections.size() == 2);
-    REQUIRE(dataStructure.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(dataStructure.sections[0].content.description == "Some description");
-    REQUIRE(dataStructure.sections[1].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(dataStructure.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(
+        dataStructure.sections[0].content.description == "Some description");
+    REQUIRE(
+        dataStructure.sections[1].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(dataStructure.sections[1].content.elements().size() == 2);
 
-    dataStructure = dataStructureGroup.node.content.elements().at(1).content.dataStructure;
+    dataStructure = dataStructureGroup.node.content.elements()
+                        .at(1)
+                        .content.dataStructure;
     REQUIRE(dataStructure.name.symbol.literal == "Email");
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
+    REQUIRE(dataStructure.typeDefinition.typeSpecification.name.base
+        == mson::ArrayTypeName);
+    REQUIRE(
+        dataStructure.typeDefinition.typeSpecification.nestedTypes.size() == 1);
 
     SourceMap<DataStructure> dataStructureSM
-        = dataStructureGroup.sourceMap.content.elements().collection[0].content.dataStructure;
+        = dataStructureGroup.sourceMap.content.elements()
+              .collection[0]
+              .content.dataStructure;
     SourceMapHelper::check(dataStructureSM.name.sourceMap, 19, 9);
     REQUIRE(dataStructureSM.typeDefinition.sourceMap.empty());
-    SourceMapHelper::check(dataStructureSM.sections.collection[0].description.sourceMap, 28, 18);
-    REQUIRE(dataStructureSM.sections.collection[1].elements().collection.size() == 2);
+    SourceMapHelper::check(
+        dataStructureSM.sections.collection[0].description.sourceMap, 28, 18);
+    REQUIRE(dataStructureSM.sections.collection[1].elements().collection.size()
+        == 2);
 
-    dataStructureSM = dataStructureGroup.sourceMap.content.elements().collection[1].content.dataStructure;
+    dataStructureSM = dataStructureGroup.sourceMap.content.elements()
+                          .collection[1]
+                          .content.dataStructure;
     SourceMapHelper::check(dataStructureSM.name.sourceMap, 88, 24);
     SourceMapHelper::check(dataStructureSM.typeDefinition.sourceMap, 88, 24);
 }

--- a/test/test-HeadersParser.cc
+++ b/test/test-HeadersParser.cc
@@ -30,7 +30,8 @@ TEST_CASE("recognize headers signature", "[headers]")
     markdownParser.parse(HeadersFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Headers>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Headers>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == HeadersSectionType);
 }
 
@@ -54,15 +55,22 @@ TEST_CASE("parse headers fixture", "[headers]")
     SourceMapHelper::check(headers.sourceMap.collection[1].sourceMap, 58, 25);
 }
 
-// This test is commented out because, in real parsing it is never parsed is "one block sourcemap"
+// This test is commented out because, in real parsing it is never parsed is
+// "one block sourcemap"
 // Just in context of HeaderParser testing.
-// This test is not completly removed, instead it is placed in context of ResourceParser (as in real world)
+// This test is not completly removed, instead it is placed in context of
+// ResourceParser (as in real world)
 
-TEST_CASE("parse headers fixture with no empty line between signature and content", "[headers]")
+TEST_CASE(
+    "parse headers fixture with no empty line between signature and content",
+    "[headers]")
 {
     ParseResult<Headers> headers;
     SectionParserHelper<Headers, HeadersParser>::parse(
-        HeadersSignatureContentFixture, HeadersSectionType, headers, ExportSourcemapOption);
+        HeadersSignatureContentFixture,
+        HeadersSectionType,
+        headers,
+        ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // content in signature
@@ -84,7 +92,8 @@ TEST_CASE("parse malformed headers fixture", "[headers]")
     source += "        X-Custom-Header:\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // malformed header
@@ -127,7 +136,8 @@ TEST_CASE("Parse header section composed of multiple blocks", "[headers]")
     source += "        X-My-Header: 42\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // not a code block
@@ -151,7 +161,8 @@ TEST_CASE("Parse header section with missing headers", "[headers]")
     mdp::ByteBuffer source = "+ Headers\n\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers, ExportSourcemapOption);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers, ExportSourcemapOption);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 1); // no headers
@@ -160,7 +171,10 @@ TEST_CASE("Parse header section with missing headers", "[headers]")
     REQUIRE(headers.sourceMap.collection.size() == 0);
 }
 
-TEST_CASE("Headers parses should return warning on multiple definition of same headers", "[headers][issue][75]")
+TEST_CASE(
+    "Headers parses should return warning on multiple definition of same "
+    "headers",
+    "[headers][issue][75]")
 {
     const mdp::ByteBuffer source
         = "+ Headers\n"
@@ -169,15 +183,19 @@ TEST_CASE("Headers parses should return warning on multiple definition of same h
           "        Content-Type: application/json\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
-    REQUIRE(headers.report.warnings.size() == 1); // one warning due to multiple declaration same header
+    REQUIRE(headers.report.warnings.size()
+        == 1); // one warning due to multiple declaration same header
 
     REQUIRE(headers.node.size() == 2);
 }
 
-TEST_CASE("Parse header section with more same headers Set-Cookie and Link - there should not be warning",
+TEST_CASE(
+    "Parse header section with more same headers Set-Cookie and Link - there "
+    "should not be warning",
     "[headers][issue][75]")
 {
     const mdp::ByteBuffer source
@@ -187,10 +205,13 @@ TEST_CASE("Parse header section with more same headers Set-Cookie and Link - the
           "        Set-Cookie: kockaprede\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
-    REQUIRE(headers.report.warnings.empty()); // no warning - multiple definition, but from allowed set
+    REQUIRE(
+        headers.report.warnings
+            .empty()); // no warning - multiple definition, but from allowed set
 
     REQUIRE(headers.node.size() == 2);
     REQUIRE(headers.node[0].first == "Set-Cookie");
@@ -199,7 +220,8 @@ TEST_CASE("Parse header section with more same headers Set-Cookie and Link - the
     REQUIRE(headers.node[1].second == "kockaprede");
 }
 
-TEST_CASE("Headers Filed Name should be case insensitive", "[headers][issue][230]")
+TEST_CASE(
+    "Headers Filed Name should be case insensitive", "[headers][issue][230]")
 {
     const mdp::ByteBuffer source
         = "+ Headers\n"
@@ -208,10 +230,13 @@ TEST_CASE("Headers Filed Name should be case insensitive", "[headers][issue][230
           "        content-type: application/json\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
-    REQUIRE(headers.report.warnings.size() == 1); // one warning - multiple definitions w/ different case sensitivity
+    REQUIRE(headers.report.warnings.size() == 1); // one warning - multiple
+                                                  // definitions w/ different
+                                                  // case sensitivity
 
     REQUIRE(headers.node.size() == 2);
     REQUIRE(headers.node[0].first == "Content-Type");
@@ -220,7 +245,10 @@ TEST_CASE("Headers Filed Name should be case insensitive", "[headers][issue][230
     REQUIRE(headers.node[1].second == "application/json");
 }
 
-TEST_CASE("Aditional test for Header name insenstivity combined with allowed multiple headers", "[headers][issue][230]")
+TEST_CASE(
+    "Aditional test for Header name insenstivity combined with allowed "
+    "multiple headers",
+    "[headers][issue][230]")
 {
     const mdp::ByteBuffer source
         = "+ Headers\n"
@@ -229,10 +257,13 @@ TEST_CASE("Aditional test for Header name insenstivity combined with allowed mul
           "        Set-Cookie: kockaprede\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
-    REQUIRE(headers.report.warnings.empty()); // no warning - multiple definition, but from allowed set
+    REQUIRE(
+        headers.report.warnings
+            .empty()); // no warning - multiple definition, but from allowed set
 
     REQUIRE(headers.node.size() == 2);
     REQUIRE(headers.node[0].first == "Set-cookie");
@@ -241,7 +272,8 @@ TEST_CASE("Aditional test for Header name insenstivity combined with allowed mul
     REQUIRE(headers.node[1].second == "kockaprede");
 }
 
-TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue][158]")
+TEST_CASE("Missing or wrong placed colon in header definition",
+    "[headers][issue][158]")
 {
 
     SECTION("No colon")
@@ -251,12 +283,15 @@ TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue
               "        Set-Cookie chocolate cookie\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
-        REQUIRE(headers.report.warnings.size() == 1); // warning - header is not defined correctly
-        REQUIRE(headers.report.warnings[0].message == "missing colon after header name 'Set-Cookie'");
+        REQUIRE(headers.report.warnings.size()
+            == 1); // warning - header is not defined correctly
+        REQUIRE(headers.report.warnings[0].message
+            == "missing colon after header name 'Set-Cookie'");
 
         REQUIRE(headers.node[0].first == "Set-Cookie");
         REQUIRE(headers.node[0].second == "chocolate cookie");
@@ -269,12 +304,15 @@ TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue
               "        Last-Modified Sat, 02 Aug 2014 23:10:05 GMT\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
-        REQUIRE(headers.report.warnings.size() == 1); // warning - header is not defined correctly
-        REQUIRE(headers.report.warnings[0].message == "missing colon after header name 'Last-Modified'");
+        REQUIRE(headers.report.warnings.size()
+            == 1); // warning - header is not defined correctly
+        REQUIRE(headers.report.warnings[0].message
+            == "missing colon after header name 'Last-Modified'");
 
         REQUIRE(headers.node[0].first == "Last-Modified");
         REQUIRE(headers.node[0].second == "Sat, 02 Aug 2014 23:10:05 GMT");
@@ -287,7 +325,8 @@ TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue
               "        Set-Cookie :: chocolate cookie\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
         REQUIRE(headers.report.warnings.empty());
@@ -297,7 +336,8 @@ TEST_CASE("Missing or wrong placed colon in header definition", "[headers][issue
     }
 }
 
-TEST_CASE("Allow parse nonvalid headers, provide apropriate warning", "[headers][issue][158]")
+TEST_CASE("Allow parse nonvalid headers, provide apropriate warning",
+    "[headers][issue][158]")
 {
 
     SECTION("Strange but valid token")
@@ -307,7 +347,8 @@ TEST_CASE("Allow parse nonvalid headers, provide apropriate warning", "[headers]
               "        # : chocolate cookie\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
         REQUIRE(headers.report.warnings.empty());
@@ -323,12 +364,15 @@ TEST_CASE("Allow parse nonvalid headers, provide apropriate warning", "[headers]
               "        Header:\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
-        REQUIRE(headers.report.warnings.size() == 1); // warning - header name is not defined correctly
-        REQUIRE(headers.report.warnings[0].message == "HTTP header 'Header' has no value");
+        REQUIRE(headers.report.warnings.size()
+            == 1); // warning - header name is not defined correctly
+        REQUIRE(headers.report.warnings[0].message
+            == "HTTP header 'Header' has no value");
 
         REQUIRE(headers.node.size() == 1);
         REQUIRE(headers.node[0].first == "Header");
@@ -342,13 +386,16 @@ TEST_CASE("Allow parse nonvalid headers, provide apropriate warning", "[headers]
               "        Header\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
         REQUIRE(headers.report.warnings.size() == 2);
-        REQUIRE(headers.report.warnings[0].message == "missing colon after header name 'Header'");
-        REQUIRE(headers.report.warnings[1].message == "HTTP header 'Header' has no value");
+        REQUIRE(headers.report.warnings[0].message
+            == "missing colon after header name 'Header'");
+        REQUIRE(headers.report.warnings[1].message
+            == "HTTP header 'Header' has no value");
 
         REQUIRE(headers.node.size() == 1);
         REQUIRE(headers.node[0].first == "Header");
@@ -367,11 +414,13 @@ TEST_CASE("Skip completely invalid headers", "[headers][drafter-issue][382]")
               "        Header : chocolate cookie\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
-        REQUIRE(headers.report.warnings.size() == 1); // warning - header name is not defined correctly
+        REQUIRE(headers.report.warnings.size()
+            == 1); // warning - header name is not defined correctly
         REQUIRE(headers.report.warnings[0].message
             == "HTTP header name '<Header>' contains illegal character '<' (0x3c) skipping the header");
 
@@ -387,14 +436,17 @@ TEST_CASE("Skip completely invalid headers", "[headers][drafter-issue][382]")
               "        <Header> : Invalid\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
-        REQUIRE(headers.report.warnings.size() == 2); // warning - header name is not defined correctly
+        REQUIRE(headers.report.warnings.size()
+            == 2); // warning - header name is not defined correctly
         REQUIRE(headers.report.warnings[0].message
             == "HTTP header name '<Header>' contains illegal character '<' (0x3c) skipping the header");
-        REQUIRE(headers.report.warnings[1].message == "no valid headers specified");
+        REQUIRE(
+            headers.report.warnings[1].message == "no valid headers specified");
     }
 
     SECTION("Invalid header")
@@ -404,14 +456,17 @@ TEST_CASE("Skip completely invalid headers", "[headers][drafter-issue][382]")
               "        :Header: :\n";
 
         ParseResult<Headers> headers;
-        SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+        SectionParserHelper<Headers, HeadersParser>::parse(
+            source, HeadersSectionType, headers);
 
         REQUIRE(headers.report.error.code == Error::OK); // no error
 
-        REQUIRE(headers.report.warnings.size() == 2); // warning - header name is not defined correctly
+        REQUIRE(headers.report.warnings.size()
+            == 2); // warning - header name is not defined correctly
         REQUIRE(headers.report.warnings[0].message
             == "unable to parse HTTP header, expected '<header name> : <header value>', one header per line");
-        REQUIRE(headers.report.warnings[1].message == "no valid headers specified");
+        REQUIRE(
+            headers.report.warnings[1].message == "no valid headers specified");
     }
 }
 
@@ -424,7 +479,8 @@ TEST_CASE("Parse headers in codefences", "[headers][codefence]")
           "    ```\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.empty());
@@ -444,7 +500,8 @@ TEST_CASE("Parse headers with in the middle codefences", "[headers][codefence]")
           "        \n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.size() == 2);
@@ -467,7 +524,8 @@ TEST_CASE("Parse headers in codefences with hint", "[headers][codefence]")
           "    ```\n";
 
     ParseResult<Headers> headers;
-    SectionParserHelper<Headers, HeadersParser>::parse(source, HeadersSectionType, headers);
+    SectionParserHelper<Headers, HeadersParser>::parse(
+        source, HeadersSectionType, headers);
 
     REQUIRE(headers.report.error.code == Error::OK);
     REQUIRE(headers.report.warnings.empty());

--- a/test/test-Indentation.cc
+++ b/test/test-Indentation.cc
@@ -30,7 +30,8 @@ TEST_CASE("Correct indentation", "[indentation]")
           "        { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -49,7 +50,8 @@ TEST_CASE("No Indentation & No Newline", "[indentation]")
           "{ ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -71,7 +73,8 @@ TEST_CASE("No Indentation", "[indentation]")
           "{ ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -92,7 +95,8 @@ TEST_CASE("Poor Indentation & No Newline", "[indentation]")
           "    { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -114,7 +118,8 @@ TEST_CASE("Poor Indentation", "[indentation]")
           "    { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -135,7 +140,8 @@ TEST_CASE("OK Indentation & No Newline", "[indentation]")
           "        { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -158,7 +164,8 @@ TEST_CASE("Full syntax - correct", "[indentation]")
           "            { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.empty());
@@ -179,7 +186,8 @@ TEST_CASE("Full syntax - Poor Body Indentation", "[indentation]")
           "        { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -202,7 +210,8 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation", "[indentation]")
           "    { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -215,7 +224,8 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation", "[indentation]")
     REQUIRE(action.node.examples[0].responses[0].body.empty());
 }
 
-TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline", "[indentation]")
+TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline",
+    "[indentation]")
 {
     mdp::ByteBuffer source
         = "## GET /1\n"
@@ -224,7 +234,8 @@ TEST_CASE("Full syntax - Poor Body & Body Asset Indentation & No Newline", "[ind
           "    { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -247,7 +258,8 @@ TEST_CASE("Full syntax - No Indentation", "[indentation]")
           "{ ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 2);
@@ -271,7 +283,8 @@ TEST_CASE("Full syntax - No Indentation & No Newline", "[indentation]")
           "{ ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -295,7 +308,8 @@ TEST_CASE("Full syntax - Extra indentation", "[indentation]")
           "                { ... }\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 1);
@@ -305,7 +319,8 @@ TEST_CASE("Full syntax - Extra indentation", "[indentation]")
     REQUIRE(action.node.examples.size() == 1);
     REQUIRE(action.node.examples[0].responses.size() == 1);
     REQUIRE(action.node.examples[0].responses[0].name == "200");
-    REQUIRE(action.node.examples[0].responses[0].body == "+ Body\n\n        { ... }\n");
+    REQUIRE(action.node.examples[0].responses[0].body
+        == "+ Body\n\n        { ... }\n");
 }
 
 TEST_CASE("No Indentation & No Newline multi-line", "[indentation]")
@@ -319,7 +334,8 @@ TEST_CASE("No Indentation & No Newline multi-line", "[indentation]")
           "}\n";
 
     ParseResult<Action> action;
-    SectionParserHelper<Action, ActionParser>::parse(source, ActionSectionType, action);
+    SectionParserHelper<Action, ActionParser>::parse(
+        source, ActionSectionType, action);
 
     REQUIRE(action.report.error.code == Error::OK);
     REQUIRE(action.report.warnings.size() == 2);

--- a/test/test-MSONMixinParser.cc
+++ b/test/test-MSONMixinParser.cc
@@ -22,14 +22,18 @@ TEST_CASE("Mixin block classifier", "[mson][mixin]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    REQUIRE(markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
+    REQUIRE(
+        markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
     REQUIRE(!markdownAST.children().front().children().empty());
 
-    sectionType = SectionProcessor<mson::Mixin>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::Mixin>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONMixinSectionType);
 
-    markdownAST.children().front().children().front().text = "Include (Address, sample)";
-    sectionType = SectionProcessor<mson::Mixin>::sectionType(markdownAST.children().begin());
+    markdownAST.children().front().children().front().text
+        = "Include (Address, sample)";
+    sectionType = SectionProcessor<mson::Mixin>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONMixinSectionType);
 }
 
@@ -118,9 +122,11 @@ TEST_CASE("Parse mson mixin with nested type definition", "[mson][mixin]")
     REQUIRE(mixin.node.typeSpecification.name.symbol.literal == "Person");
     REQUIRE(mixin.node.typeSpecification.name.symbol.variable == false);
     REQUIRE(mixin.node.typeSpecification.nestedTypes.size() == 2);
-    REQUIRE(mixin.node.typeSpecification.nestedTypes[0].base == mson::NumberTypeName);
+    REQUIRE(mixin.node.typeSpecification.nestedTypes[0].base
+        == mson::NumberTypeName);
     REQUIRE(mixin.node.typeSpecification.nestedTypes[0].symbol.empty());
-    REQUIRE(mixin.node.typeSpecification.nestedTypes[1].base == mson::StringTypeName);
+    REQUIRE(mixin.node.typeSpecification.nestedTypes[1].base
+        == mson::StringTypeName);
     REQUIRE(mixin.node.typeSpecification.nestedTypes[1].symbol.empty());
 
     SourceMapHelper::check(mixin.sourceMap.sourceMap, 2, 42);

--- a/test/test-MSONNamedTypeParser.cc
+++ b/test/test-MSONNamedTypeParser.cc
@@ -39,122 +39,172 @@ TEST_CASE("Parse canonical mson named type", "[mson][named_type]")
     REQUIRE(namedType.node.name.symbol.literal == "User");
     REQUIRE(namedType.node.name.base == mson::UndefinedTypeName);
     REQUIRE(namedType.node.typeDefinition.attributes == 0);
-    REQUIRE(namedType.node.typeDefinition.typeSpecification.name.base == mson::ObjectTypeName);
-    REQUIRE(namedType.node.typeDefinition.typeSpecification.name.symbol.empty());
+    REQUIRE(namedType.node.typeDefinition.typeSpecification.name.base
+        == mson::ObjectTypeName);
+    REQUIRE(
+        namedType.node.typeDefinition.typeSpecification.name.symbol.empty());
     REQUIRE(namedType.node.typeDefinition.baseType == mson::ObjectBaseType);
     REQUIRE(namedType.node.sections.size() == 1);
-    REQUIRE(namedType.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        namedType.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
     REQUIRE(namedType.node.sections[0].content.elements().size() == 5);
 
     element = namedType.node.sections[0].content.elements().at(0);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "login");
     REQUIRE(element.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(element.content.property.valueDefinition.values[0].literal == "pksunkara");
-    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType == mson::PrimitiveBaseType);
-    REQUIRE(
-        element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+    REQUIRE(element.content.property.valueDefinition.values[0].literal
+        == "pksunkara");
+    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType
+        == mson::PrimitiveBaseType);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::StringTypeName);
     REQUIRE(element.content.property.sections.empty());
 
     element = namedType.node.sections[0].content.elements().at(1);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "name");
     REQUIRE(element.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(element.content.property.valueDefinition.values[0].literal == "Pavan Kumar Sunkara");
-    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType == mson::PrimitiveBaseType);
-    REQUIRE(
-        element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+    REQUIRE(element.content.property.valueDefinition.values[0].literal
+        == "Pavan Kumar Sunkara");
+    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType
+        == mson::PrimitiveBaseType);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::StringTypeName);
     REQUIRE(element.content.property.sections.empty());
 
     element = namedType.node.sections[0].content.elements().at(2);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "admin");
     REQUIRE(element.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(element.content.property.valueDefinition.values[0].literal == "false");
-    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType == mson::PrimitiveBaseType);
     REQUIRE(
-        element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::BooleanTypeName);
+        element.content.property.valueDefinition.values[0].literal == "false");
+    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType
+        == mson::PrimitiveBaseType);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::BooleanTypeName);
     REQUIRE(element.content.property.sections.empty());
 
     element = namedType.node.sections[0].content.elements().at(3);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "orgs");
     REQUIRE(element.content.property.valueDefinition.values.size() == 2);
-    REQUIRE(element.content.property.valueDefinition.values[0].literal == "confy");
-    REQUIRE(element.content.property.valueDefinition.values[1].literal == "apiary");
-    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType == mson::ValueBaseType);
-    REQUIRE(element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(
+        element.content.property.valueDefinition.values[0].literal == "confy");
+    REQUIRE(
+        element.content.property.valueDefinition.values[1].literal == "apiary");
+    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType
+        == mson::ValueBaseType);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::ArrayTypeName);
     REQUIRE(element.content.property.sections.empty());
 
     element = namedType.node.sections[0].content.elements().at(4);
     REQUIRE(element.klass == mson::Element::PropertyClass);
     REQUIRE(element.content.property.name.literal == "plan");
     REQUIRE(element.content.property.valueDefinition.values.empty());
-    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType == mson::ObjectBaseType);
-    REQUIRE(
-        element.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::ObjectTypeName);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition.baseType
+        == mson::ObjectBaseType);
+    REQUIRE(element.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::ObjectTypeName);
     REQUIRE(element.content.property.sections.size() == 2);
-    REQUIRE(element.content.property.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(element.content.property.sections[0].content.description == "The subscription plan of the user");
-    REQUIRE(element.content.property.sections[1].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(element.content.property.sections[1].content.elements().size() == 2);
+    REQUIRE(element.content.property.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(element.content.property.sections[0].content.description
+        == "The subscription plan of the user");
+    REQUIRE(element.content.property.sections[1].klass
+        == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        element.content.property.sections[1].content.elements().size() == 2);
 
     subelement = element.content.property.sections[1].content.elements().at(0);
     REQUIRE(subelement.klass == mson::Element::PropertyClass);
     REQUIRE(subelement.content.property.name.literal == "stripe");
-    REQUIRE(
-        subelement.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::NumberTypeName);
+    REQUIRE(subelement.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::NumberTypeName);
     REQUIRE(subelement.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(subelement.content.property.valueDefinition.values[0].literal == "1284");
+    REQUIRE(subelement.content.property.valueDefinition.values[0].literal
+        == "1284");
 
     subelement = element.content.property.sections[1].content.elements().at(1);
     REQUIRE(subelement.klass == mson::Element::PropertyClass);
     REQUIRE(subelement.content.property.name.literal == "name");
-    REQUIRE(
-        subelement.content.property.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+    REQUIRE(subelement.content.property.valueDefinition.typeDefinition
+                .typeSpecification.name.base
+        == mson::StringTypeName);
     REQUIRE(subelement.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(subelement.content.property.valueDefinition.values[0].literal == "Medium");
+    REQUIRE(subelement.content.property.valueDefinition.values[0].literal
+        == "Medium");
 
     SourceMapHelper::check(namedType.sourceMap.name.sourceMap, 0, 16);
     SourceMapHelper::check(namedType.sourceMap.typeDefinition.sourceMap, 0, 16);
     REQUIRE(namedType.sourceMap.sections.collection.size() == 1);
-    REQUIRE(namedType.sourceMap.sections.collection[0].elements().collection.size() == 5);
+    REQUIRE(
+        namedType.sourceMap.sections.collection[0].elements().collection.size()
+        == 5);
 
-    elementSM = namedType.sourceMap.sections.collection[0].elements().collection[0];
+    elementSM
+        = namedType.sourceMap.sections.collection[0].elements().collection[0];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 18, 26);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 18, 26);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 18, 26);
     REQUIRE(elementSM.property.sections.collection.empty());
 
-    elementSM = namedType.sourceMap.sections.collection[0].elements().collection[1];
+    elementSM
+        = namedType.sourceMap.sections.collection[0].elements().collection[1];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 46, 45);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 46, 45);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 46, 45);
     REQUIRE(elementSM.property.sections.collection.empty());
 
-    elementSM = namedType.sourceMap.sections.collection[0].elements().collection[2];
+    elementSM
+        = namedType.sourceMap.sections.collection[0].elements().collection[2];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 93, 32);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 93, 32);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 93, 32);
     REQUIRE(elementSM.property.sections.collection.empty());
 
-    elementSM = namedType.sourceMap.sections.collection[0].elements().collection[3];
+    elementSM
+        = namedType.sourceMap.sections.collection[0].elements().collection[3];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 127, 28);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 127, 28);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 127, 28);
     REQUIRE(elementSM.property.sections.collection.empty());
 
-    elementSM = namedType.sourceMap.sections.collection[0].elements().collection[4];
+    elementSM
+        = namedType.sourceMap.sections.collection[0].elements().collection[4];
     SourceMapHelper::check(elementSM.property.name.sourceMap, 157, 14, 175, 34);
-    SourceMapHelper::check(elementSM.property.valueDefinition.sourceMap, 157, 14, 175, 34);
+    SourceMapHelper::check(
+        elementSM.property.valueDefinition.sourceMap, 157, 14, 175, 34);
     REQUIRE(elementSM.property.sections.collection.size() == 2);
-    SourceMapHelper::check(elementSM.property.sections.collection[0].description.sourceMap, 157, 14, 175, 34);
-    REQUIRE(elementSM.property.sections.collection[1].elements().collection.size() == 2);
+    SourceMapHelper::check(
+        elementSM.property.sections.collection[0].description.sourceMap,
+        157,
+        14,
+        175,
+        34);
+    REQUIRE(
+        elementSM.property.sections.collection[1].elements().collection.size()
+        == 2);
 
-    subelementSM = elementSM.property.sections.collection[1].elements().collection[0];
+    subelementSM
+        = elementSM.property.sections.collection[1].elements().collection[0];
     SourceMapHelper::check(subelementSM.property.name.sourceMap, 236, 22);
-    SourceMapHelper::check(subelementSM.property.valueDefinition.sourceMap, 236, 22);
+    SourceMapHelper::check(
+        subelementSM.property.valueDefinition.sourceMap, 236, 22);
     REQUIRE(subelementSM.property.sections.collection.empty());
 
-    subelementSM = elementSM.property.sections.collection[1].elements().collection[1];
+    subelementSM
+        = elementSM.property.sections.collection[1].elements().collection[1];
     SourceMapHelper::check(subelementSM.property.name.sourceMap, 268, 22);
-    SourceMapHelper::check(subelementSM.property.valueDefinition.sourceMap, 268, 22);
+    SourceMapHelper::check(
+        subelementSM.property.valueDefinition.sourceMap, 268, 22);
     REQUIRE(subelementSM.property.sections.collection.empty());
 }
 
@@ -174,8 +224,10 @@ TEST_CASE("Parse named type with a type section", "[mson][named_type]")
     REQUIRE(namedType.node.name.symbol.literal == "User");
     REQUIRE(namedType.node.name.base == mson::UndefinedTypeName);
     REQUIRE(namedType.node.typeDefinition.attributes == 0);
-    REQUIRE(namedType.node.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
-    REQUIRE(namedType.node.typeDefinition.typeSpecification.name.symbol.empty());
+    REQUIRE(namedType.node.typeDefinition.typeSpecification.name.base
+        == mson::StringTypeName);
+    REQUIRE(
+        namedType.node.typeDefinition.typeSpecification.name.symbol.empty());
     REQUIRE(namedType.node.typeDefinition.baseType == mson::PrimitiveBaseType);
     REQUIRE(namedType.node.sections.size() == 1);
     REQUIRE(namedType.node.sections[0].klass == mson::TypeSection::SampleClass);
@@ -184,7 +236,8 @@ TEST_CASE("Parse named type with a type section", "[mson][named_type]")
     SourceMapHelper::check(namedType.sourceMap.name.sourceMap, 0, 16);
     SourceMapHelper::check(namedType.sourceMap.typeDefinition.sourceMap, 0, 16);
     REQUIRE(namedType.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(namedType.sourceMap.sections.collection[0].value.sourceMap, 16, 20);
+    SourceMapHelper::check(
+        namedType.sourceMap.sections.collection[0].value.sourceMap, 16, 20);
 }
 
 TEST_CASE("Parse named type without type specification", "[mson][named_type]")
@@ -204,10 +257,12 @@ TEST_CASE("Parse named type without type specification", "[mson][named_type]")
     REQUIRE(namedType.node.name.symbol.literal == "User");
     REQUIRE(namedType.node.typeDefinition.attributes == 0);
     REQUIRE(namedType.node.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(namedType.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        namedType.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(namedType.node.sections.size() == 1);
     REQUIRE(namedType.node.sections[0].klass == mson::TypeSection::SampleClass);
-    REQUIRE(namedType.node.sections[0].baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        namedType.node.sections[0].baseType == mson::ImplicitObjectBaseType);
 
     SourceMapHelper::check(namedType.sourceMap.name.sourceMap, 0, 7);
     REQUIRE(namedType.sourceMap.typeDefinition.sourceMap.empty());
@@ -232,9 +287,11 @@ TEST_CASE("Parse type attributes on named type", "[mson][named_type]")
     REQUIRE(namedType.node.name.symbol.literal == "User");
     REQUIRE(namedType.node.typeDefinition.attributes == 4);
     REQUIRE(namedType.node.typeDefinition.typeSpecification.name.empty());
-    REQUIRE(namedType.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(
+        namedType.node.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(namedType.node.sections.size() == 1);
-    REQUIRE(namedType.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(
+        namedType.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
 }
 
 TEST_CASE("Parse variable named type", "[mson][named_type]")
@@ -252,7 +309,8 @@ TEST_CASE("Parse variable named type", "[mson][named_type]")
     REQUIRE(namedType.node.name.symbol.variable == true);
 }
 
-TEST_CASE("Parse variable named type with reserved characters", "[mson][named_type][335]")
+TEST_CASE("Parse variable named type with reserved characters",
+    "[mson][named_type][335]")
 {
     mdp::ByteBuffer source = "# *User (string)*";
 
@@ -267,7 +325,8 @@ TEST_CASE("Parse variable named type with reserved characters", "[mson][named_ty
     REQUIRE(namedType.node.name.symbol.variable == true);
 }
 
-TEST_CASE("Parse variable named type with escaped reserved characters", "[mson][named_type]")
+TEST_CASE("Parse variable named type with escaped reserved characters",
+    "[mson][named_type]")
 {
     mdp::ByteBuffer source = "# `User-A` (string)";
 

--- a/test/test-MSONOneOfParser.cc
+++ b/test/test-MSONOneOfParser.cc
@@ -22,14 +22,17 @@ TEST_CASE("OneOf block classifier", "[mson][one_of]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    REQUIRE(markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
+    REQUIRE(
+        markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
     REQUIRE(!markdownAST.children().front().children().empty());
 
-    sectionType = SectionProcessor<mson::OneOf>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::OneOf>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONOneOfSectionType);
 
     markdownAST.children().front().children().front().text = "One of";
-    sectionType = SectionProcessor<mson::OneOf>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::OneOf>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONOneOfSectionType);
 }
 
@@ -42,7 +45,8 @@ TEST_CASE("OneOf be tolerant on parsing input", "[mson][one_of]")
     SectionType sectionType;
     markdownParser.parse(source, markdownAST);
 
-    sectionType = SectionProcessor<mson::OneOf>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::OneOf>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONOneOfSectionType);
 }
 
@@ -64,8 +68,11 @@ TEST_CASE("Parse canonical mson one of", "[mson][one_of]")
 
     REQUIRE(oneOf.node.at(0).klass == mson::Element::PropertyClass);
     REQUIRE(oneOf.node.at(0).content.property.name.literal == "state");
-    REQUIRE(oneOf.node.at(0).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(oneOf.node.at(0).content.property.valueDefinition.values.at(0).literal == "Andhra Pradesh");
+    REQUIRE(
+        oneOf.node.at(0).content.property.valueDefinition.values.size() == 1);
+    REQUIRE(
+        oneOf.node.at(0).content.property.valueDefinition.values.at(0).literal
+        == "Andhra Pradesh");
     REQUIRE(oneOf.node.at(0).content.property.sections.empty());
     REQUIRE(oneOf.node.at(0).content.property.description.empty());
     REQUIRE(oneOf.node.at(0).content.property.name.variable.empty());
@@ -76,18 +83,29 @@ TEST_CASE("Parse canonical mson one of", "[mson][one_of]")
 
     REQUIRE(oneOf.node.at(1).klass == mson::Element::PropertyClass);
     REQUIRE(oneOf.node.at(1).content.property.name.literal == "province");
-    REQUIRE(oneOf.node.at(1).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(oneOf.node.at(1).content.property.valueDefinition.values.at(0).literal == "Madras");
+    REQUIRE(
+        oneOf.node.at(1).content.property.valueDefinition.values.size() == 1);
+    REQUIRE(
+        oneOf.node.at(1).content.property.valueDefinition.values.at(0).literal
+        == "Madras");
     REQUIRE(oneOf.node.at(1).content.property.sections.empty());
     REQUIRE(oneOf.node.at(1).content.property.description.empty());
     REQUIRE(oneOf.node.at(1).content.property.name.variable.empty());
 
     REQUIRE(oneOf.sourceMap.collection.size() == 2);
 
-    SourceMapHelper::check(oneOf.sourceMap.collection[0].property.name.sourceMap, 13, 22);
-    SourceMapHelper::check(oneOf.sourceMap.collection[0].property.valueDefinition.sourceMap, 13, 22);
-    SourceMapHelper::check(oneOf.sourceMap.collection[1].property.name.sourceMap, 39, 16);
-    SourceMapHelper::check(oneOf.sourceMap.collection[1].property.valueDefinition.sourceMap, 39, 16);
+    SourceMapHelper::check(
+        oneOf.sourceMap.collection[0].property.name.sourceMap, 13, 22);
+    SourceMapHelper::check(
+        oneOf.sourceMap.collection[0].property.valueDefinition.sourceMap,
+        13,
+        22);
+    SourceMapHelper::check(
+        oneOf.sourceMap.collection[1].property.name.sourceMap, 39, 16);
+    SourceMapHelper::check(
+        oneOf.sourceMap.collection[1].property.valueDefinition.sourceMap,
+        39,
+        16);
 }
 
 TEST_CASE("Parse mson one of without any nested members", "[mson][one_of]")
@@ -132,21 +150,43 @@ TEST_CASE("Parse mson one of with one of", "[mson][one_of]")
 
     REQUIRE(oneOf.node.at(1).klass == mson::Element::OneOfClass);
     REQUIRE(oneOf.node.at(1).content.oneOf().size() == 2);
-    REQUIRE(oneOf.node.at(1).content.oneOf().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(oneOf.node.at(1).content.oneOf().at(0).content.property.name.literal == "given_name");
-    REQUIRE(oneOf.node.at(1).content.oneOf().at(0).content.property.valueDefinition.empty());
-    REQUIRE(oneOf.node.at(1).content.oneOf().at(1).klass == mson::Element::PropertyClass);
-    REQUIRE(oneOf.node.at(1).content.oneOf().at(1).content.property.name.literal == "suffixed_name");
-    REQUIRE(oneOf.node.at(1).content.oneOf().at(1).content.property.valueDefinition.empty());
+    REQUIRE(oneOf.node.at(1).content.oneOf().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(oneOf.node.at(1).content.oneOf().at(0).content.property.name.literal
+        == "given_name");
+    REQUIRE(oneOf.node.at(1)
+                .content.oneOf()
+                .at(0)
+                .content.property.valueDefinition.empty());
+    REQUIRE(oneOf.node.at(1).content.oneOf().at(1).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(oneOf.node.at(1).content.oneOf().at(1).content.property.name.literal
+        == "suffixed_name");
+    REQUIRE(oneOf.node.at(1)
+                .content.oneOf()
+                .at(1)
+                .content.property.valueDefinition.empty());
 
     REQUIRE(oneOf.sourceMap.collection.size() == 2);
 
-    SourceMapHelper::check(oneOf.sourceMap.collection[0].property.name.sourceMap, 15, 10);
-    REQUIRE(oneOf.sourceMap.collection[0].property.valueDefinition.sourceMap.empty());
+    SourceMapHelper::check(
+        oneOf.sourceMap.collection[0].property.name.sourceMap, 15, 10);
+    REQUIRE(oneOf.sourceMap.collection[0]
+                .property.valueDefinition.sourceMap.empty());
 
     REQUIRE(oneOf.sourceMap.collection[1].oneOf().collection.size() == 2);
-    SourceMapHelper::check(oneOf.sourceMap.collection[1].oneOf().collection[0].property.name.sourceMap, 48, 11);
-    SourceMapHelper::check(oneOf.sourceMap.collection[1].oneOf().collection[1].property.name.sourceMap, 69, 13);
+    SourceMapHelper::check(oneOf.sourceMap.collection[1]
+                               .oneOf()
+                               .collection[0]
+                               .property.name.sourceMap,
+        48,
+        11);
+    SourceMapHelper::check(oneOf.sourceMap.collection[1]
+                               .oneOf()
+                               .collection[1]
+                               .property.name.sourceMap,
+        69,
+        13);
 }
 
 TEST_CASE("Parse mson one of with member group", "[mson][one_of]")
@@ -176,17 +216,35 @@ TEST_CASE("Parse mson one of with member group", "[mson][one_of]")
     REQUIRE(oneOf.node.at(1).content.mixin.empty());
     REQUIRE(oneOf.node.at(1).content.value.empty());
     REQUIRE(oneOf.node.at(1).content.elements().size() == 2);
-    REQUIRE(oneOf.node.at(1).content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(oneOf.node.at(1).content.elements().at(0).content.property.name.literal == "first_name");
-    REQUIRE(oneOf.node.at(1).content.elements().at(1).klass == mson::Element::PropertyClass);
-    REQUIRE(oneOf.node.at(1).content.elements().at(1).content.property.name.literal == "last_name");
+    REQUIRE(oneOf.node.at(1).content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(
+        oneOf.node.at(1).content.elements().at(0).content.property.name.literal
+        == "first_name");
+    REQUIRE(oneOf.node.at(1).content.elements().at(1).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(
+        oneOf.node.at(1).content.elements().at(1).content.property.name.literal
+        == "last_name");
 
     REQUIRE(oneOf.sourceMap.collection.size() == 2);
 
-    SourceMapHelper::check(oneOf.sourceMap.collection[0].property.name.sourceMap, 15, 10);
-    REQUIRE(oneOf.sourceMap.collection[0].property.valueDefinition.sourceMap.empty());
+    SourceMapHelper::check(
+        oneOf.sourceMap.collection[0].property.name.sourceMap, 15, 10);
+    REQUIRE(oneOf.sourceMap.collection[0]
+                .property.valueDefinition.sourceMap.empty());
 
     REQUIRE(oneOf.sourceMap.collection[1].elements().collection.size() == 2);
-    SourceMapHelper::check(oneOf.sourceMap.collection[1].elements().collection[0].property.name.sourceMap, 52, 11);
-    SourceMapHelper::check(oneOf.sourceMap.collection[1].elements().collection[1].property.name.sourceMap, 73, 9);
+    SourceMapHelper::check(oneOf.sourceMap.collection[1]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        52,
+        11);
+    SourceMapHelper::check(oneOf.sourceMap.collection[1]
+                               .elements()
+                               .collection[1]
+                               .property.name.sourceMap,
+        73,
+        9);
 }

--- a/test/test-MSONParameterParser.cc
+++ b/test/test-MSONParameterParser.cc
@@ -20,11 +20,15 @@ const mdp::ByteBuffer ParameterFixture
       "        + `0000`\n"
       "        + `beef` - I like beef\n";
 
-TEST_CASE("Parse canonical parameter definition with new syntax", "[mson_parameter]")
+TEST_CASE(
+    "Parse canonical parameter definition with new syntax", "[mson_parameter]")
 {
     ParseResult<MSONParameter> parameter;
     SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
-        ParameterFixture, MSONParameterSectionType, parameter, ExportSourcemapOption);
+        ParameterFixture,
+        MSONParameterSectionType,
+        parameter,
+        ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -47,12 +51,16 @@ TEST_CASE("Parse canonical parameter definition with new syntax", "[mson_paramet
     SourceMapHelper::check(parameter.sourceMap.exampleValue.sourceMap, 2, 50);
     SourceMapHelper::check(parameter.sourceMap.defaultValue.sourceMap, 59, 16);
     REQUIRE(parameter.sourceMap.values.collection.size() == 3);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[0].sourceMap, 99, 27);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[1].sourceMap, 136, 7);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[2].sourceMap, 153, 21);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[0].sourceMap, 99, 27);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[1].sourceMap, 136, 7);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[2].sourceMap, 153, 21);
 }
 
-TEST_CASE("Parse parameter description when it occurs in different cases", "[mson_parameter]")
+TEST_CASE("Parse parameter description when it occurs in different cases",
+    "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ id: 100 - Same line\n"
@@ -67,12 +75,15 @@ TEST_CASE("Parse parameter description when it occurs in different cases", "[mso
     REQUIRE(parameter.report.warnings.empty());
 
     REQUIRE(parameter.node.name == "id");
-    REQUIRE(parameter.node.description == "Same line\nSingle newline\n\nDouble newline");
+    REQUIRE(parameter.node.description
+        == "Same line\nSingle newline\n\nDouble newline");
     REQUIRE(parameter.node.exampleValue == "100");
 
     SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 2, 20, 1);
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 26, 16, 2);
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 46, 15, 3);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 26, 16, 2);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 46, 15, 3);
 }
 
 TEST_CASE("Parse parameter when it has more than 2 traits", "[mson_parameter]")
@@ -95,14 +106,16 @@ TEST_CASE("Parse parameter when it has more than 2 traits", "[mson_parameter]")
     REQUIRE(parameter.sourceMap.use.sourceMap.empty());
 }
 
-TEST_CASE("Parse parameter when it has a sample type section", "[mson_parameter]")
+TEST_CASE(
+    "Parse parameter when it has a sample type section", "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ id\n"
           "    + Sample: 42";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
+        source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -112,14 +125,16 @@ TEST_CASE("Parse parameter when it has a sample type section", "[mson_parameter]
     REQUIRE(parameter.node.exampleValue == "42");
 }
 
-TEST_CASE("Warn about implicit required vs default clash in new parameter", "[mson_parameter]")
+TEST_CASE("Warn about implicit required vs default clash in new parameter",
+    "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ id\n"
           "    + Default: 42";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
+        source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -130,7 +145,8 @@ TEST_CASE("Warn about implicit required vs default clash in new parameter", "[ms
     REQUIRE(parameter.node.defaultValue == "42");
 }
 
-TEST_CASE("Warn missing example item in values in new parameter syntax", "[mson_parameter]")
+TEST_CASE("Warn missing example item in values in new parameter syntax",
+    "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ id: `Value1` (optional, enum[string])\n"
@@ -139,7 +155,8 @@ TEST_CASE("Warn missing example item in values in new parameter syntax", "[mson_
           "        + `Value2`\n";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
+        source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -150,7 +167,8 @@ TEST_CASE("Warn missing example item in values in new parameter syntax", "[mson_
     REQUIRE(parameter.node.defaultValue == "Value2");
 }
 
-TEST_CASE("Warn missing default value in values in new parameter syntax", "[mson_parameter]")
+TEST_CASE("Warn missing default value in values in new parameter syntax",
+    "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ id: `Value2` (optional, enum[string])\n"
@@ -159,7 +177,8 @@ TEST_CASE("Warn missing default value in values in new parameter syntax", "[mson
           "        + `Value2`\n";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
+        source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -175,7 +194,8 @@ TEST_CASE("Parentheses in parameter description with new syntax", "[parameter]")
     mdp::ByteBuffer source = "+ id (string) - lorem (ipsum) dolor\n";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
+        source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());
@@ -185,7 +205,8 @@ TEST_CASE("Parentheses in parameter description with new syntax", "[parameter]")
     REQUIRE(parameter.node.description == "lorem (ipsum) dolor");
 }
 
-TEST_CASE("Parse parameter including backtics for escaping, issue drafter#445", "[mson_parameter]")
+TEST_CASE("Parse parameter including backtics for escaping, issue drafter#445",
+    "[mson_parameter]")
 {
     mdp::ByteBuffer source
         = "+ `start_time`: `recorded_at` (enum[string], optional)\n"
@@ -195,7 +216,8 @@ TEST_CASE("Parse parameter including backtics for escaping, issue drafter#445", 
           "        + `created_at`";
 
     ParseResult<MSONParameter> parameter;
-    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(source, MSONParameterSectionType, parameter);
+    SectionParserHelper<MSONParameter, MSONParameterParser>::parse(
+        source, MSONParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.empty());

--- a/test/test-MSONPropertyMemberParser.cc
+++ b/test/test-MSONPropertyMemberParser.cc
@@ -18,7 +18,10 @@ TEST_CASE("Parse canonical mson property member", "[mson][property_member]")
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -28,17 +31,25 @@ TEST_CASE("Parse canonical mson property member", "[mson][property_member]")
     REQUIRE(propertyMember.node.description == "A color");
     REQUIRE(propertyMember.node.valueDefinition.values.size() == 1);
     REQUIRE(propertyMember.node.valueDefinition.values[0].literal == "red");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.symbol.empty());
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.nestedTypes.empty());
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.attributes == mson::RequiredTypeAttribute);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::StringTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.symbol.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .nestedTypes.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.attributes
+        == mson::RequiredTypeAttribute);
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 39);
-    SourceMapHelper::check(propertyMember.sourceMap.description.sourceMap, 2, 39);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 39);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.description.sourceMap, 2, 39);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 39);
 }
 
-TEST_CASE("Parse mson property member with description not on new line", "[mson][property_member]")
+TEST_CASE("Parse mson property member with description not on new line",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- color: red (string, required) - A color\n"
@@ -46,7 +57,10 @@ TEST_CASE("Parse mson property member with description not on new line", "[mson]
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -56,20 +70,33 @@ TEST_CASE("Parse mson property member with description not on new line", "[mson]
     REQUIRE(propertyMember.node.description == "A color");
     REQUIRE(propertyMember.node.valueDefinition.values.size() == 1);
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "Which is also very nice");
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].content.description
+        == "Which is also very nice");
     REQUIRE(propertyMember.node.sections[0].content.elements().empty());
 
-    SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 40, 44, 24);
-    SourceMapHelper::check(propertyMember.sourceMap.description.sourceMap, 2, 40, 44, 24);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 40, 44, 24);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.name.sourceMap, 2, 40, 44, 24);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.description.sourceMap, 2, 40, 44, 24);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 40, 44, 24);
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].elements().collection.empty());
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 2, 40, 44, 24);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.empty());
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        2,
+        40,
+        44,
+        24);
 }
 
-TEST_CASE("Parse mson property member with block description", "[mson][property_member]")
+TEST_CASE("Parse mson property member with block description",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- color: red (string, required) - A color\n\n"
@@ -79,7 +106,10 @@ TEST_CASE("Parse mson property member with block description", "[mson][property_
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -88,20 +118,32 @@ TEST_CASE("Parse mson property member with block description", "[mson][property_
     REQUIRE(propertyMember.node.name.variable.empty());
     REQUIRE(propertyMember.node.description == "A color");
     REQUIRE(propertyMember.node.valueDefinition.values.size() == 1);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.attributes == mson::RequiredTypeAttribute);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.attributes
+        == mson::RequiredTypeAttribute);
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "Which is also very nice\n\n- and awesome");
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].content.description
+        == "Which is also very nice\n\n- and awesome");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 41);
-    SourceMapHelper::check(propertyMember.sourceMap.description.sourceMap, 2, 41);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 41);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.description.sourceMap, 2, 41);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 41);
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 47, 24, 76, 14);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        47,
+        24,
+        76,
+        14);
 }
 
-TEST_CASE("Parse mson property member with block description, default and sample", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property member with block description, default and sample",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- color: red (string) - A color\n\n"
@@ -113,7 +155,10 @@ TEST_CASE("Parse mson property member with block description, default and sample
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -124,24 +169,42 @@ TEST_CASE("Parse mson property member with block description, default and sample
     REQUIRE(propertyMember.node.valueDefinition.values.size() == 1);
     REQUIRE(propertyMember.node.valueDefinition.values[0].literal == "red");
     REQUIRE(propertyMember.node.sections.size() == 3);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "Which is also very nice\n\n- and awesome");
-    REQUIRE(propertyMember.node.sections[1].klass == mson::TypeSection::DefaultClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].content.description
+        == "Which is also very nice\n\n- and awesome");
+    REQUIRE(propertyMember.node.sections[1].klass
+        == mson::TypeSection::DefaultClass);
     REQUIRE(propertyMember.node.sections[1].content.value == "yellow");
-    REQUIRE(propertyMember.node.sections[2].klass == mson::TypeSection::SampleClass);
+    REQUIRE(propertyMember.node.sections[2].klass
+        == mson::TypeSection::SampleClass);
     REQUIRE(propertyMember.node.sections[2].content.value == "green\n");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 31);
-    SourceMapHelper::check(propertyMember.sourceMap.description.sourceMap, 2, 31);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 31);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.description.sourceMap, 2, 31);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 31);
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 3);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 37, 24, 66, 14);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1].value.sourceMap, 87, 16);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[2].value.sourceMap, 125, 6);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        37,
+        24,
+        66,
+        14);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[1].value.sourceMap,
+        87,
+        16);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[2].value.sourceMap,
+        125,
+        6);
 }
 
-TEST_CASE("Parse mson property member object with nested members", "[mson][property_member]")
+TEST_CASE("Parse mson property member object with nested members",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- user (object)\n"
@@ -150,7 +213,10 @@ TEST_CASE("Parse mson property member object with nested members", "[mson][prope
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -159,41 +225,92 @@ TEST_CASE("Parse mson property member object with nested members", "[mson][prope
     REQUIRE(propertyMember.node.name.variable.empty());
     REQUIRE(propertyMember.node.description.empty());
     REQUIRE(propertyMember.node.valueDefinition.values.empty());
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::ObjectTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::ObjectTypeName);
     REQUIRE(propertyMember.node.sections.size() == 1);
 
     REQUIRE(propertyMember.node.sections[0].content.description.empty());
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[0].content.elements().size() == 2);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.name.literal == "first_name");
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.name.variable.empty());
-    REQUIRE(
-        propertyMember.node.sections[0].content.elements().at(0).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.valueDefinition.values[0].literal
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "first_name");
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.name.variable.empty());
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.valueDefinition.values.size()
+        == 1);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.valueDefinition.values[0]
+                .literal
         == "Pavan");
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.description == "A sample value");
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.property.name.literal == "last_name");
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.property.name.variable.empty());
-    REQUIRE(
-        propertyMember.node.sections[0].content.elements().at(1).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.property.valueDefinition.values[0].literal
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.description
+        == "A sample value");
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.name.literal
+        == "last_name");
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.name.variable.empty());
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.valueDefinition.values.size()
+        == 1);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.valueDefinition.values[0]
+                .literal
         == "Sunkara");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 14);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 14);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 14);
     REQUIRE(propertyMember.sourceMap.description.sourceMap.empty());
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].elements().collection.size() == 2);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[0].property.name.sourceMap, 22, 44);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[1].property.name.sourceMap, 72, 27);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.size()
+        == 2);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        22,
+        44);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[1]
+                               .property.name.sourceMap,
+        72,
+        27);
 }
 
-TEST_CASE("Parse mson array property member with nested properties type section", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson array property member with nested properties type section",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- user (array)\n\n"
@@ -204,20 +321,29 @@ TEST_CASE("Parse mson array property member with nested properties type section"
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.size() == 1);
     REQUIRE(propertyMember.report.warnings[0].code == LogicalErrorWarning);
 
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 20, 14);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        20,
+        14);
 }
 
-TEST_CASE("Parse mson property member when it has a member group in nested members", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property member when it has a member group in nested members",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- user (object)\n"
@@ -228,32 +354,68 @@ TEST_CASE("Parse mson property member when it has a member group in nested membe
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.sections.size() == 2);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[0].content.elements().size() == 1);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.name.literal == "username");
-    REQUIRE(propertyMember.node.sections[1].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "username");
+    REQUIRE(propertyMember.node.sections[1].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[1].content.elements().size() == 2);
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).content.property.name.literal == "last_name");
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(1).content.property.name.literal == "first_name");
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "last_name");
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(1)
+                .content.property.name.literal
+        == "first_name");
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 2);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].elements().collection.size() == 1);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[0].property.name.sourceMap, 22, 18);
-    REQUIRE(propertyMember.sourceMap.sections.collection[1].elements().collection.size() == 2);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[1].elements().collection[0].property.name.sourceMap, 67, 10);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[1].elements().collection[1].property.name.sourceMap, 83, 19);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.size()
+        == 1);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        22,
+        18);
+    REQUIRE(propertyMember.sourceMap.sections.collection[1]
+                .elements()
+                .collection.size()
+        == 2);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        67,
+        10);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1]
+                               .elements()
+                               .collection[1]
+                               .property.name.sourceMap,
+        83,
+        19);
 }
 
-TEST_CASE("Parse mson property member when it has multiple member groups", "[mson][property_member]")
+TEST_CASE("Parse mson property member when it has multiple member groups",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- user (object)\n\n"
@@ -267,37 +429,81 @@ TEST_CASE("Parse mson property member when it has multiple member groups", "[mso
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.sections.size() == 3);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "This is good\n\n- really\n\nI am serious");
-    REQUIRE(propertyMember.node.sections[1].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].content.description
+        == "This is good\n\n- really\n\nI am serious");
+    REQUIRE(propertyMember.node.sections[1].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[1].content.elements().size() == 1);
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).content.property.name.literal == "last_name");
-    REQUIRE(propertyMember.node.sections[2].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "last_name");
+    REQUIRE(propertyMember.node.sections[2].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[2].content.elements().size() == 1);
-    REQUIRE(propertyMember.node.sections[2].content.elements().at(0).content.property.name.literal == "first_name");
+    REQUIRE(propertyMember.node.sections[2]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "first_name");
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 3);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].description.sourceMap.size() == 3);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 21, 13, 1);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 38, 10, 2);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 52, 13, 3);
-
-    REQUIRE(propertyMember.sourceMap.sections.collection[1].elements().collection.size() == 1);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .description.sourceMap.size()
+        == 3);
     SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[1].elements().collection[0].property.name.sourceMap, 92, 10);
-
-    REQUIRE(propertyMember.sourceMap.sections.collection[2].elements().collection.size() == 1);
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        21,
+        13,
+        1);
     SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[2].elements().collection[0].property.name.sourceMap, 130, 10);
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        38,
+        10,
+        2);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        52,
+        13,
+        3);
+
+    REQUIRE(propertyMember.sourceMap.sections.collection[1]
+                .elements()
+                .collection.size()
+        == 1);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        92,
+        10);
+
+    REQUIRE(propertyMember.sourceMap.sections.collection[2]
+                .elements()
+                .collection.size()
+        == 1);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[2]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        130,
+        10);
 }
 
-TEST_CASE("Parse mson property member when it has the wrong member group", "[mson][property_member]")
+TEST_CASE("Parse mson property member when it has the wrong member group",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- user (array)\n\n"
@@ -307,21 +513,31 @@ TEST_CASE("Parse mson property member when it has the wrong member group", "[mso
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.size() == 1);
     REQUIRE(propertyMember.report.warnings[0].code == LogicalErrorWarning);
 
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "This is good");
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(
+        propertyMember.node.sections[0].content.description == "This is good");
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 20, 13);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        20,
+        13);
 }
 
-TEST_CASE("Parse mson property member when it is an object and has no sub-type specified and with member group",
+TEST_CASE(
+    "Parse mson property member when it is an object and has no sub-type "
+    "specified and with member group",
     "[mson][property_member]")
 {
     mdp::ByteBuffer source
@@ -332,43 +548,83 @@ TEST_CASE("Parse mson property member when it is an object and has no sub-type s
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.name.literal == "user");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::UndefinedTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.symbol.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::UndefinedTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.symbol.empty());
 
     REQUIRE(propertyMember.node.sections.size() == 2);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "This is good");
-    REQUIRE(propertyMember.node.sections[1].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(propertyMember.node.sections[1].content.elements().size() == 1);
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).content.property.name.literal == "last_name");
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
     REQUIRE(
-        propertyMember.node.sections[1].content.elements().at(0).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).content.property.valueDefinition.values[0].literal
+        propertyMember.node.sections[0].content.description == "This is good");
+    REQUIRE(propertyMember.node.sections[1].klass
+        == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[1].content.elements().size() == 1);
+    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "last_name");
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(0)
+                .content.property.valueDefinition.values.size()
+        == 1);
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(0)
+                .content.property.valueDefinition.values[0]
+                .literal
         == "sunkara");
-    REQUIRE(propertyMember.node.sections[1].content.elements().at(0).content.property.sections.empty());
+    REQUIRE(propertyMember.node.sections[1]
+                .content.elements()
+                .at(0)
+                .content.property.sections.empty());
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 6);
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 2);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 12, 13);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        12,
+        13);
 
-    REQUIRE(propertyMember.sourceMap.sections.collection[1].elements().collection.size() == 1);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[1].elements().collection[0].property.name.sourceMap, 52, 27);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[1].elements().collection[0].property.valueDefinition.sourceMap,
+    REQUIRE(propertyMember.sourceMap.sections.collection[1]
+                .elements()
+                .collection.size()
+        == 1);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        52,
+        27);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1]
+                               .elements()
+                               .collection[0]
+                               .property.valueDefinition.sourceMap,
         52,
         27);
 }
 
-TEST_CASE("Parse mson property member when it is an object and has no sub-type specified", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property member when it is an object and has no sub-type "
+    "specified",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- user\n\n"
@@ -378,59 +634,116 @@ TEST_CASE("Parse mson property member when it is an object and has no sub-type s
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.size() == 1);
     REQUIRE(propertyMember.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(propertyMember.node.name.literal == "user");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitObjectBaseType);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::UndefinedTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.symbol.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitObjectBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::UndefinedTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.symbol.empty());
 
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
-    REQUIRE(propertyMember.node.sections[0].baseType == mson::ImplicitObjectBaseType);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0].baseType
+        == mson::ImplicitObjectBaseType);
     REQUIRE(propertyMember.node.sections[0].content.elements().size() == 2);
 
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.name.literal == "last_name");
-    REQUIRE(
-        propertyMember.node.sections[0].content.elements().at(0).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.valueDefinition.values[0].literal
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.name.literal
+        == "last_name");
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.valueDefinition.values.size()
+        == 1);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.valueDefinition.values[0]
+                .literal
         == "sunkara");
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).content.property.sections.empty());
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.property.sections.empty());
 
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.property.name.literal == "first_name");
-    REQUIRE(
-        propertyMember.node.sections[0].content.elements().at(1).content.property.valueDefinition.values.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.property.valueDefinition.values[0].literal
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.name.literal
+        == "first_name");
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.valueDefinition.values.size()
+        == 1);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.valueDefinition.values[0]
+                .literal
         == "pavan");
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.property.sections.empty());
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.property.sections.empty());
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 5);
     REQUIRE(propertyMember.sourceMap.valueDefinition.sourceMap.empty());
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].elements().collection.size() == 2);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.size()
+        == 2);
 
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[0].property.name.sourceMap, 14, 28);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[0].property.valueDefinition.sourceMap,
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
         14,
         28);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[1].property.name.sourceMap, 75, 26);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[1].property.valueDefinition.sourceMap,
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[0]
+                               .property.valueDefinition.sourceMap,
+        14,
+        28);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[1]
+                               .property.name.sourceMap,
+        75,
+        26);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[1]
+                               .property.valueDefinition.sourceMap,
         75,
         26);
 }
 
-TEST_CASE("Parse mson property member when it is a string and has no sub-type specified", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property member when it is a string and has no sub-type "
+    "specified",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- username\n\n"
@@ -439,32 +752,52 @@ TEST_CASE("Parse mson property member when it is a string and has no sub-type sp
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.name.literal == "username");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitPrimitiveBaseType);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::UndefinedTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.symbol.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitPrimitiveBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::UndefinedTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.symbol.empty());
 
     REQUIRE(propertyMember.node.sections.size() == 2);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "Some block description");
-    REQUIRE(propertyMember.node.sections[1].klass == mson::TypeSection::SampleClass);
-    REQUIRE(propertyMember.node.sections[1].baseType == mson::ImplicitPrimitiveBaseType);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].content.description
+        == "Some block description");
+    REQUIRE(propertyMember.node.sections[1].klass
+        == mson::TypeSection::SampleClass);
+    REQUIRE(propertyMember.node.sections[1].baseType
+        == mson::ImplicitPrimitiveBaseType);
     REQUIRE(propertyMember.node.sections[1].content.value == "Pavan, Sunkara");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 10);
     REQUIRE(propertyMember.sourceMap.valueDefinition.sourceMap.empty());
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 2);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 16, 23);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[1].value.sourceMap, 46, 22);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        16,
+        23);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[1].value.sourceMap,
+        46,
+        22);
 }
 
-TEST_CASE("Parse mson property member when no sub-type specified and no nested sections", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property member when no sub-type specified and no nested "
+    "sections",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- username\n\n"
@@ -472,28 +805,41 @@ TEST_CASE("Parse mson property member when no sub-type specified and no nested s
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.name.literal == "username");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitPrimitiveBaseType);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::UndefinedTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.symbol.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitPrimitiveBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::UndefinedTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.symbol.empty());
 
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(propertyMember.node.sections[0].content.description == "Some block description");
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(propertyMember.node.sections[0].content.description
+        == "Some block description");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 10);
     REQUIRE(propertyMember.sourceMap.valueDefinition.sourceMap.empty());
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0].description.sourceMap, 16, 22);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.sections.collection[0].description.sourceMap,
+        16,
+        22);
 }
 
-TEST_CASE("Parse mson property member when containing a mixin", "[mson][property_member]")
+TEST_CASE("Parse mson property member when containing a mixin",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- formal_person (object)\n"
@@ -505,34 +851,59 @@ TEST_CASE("Parse mson property member when containing a mixin", "[mson][property
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption, Models(), NULL, namedTypes);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption,
+        Models(),
+        NULL,
+        namedTypes);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.name.literal == "formal_person");
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[0].content.elements().size() == 2);
 
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass == mson::Element::MixinClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).content.mixin.typeSpecification.name.symbol.literal
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass
+        == mson::Element::MixinClass);
+    REQUIRE(propertyMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.mixin.typeSpecification.name.symbol.literal
         == "Person");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 23);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 23);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 23);
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].elements().collection.size() == 2);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.size()
+        == 2);
 
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[0].property.name.sourceMap, 29, 11);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[1].mixin.sourceMap, 44, 14);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        29,
+        11);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[1]
+                               .mixin.sourceMap,
+        44,
+        14);
 }
 
-TEST_CASE("Parse mson property member when containing an oneOf", "[mson][property_member]")
+TEST_CASE("Parse mson property member when containing an oneOf",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source
         = "- formal_person (object)\n"
@@ -543,20 +914,29 @@ TEST_CASE("Parse mson property member when containing an oneOf", "[mson][propert
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.name.literal == "formal_person");
     REQUIRE(propertyMember.node.sections.size() == 1);
-    REQUIRE(propertyMember.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(propertyMember.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(propertyMember.node.sections[0].content.elements().size() == 2);
 
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass == mson::Element::OneOfClass);
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(propertyMember.node.sections[0].content.elements().at(1).klass
+        == mson::Element::OneOfClass);
 
-    mson::OneOf oneOf = propertyMember.node.sections[0].content.elements().at(1).content.oneOf();
+    mson::OneOf oneOf = propertyMember.node.sections[0]
+                            .content.elements()
+                            .at(1)
+                            .content.oneOf();
     REQUIRE(oneOf.size() == 2);
     REQUIRE(oneOf.at(0).klass == mson::Element::PropertyClass);
     REQUIRE(oneOf.at(0).content.property.name.literal == "last_name");
@@ -564,26 +944,46 @@ TEST_CASE("Parse mson property member when containing an oneOf", "[mson][propert
     REQUIRE(oneOf.at(1).content.property.name.literal == "given_name");
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 23);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 23);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 23);
 
     REQUIRE(propertyMember.sourceMap.sections.collection.size() == 1);
-    REQUIRE(propertyMember.sourceMap.sections.collection[0].elements().collection.size() == 2);
-    SourceMapHelper::check(
-        propertyMember.sourceMap.sections.collection[0].elements().collection[0].property.name.sourceMap, 31, 11);
+    REQUIRE(propertyMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.size()
+        == 2);
+    SourceMapHelper::check(propertyMember.sourceMap.sections.collection[0]
+                               .elements()
+                               .collection[0]
+                               .property.name.sourceMap,
+        31,
+        11);
 
-    SourceMap<mson::OneOf> oneOfSM = propertyMember.sourceMap.sections.collection[0].elements().collection[1].oneOf();
+    SourceMap<mson::OneOf> oneOfSM
+        = propertyMember.sourceMap.sections.collection[0]
+              .elements()
+              .collection[1]
+              .oneOf();
     REQUIRE(oneOfSM.collection.size() == 2);
-    SourceMapHelper::check(oneOfSM.collection[0].property.name.sourceMap, 65, 10);
-    SourceMapHelper::check(oneOfSM.collection[1].property.name.sourceMap, 85, 17);
+    SourceMapHelper::check(
+        oneOfSM.collection[0].property.name.sourceMap, 65, 10);
+    SourceMapHelper::check(
+        oneOfSM.collection[1].property.name.sourceMap, 85, 17);
 }
 
-TEST_CASE("Parse mson property member containing a list of values and no type specification", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property member containing a list of values and no type "
+    "specification",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source = "- list: 1, 2, 3";
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -593,21 +993,30 @@ TEST_CASE("Parse mson property member containing a list of values and no type sp
     REQUIRE(propertyMember.node.valueDefinition.values[0].literal == "1");
     REQUIRE(propertyMember.node.valueDefinition.values[1].literal == "2");
     REQUIRE(propertyMember.node.valueDefinition.values[2].literal == "3");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ImplicitValueBaseType);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.empty());
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::ImplicitValueBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .empty());
     REQUIRE(propertyMember.node.sections.empty());
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 13);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 13);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 13);
 }
 
-TEST_CASE("Parse mson property containing list of value with string type specification", "[mson][property_member]")
+TEST_CASE(
+    "Parse mson property containing list of value with string type "
+    "specification",
+    "[mson][property_member]")
 {
     mdp::ByteBuffer source = "- list: 1, 2, 3 (string)";
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
@@ -615,31 +1024,47 @@ TEST_CASE("Parse mson property containing list of value with string type specifi
     REQUIRE(propertyMember.node.name.literal == "list");
     REQUIRE(propertyMember.node.valueDefinition.values.size() == 1);
     REQUIRE(propertyMember.node.valueDefinition.values[0].literal == "1, 2, 3");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::PrimitiveBaseType);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::PrimitiveBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::StringTypeName);
     REQUIRE(propertyMember.node.sections.empty());
 
     SourceMapHelper::check(propertyMember.sourceMap.name.sourceMap, 2, 22);
-    SourceMapHelper::check(propertyMember.sourceMap.valueDefinition.sourceMap, 2, 22);
+    SourceMapHelper::check(
+        propertyMember.sourceMap.valueDefinition.sourceMap, 2, 22);
 }
 
-TEST_CASE("Parse fixed type attribute on array with primitive nested type", "[mson][property_member][now]")
+TEST_CASE("Parse fixed type attribute on array with primitive nested type",
+    "[mson][property_member][now]")
 {
     mdp::ByteBuffer source = "+ s (array[string], fixed-type)";
 
     ParseResult<mson::PropertyMember> propertyMember;
     SectionParserHelper<mson::PropertyMember, MSONPropertyMemberParser>::parse(
-        source, MSONPropertyMemberSectionType, propertyMember, ExportSourcemapOption);
+        source,
+        MSONPropertyMemberSectionType,
+        propertyMember,
+        ExportSourcemapOption);
 
     REQUIRE(propertyMember.report.error.code == Error::OK);
     REQUIRE(propertyMember.report.warnings.empty());
 
     REQUIRE(propertyMember.node.name.literal == "s");
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.attributes == mson::FixedTypeTypeAttribute);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification.nestedTypes[0].base
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.attributes
+        == mson::FixedTypeTypeAttribute);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::ArrayTypeName);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .nestedTypes.size()
+        == 1);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.typeSpecification
+                .nestedTypes[0]
+                .base
         == mson::StringTypeName);
-    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType == mson::ValueBaseType);
+    REQUIRE(propertyMember.node.valueDefinition.typeDefinition.baseType
+        == mson::ValueBaseType);
     REQUIRE(propertyMember.node.sections.empty());
 }

--- a/test/test-MSONTypeSectionParser.cc
+++ b/test/test-MSONTypeSectionParser.cc
@@ -24,23 +24,28 @@ TEST_CASE("Type Section header block classifier", "[mson][type_section]")
     REQUIRE(!markdownAST.children().empty());
     REQUIRE(markdownAST.children().front().type == mdp::HeaderMarkdownNodeType);
 
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONValueMembersSectionType);
 
     markdownAST.children().front().text = "Members";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONValueMembersSectionType);
 
     markdownAST.children().front().text = "Properties";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONPropertyMembersSectionType);
 
     markdownAST.children().front().text = "Default";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONSampleDefaultSectionType);
 
     markdownAST.children().front().text = "Sample";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONSampleDefaultSectionType);
 }
 
@@ -54,41 +59,53 @@ TEST_CASE("Type Section list block classifier", "[mson][type_section]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    REQUIRE(markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
+    REQUIRE(
+        markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
     REQUIRE(!markdownAST.children().front().children().empty());
 
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONValueMembersSectionType);
 
     markdownAST.children().front().children().front().text = "Members";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONValueMembersSectionType);
 
     markdownAST.children().front().children().front().text = "Properties";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONPropertyMembersSectionType);
 
     markdownAST.children().front().children().front().text = "Default";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONSampleDefaultSectionType);
 
     markdownAST.children().front().children().front().text = "Default : 400";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONSampleDefaultSectionType);
 
-    markdownAST.children().front().children().front().text = "Sample: red, green";
-    sectionType = SectionProcessor<mson::TypeSection>::sectionType(markdownAST.children().begin());
+    markdownAST.children().front().children().front().text
+        = "Sample: red, green";
+    sectionType = SectionProcessor<mson::TypeSection>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONSampleDefaultSectionType);
 }
 
-TEST_CASE("Parse canonical mson sample list type section", "[mson][type_section]")
+TEST_CASE(
+    "Parse canonical mson sample list type section", "[mson][type_section]")
 {
     mdp::ByteBuffer source = "- Sample: 75";
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -110,7 +127,10 @@ TEST_CASE("Parse array mson sample list type section", "[mson][type_section]")
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -119,28 +139,56 @@ TEST_CASE("Parse array mson sample list type section", "[mson][type_section]")
     REQUIRE(typeSection.node.content.value.empty());
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().size() == 2);
-    REQUIRE(typeSection.node.content.elements().at(0).klass == mson::Element::ValueClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).content.value.valueDefinition.values[0].literal == "75");
-    REQUIRE(typeSection.node.content.elements().at(1).klass == mson::Element::ValueClass);
-    REQUIRE(typeSection.node.content.elements().at(1).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(1).content.value.valueDefinition.values[0].literal == "100");
+    REQUIRE(typeSection.node.content.elements().at(0).klass
+        == mson::Element::ValueClass);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.value.valueDefinition.values[0]
+                .literal
+        == "75");
+    REQUIRE(typeSection.node.content.elements().at(1).klass
+        == mson::Element::ValueClass);
+    REQUIRE(typeSection.node.content.elements()
+                .at(1)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(1)
+                .content.value.valueDefinition.values[0]
+                .literal
+        == "100");
 
     REQUIRE(typeSection.sourceMap.value.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.size() == 2);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].value.valueDefinition.sourceMap, 2, 15);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[1].value.valueDefinition.sourceMap, 2, 15);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[0]
+                               .value.valueDefinition.sourceMap,
+        2,
+        15);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[1]
+                               .value.valueDefinition.sourceMap,
+        2,
+        15);
 }
 
-TEST_CASE("Parse mson sample list type section for a string but having values", "[mson][type_section]")
+TEST_CASE("Parse mson sample list type section for a string but having values",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source = "- Sample: 75, 100";
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -155,14 +203,18 @@ TEST_CASE("Parse mson sample list type section for a string but having values", 
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson sample list type section for an object with a value", "[mson][type_section]")
+TEST_CASE("Parse mson sample list type section for an object with a value",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source = "- Sample: 75, 100";
 
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ObjectBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.size() == 1);
@@ -178,7 +230,8 @@ TEST_CASE("Parse mson sample list type section for an object with a value", "[ms
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson sample list type section with values as list items", "[mson][type_section]")
+TEST_CASE("Parse mson sample list type section with values as list items",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n"
@@ -188,7 +241,10 @@ TEST_CASE("Parse mson sample list type section with values as list items", "[mso
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -197,21 +253,46 @@ TEST_CASE("Parse mson sample list type section with values as list items", "[mso
     REQUIRE(typeSection.node.content.value.empty());
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().size() == 2);
-    REQUIRE(typeSection.node.content.elements().at(0).klass == mson::Element::ValueClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).content.value.valueDefinition.values[0].literal == "red");
-    REQUIRE(typeSection.node.content.elements().at(1).klass == mson::Element::ValueClass);
-    REQUIRE(typeSection.node.content.elements().at(1).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(1).content.value.valueDefinition.values[0].literal == "green");
+    REQUIRE(typeSection.node.content.elements().at(0).klass
+        == mson::Element::ValueClass);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.value.valueDefinition.values[0]
+                .literal
+        == "red");
+    REQUIRE(typeSection.node.content.elements().at(1).klass
+        == mson::Element::ValueClass);
+    REQUIRE(typeSection.node.content.elements()
+                .at(1)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(1)
+                .content.value.valueDefinition.values[0]
+                .literal
+        == "green");
 
     REQUIRE(typeSection.sourceMap.value.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.size() == 2);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].value.valueDefinition.sourceMap, 13, 4);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[1].value.valueDefinition.sourceMap, 21, 6);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[0]
+                               .value.valueDefinition.sourceMap,
+        13,
+        4);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[1]
+                               .value.valueDefinition.sourceMap,
+        21,
+        6);
 }
 
-TEST_CASE("Parse multi-line mson sample list type section without newline", "[mson][type_section]")
+TEST_CASE("Parse multi-line mson sample list type section without newline",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n"
@@ -222,7 +303,10 @@ TEST_CASE("Parse multi-line mson sample list type section without newline", "[ms
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -241,7 +325,8 @@ TEST_CASE("Parse multi-line mson sample list type section without newline", "[ms
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse multi-line mson sample list type section with newline", "[mson][type_section]")
+TEST_CASE("Parse multi-line mson sample list type section with newline",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n\n"
@@ -252,7 +337,10 @@ TEST_CASE("Parse multi-line mson sample list type section with newline", "[mson]
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -262,12 +350,16 @@ TEST_CASE("Parse multi-line mson sample list type section with newline", "[mson]
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().empty());
 
-    SourceMapHelper::check(typeSection.sourceMap.value.sourceMap, 14, 5, 23, 15);
+    SourceMapHelper::check(
+        typeSection.sourceMap.value.sourceMap, 14, 5, 23, 15);
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson sample list type section with values as para for values base type", "[mson][type_section]")
+TEST_CASE(
+    "Parse mson sample list type section with values as para for values base "
+    "type",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n\n"
@@ -277,7 +369,10 @@ TEST_CASE("Parse mson sample list type section with values as para for values ba
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -292,7 +387,8 @@ TEST_CASE("Parse mson sample list type section with values as para for values ba
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse markdown multi-line mson sample list type section", "[mson][type_section]")
+TEST_CASE("Parse markdown multi-line mson sample list type section",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n"
@@ -302,7 +398,10 @@ TEST_CASE("Parse markdown multi-line mson sample list type section", "[mson][typ
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -317,7 +416,8 @@ TEST_CASE("Parse markdown multi-line mson sample list type section", "[mson][typ
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson sample header type section with values as list items", "[mson][type_section]")
+TEST_CASE("Parse mson sample header type section with values as list items",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "# Sample\n"
@@ -327,7 +427,10 @@ TEST_CASE("Parse mson sample header type section with values as list items", "[m
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -336,21 +439,46 @@ TEST_CASE("Parse mson sample header type section with values as list items", "[m
     REQUIRE(typeSection.node.content.value.empty());
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().size() == 2);
-    REQUIRE(typeSection.node.content.elements().at(0).klass == mson::Element::ValueClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).content.value.valueDefinition.values[0].literal == "red");
-    REQUIRE(typeSection.node.content.elements().at(1).klass == mson::Element::ValueClass);
-    REQUIRE(typeSection.node.content.elements().at(1).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(1).content.value.valueDefinition.values[0].literal == "green");
+    REQUIRE(typeSection.node.content.elements().at(0).klass
+        == mson::Element::ValueClass);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.value.valueDefinition.values[0]
+                .literal
+        == "red");
+    REQUIRE(typeSection.node.content.elements().at(1).klass
+        == mson::Element::ValueClass);
+    REQUIRE(typeSection.node.content.elements()
+                .at(1)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(1)
+                .content.value.valueDefinition.values[0]
+                .literal
+        == "green");
 
     REQUIRE(typeSection.sourceMap.value.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.size() == 2);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].value.valueDefinition.sourceMap, 13, 4);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[1].value.valueDefinition.sourceMap, 21, 6);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[0]
+                               .value.valueDefinition.sourceMap,
+        13,
+        4);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[1]
+                               .value.valueDefinition.sourceMap,
+        21,
+        6);
 }
 
-TEST_CASE("Parse multi-line mson sample header type section", "[mson][type_section]")
+TEST_CASE(
+    "Parse multi-line mson sample header type section", "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "# Sample\n"
@@ -361,7 +489,10 @@ TEST_CASE("Parse multi-line mson sample header type section", "[mson][type_secti
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -376,7 +507,10 @@ TEST_CASE("Parse multi-line mson sample header type section", "[mson][type_secti
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse multi-line mson sample header type section with multiple nested nodes", "[mson][type_section]")
+TEST_CASE(
+    "Parse multi-line mson sample header type section with multiple nested "
+    "nodes",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "# Sample\n"
@@ -387,7 +521,10 @@ TEST_CASE("Parse multi-line mson sample header type section with multiple nested
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -402,7 +539,8 @@ TEST_CASE("Parse multi-line mson sample header type section with multiple nested
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse markdown multi-line mson sample header type section", "[mson][type_section]")
+TEST_CASE("Parse markdown multi-line mson sample header type section",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "# Sample\n"
@@ -412,7 +550,10 @@ TEST_CASE("Parse markdown multi-line mson sample header type section", "[mson][t
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::PrimitiveBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionHeaderParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -427,7 +568,9 @@ TEST_CASE("Parse markdown multi-line mson sample header type section", "[mson][t
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson items list type section for values base type containing one of", "[mson][type_section]")
+TEST_CASE(
+    "Parse mson items list type section for values base type containing one of",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Items\n"
@@ -438,7 +581,10 @@ TEST_CASE("Parse mson items list type section for values base type containing on
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.size() == 1);
@@ -451,7 +597,8 @@ TEST_CASE("Parse mson items list type section for values base type containing on
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson properties list type section for values base type", "[mson][type_section]")
+TEST_CASE("Parse mson properties list type section for values base type",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Properties\n"
@@ -461,7 +608,10 @@ TEST_CASE("Parse mson properties list type section for values base type", "[mson
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ValueBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.size() == 1);
@@ -473,7 +623,8 @@ TEST_CASE("Parse mson properties list type section for values base type", "[mson
     REQUIRE(typeSection.sourceMap.elements().collection.empty());
 }
 
-TEST_CASE("Parse mson sample type section for a simple object", "[mson][type_section]")
+TEST_CASE("Parse mson sample type section for a simple object",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n"
@@ -487,7 +638,10 @@ TEST_CASE("Parse mson sample type section for a simple object", "[mson][type_sec
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ObjectBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -496,44 +650,91 @@ TEST_CASE("Parse mson sample type section for a simple object", "[mson][type_sec
     REQUIRE(typeSection.node.content.value.empty());
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.name.literal == "user");
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.sections.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.sections[0].klass
+    REQUIRE(typeSection.node.content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(
+        typeSection.node.content.elements().at(0).content.property.name.literal
+        == "user");
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.property.sections.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.property.sections[0]
+                .klass
         == mson::TypeSection::MemberTypeClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.sections[0].content.elements().size() == 2);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.property.sections[0]
+                .content.elements()
+                .size()
+        == 2);
 
-    member = typeSection.node.content.elements().at(0).content.property.sections[0].content.elements().at(0);
+    member = typeSection.node.content.elements()
+                 .at(0)
+                 .content.property.sections[0]
+                 .content.elements()
+                 .at(0);
     REQUIRE(member.klass == mson::Element::PropertyClass);
     REQUIRE(member.content.property.name.literal == "username");
     REQUIRE(member.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(member.content.property.valueDefinition.values[0].literal == "pksunkara");
+    REQUIRE(member.content.property.valueDefinition.values[0].literal
+        == "pksunkara");
 
-    member = typeSection.node.content.elements().at(0).content.property.sections[0].content.elements().at(1);
+    member = typeSection.node.content.elements()
+                 .at(0)
+                 .content.property.sections[0]
+                 .content.elements()
+                 .at(1);
     REQUIRE(member.klass == mson::Element::PropertyClass);
     REQUIRE(member.content.property.name.literal == "admin");
     REQUIRE(member.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(member.content.property.valueDefinition.values[0].literal == "false");
+    REQUIRE(
+        member.content.property.valueDefinition.values[0].literal == "false");
 
     REQUIRE(typeSection.sourceMap.value.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.size() == 1);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].property.name.sourceMap, 15, 14);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].property.valueDefinition.sourceMap, 15, 14);
-    REQUIRE(typeSection.sourceMap.elements().collection[0].property.sections.collection.size() == 1);
-    REQUIRE(typeSection.sourceMap.elements().collection[0].property.sections.collection[0].elements().collection.size()
+    SourceMapHelper::check(
+        typeSection.sourceMap.elements().collection[0].property.name.sourceMap,
+        15,
+        14);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[0]
+                               .property.valueDefinition.sourceMap,
+        15,
+        14);
+    REQUIRE(typeSection.sourceMap.elements()
+                .collection[0]
+                .property.sections.collection.size()
+        == 1);
+    REQUIRE(typeSection.sourceMap.elements()
+                .collection[0]
+                .property.sections.collection[0]
+                .elements()
+                .collection.size()
         == 2);
 
-    memberSM = typeSection.sourceMap.elements().collection[0].property.sections.collection[0].elements().collection[0];
+    memberSM = typeSection.sourceMap.elements()
+                   .collection[0]
+                   .property.sections.collection[0]
+                   .elements()
+                   .collection[0];
     SourceMapHelper::check(memberSM.property.name.sourceMap, 39, 20);
     SourceMapHelper::check(memberSM.property.valueDefinition.sourceMap, 39, 20);
 
-    memberSM = typeSection.sourceMap.elements().collection[0].property.sections.collection[0].elements().collection[1];
+    memberSM = typeSection.sourceMap.elements()
+                   .collection[0]
+                   .property.sections.collection[0]
+                   .elements()
+                   .collection[1];
     SourceMapHelper::check(memberSM.property.name.sourceMap, 69, 12);
     SourceMapHelper::check(memberSM.property.valueDefinition.sourceMap, 69, 12);
 }
 
-TEST_CASE("Parse mson sample type section for a complex object", "[mson][type_section]")
+TEST_CASE("Parse mson sample type section for a complex object",
+    "[mson][type_section]")
 {
     mdp::ByteBuffer source
         = "- Sample\n"
@@ -550,7 +751,10 @@ TEST_CASE("Parse mson sample type section for a complex object", "[mson][type_se
     ParseResult<mson::TypeSection> typeSection;
     typeSection.node.baseType = mson::ObjectBaseType;
     SectionParserHelper<mson::TypeSection, MSONTypeSectionListParser>::parse(
-        source, MSONSampleDefaultSectionType, typeSection, ExportSourcemapOption);
+        source,
+        MSONSampleDefaultSectionType,
+        typeSection,
+        ExportSourcemapOption);
 
     REQUIRE(typeSection.report.error.code == Error::OK);
     REQUIRE(typeSection.report.warnings.empty());
@@ -559,79 +763,131 @@ TEST_CASE("Parse mson sample type section for a complex object", "[mson][type_se
     REQUIRE(typeSection.node.content.value.empty());
     REQUIRE(typeSection.node.content.description.empty());
     REQUIRE(typeSection.node.content.elements().size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).klass == mson::Element::PropertyClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.name.literal == "user");
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.sections.size() == 1);
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.sections[0].klass
+    REQUIRE(typeSection.node.content.elements().at(0).klass
+        == mson::Element::PropertyClass);
+    REQUIRE(
+        typeSection.node.content.elements().at(0).content.property.name.literal
+        == "user");
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.property.sections.size()
+        == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.property.sections[0]
+                .klass
         == mson::TypeSection::MemberTypeClass);
-    REQUIRE(typeSection.node.content.elements().at(0).content.property.sections[0].content.elements().size() == 1);
+    REQUIRE(typeSection.node.content.elements()
+                .at(0)
+                .content.property.sections[0]
+                .content.elements()
+                .size()
+        == 1);
 
-    member = typeSection.node.content.elements().at(0).content.property.sections[0].content.elements().at(0);
+    member = typeSection.node.content.elements()
+                 .at(0)
+                 .content.property.sections[0]
+                 .content.elements()
+                 .at(0);
     REQUIRE(member.klass == mson::Element::PropertyClass);
     REQUIRE(member.content.property.name.literal == "data");
     REQUIRE(member.content.property.valueDefinition.values.empty());
-    REQUIRE(member.content.property.valueDefinition.typeDefinition.baseType == mson::ValueBaseType);
+    REQUIRE(member.content.property.valueDefinition.typeDefinition.baseType
+        == mson::ValueBaseType);
     REQUIRE(member.content.property.sections.size() == 1);
-    REQUIRE(member.content.property.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(member.content.property.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(member.content.property.sections[0].content.elements().size() == 3);
 
     submember = member.content.property.sections[0].content.elements().at(0);
     REQUIRE(submember.klass == mson::Element::ValueClass);
     REQUIRE(submember.content.value.valueDefinition.values.size() == 1);
-    REQUIRE(submember.content.value.valueDefinition.values[0].literal == "pksunkara");
+    REQUIRE(submember.content.value.valueDefinition.values[0].literal
+        == "pksunkara");
     REQUIRE(submember.content.value.sections.empty());
 
     submember = member.content.property.sections[0].content.elements().at(1);
     REQUIRE(submember.klass == mson::Element::ValueClass);
     REQUIRE(submember.content.value.valueDefinition.values.size() == 1);
-    REQUIRE(submember.content.value.valueDefinition.values[0].literal == "1200");
+    REQUIRE(
+        submember.content.value.valueDefinition.values[0].literal == "1200");
     REQUIRE(submember.content.value.sections.empty());
 
     submember = member.content.property.sections[0].content.elements().at(2);
     REQUIRE(submember.klass == mson::Element::ValueClass);
     REQUIRE(submember.content.value.valueDefinition.values.empty());
-    REQUIRE(submember.content.value.valueDefinition.typeDefinition.baseType == mson::ObjectBaseType);
+    REQUIRE(submember.content.value.valueDefinition.typeDefinition.baseType
+        == mson::ObjectBaseType);
     REQUIRE(submember.content.value.sections.size() == 1);
-    REQUIRE(submember.content.value.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(submember.content.value.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(submember.content.value.sections[0].content.elements().size() == 1);
 
     member = submember.content.value.sections[0].content.elements().at(0);
     REQUIRE(member.klass == mson::Element::PropertyClass);
     REQUIRE(member.content.property.name.literal == "admin");
     REQUIRE(member.content.property.valueDefinition.values.size() == 1);
-    REQUIRE(member.content.property.valueDefinition.values[0].literal == "false");
+    REQUIRE(
+        member.content.property.valueDefinition.values[0].literal == "false");
     REQUIRE(member.content.property.sections.empty());
 
     REQUIRE(typeSection.sourceMap.value.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.description.sourceMap.empty());
     REQUIRE(typeSection.sourceMap.elements().collection.size() == 1);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].property.name.sourceMap, 15, 14);
-    SourceMapHelper::check(typeSection.sourceMap.elements().collection[0].property.valueDefinition.sourceMap, 15, 14);
-    REQUIRE(typeSection.sourceMap.elements().collection[0].property.sections.collection.size() == 1);
-    REQUIRE(typeSection.sourceMap.elements().collection[0].property.sections.collection[0].elements().collection.size()
+    SourceMapHelper::check(
+        typeSection.sourceMap.elements().collection[0].property.name.sourceMap,
+        15,
+        14);
+    SourceMapHelper::check(typeSection.sourceMap.elements()
+                               .collection[0]
+                               .property.valueDefinition.sourceMap,
+        15,
+        14);
+    REQUIRE(typeSection.sourceMap.elements()
+                .collection[0]
+                .property.sections.collection.size()
+        == 1);
+    REQUIRE(typeSection.sourceMap.elements()
+                .collection[0]
+                .property.sections.collection[0]
+                .elements()
+                .collection.size()
         == 1);
 
-    memberSM = typeSection.sourceMap.elements().collection[0].property.sections.collection[0].elements().collection[0];
+    memberSM = typeSection.sourceMap.elements()
+                   .collection[0]
+                   .property.sections.collection[0]
+                   .elements()
+                   .collection[0];
     SourceMapHelper::check(memberSM.property.name.sourceMap, 39, 13);
     SourceMapHelper::check(memberSM.property.valueDefinition.sourceMap, 39, 13);
     REQUIRE(memberSM.property.sections.collection.size() == 1);
-    REQUIRE(memberSM.property.sections.collection[0].elements().collection.size() == 3);
+    REQUIRE(
+        memberSM.property.sections.collection[0].elements().collection.size()
+        == 3);
 
-    submemberSM = memberSM.property.sections.collection[0].elements().collection[0];
+    submemberSM
+        = memberSM.property.sections.collection[0].elements().collection[0];
     SourceMapHelper::check(submemberSM.value.valueDefinition.sourceMap, 66, 10);
     REQUIRE(submemberSM.value.sections.collection.empty());
 
-    submemberSM = memberSM.property.sections.collection[0].elements().collection[1];
+    submemberSM
+        = memberSM.property.sections.collection[0].elements().collection[1];
     SourceMapHelper::check(submemberSM.value.valueDefinition.sourceMap, 90, 5);
     REQUIRE(submemberSM.value.sections.collection.empty());
 
-    submemberSM = memberSM.property.sections.collection[0].elements().collection[2];
+    submemberSM
+        = memberSM.property.sections.collection[0].elements().collection[2];
     SourceMapHelper::check(submemberSM.value.valueDefinition.sourceMap, 109, 9);
     REQUIRE(submemberSM.value.sections.collection.size() == 1);
-    REQUIRE(submemberSM.value.sections.collection[0].elements().collection.size() == 1);
+    REQUIRE(
+        submemberSM.value.sections.collection[0].elements().collection.size()
+        == 1);
 
-    memberSM = submemberSM.value.sections.collection[0].elements().collection[0];
+    memberSM
+        = submemberSM.value.sections.collection[0].elements().collection[0];
     SourceMapHelper::check(memberSM.property.name.sourceMap, 136, 12);
-    SourceMapHelper::check(memberSM.property.valueDefinition.sourceMap, 136, 12);
+    SourceMapHelper::check(
+        memberSM.property.valueDefinition.sourceMap, 136, 12);
     REQUIRE(memberSM.property.sections.collection.empty());
 }

--- a/test/test-MSONUtility.cc
+++ b/test/test-MSONUtility.cc
@@ -306,11 +306,13 @@ TEST_CASE("Parse typed type attribute", "[mson][utility]")
     REQUIRE((typeAttributes & SampleTypeAttribute) == 0);
     REQUIRE((typeAttributes & DefaultTypeAttribute) == 0);
     REQUIRE((typeAttributes & NullableTypeAttribute) == 0);
-    REQUIRE((typeAttributes & FixedTypeTypeAttribute) == FixedTypeTypeAttribute);
+    REQUIRE(
+        (typeAttributes & FixedTypeTypeAttribute) == FixedTypeTypeAttribute);
     REQUIRE(isAttributeParsed);
 }
 
-TEST_CASE("Parse required type attribute enclosed in backticks", "[mson][utility]")
+TEST_CASE(
+    "Parse required type attribute enclosed in backticks", "[mson][utility]")
 {
     std::string source = "`required`";
     TypeAttributes typeAttributes = 0;
@@ -422,7 +424,11 @@ TEST_CASE("Parse canonical type definition", "[mson][utility]")
     markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
-    parseTypeDefinition(markdownAST.children().begin(), pd, attributes, typeDefinition.report, typeDefinition.node);
+    parseTypeDefinition(markdownAST.children().begin(),
+        pd,
+        attributes,
+        typeDefinition.report,
+        typeDefinition.node);
 
     REQUIRE(typeDefinition.report.error.code == snowcrash::Error::OK);
     REQUIRE(typeDefinition.report.warnings.empty());
@@ -433,7 +439,8 @@ TEST_CASE("Parse canonical type definition", "[mson][utility]")
     REQUIRE(typeDefinition.node.attributes == RequiredTypeAttribute);
 }
 
-TEST_CASE("Parse type definition with non recognized type attribute", "[mson][utility]")
+TEST_CASE("Parse type definition with non recognized type attribute",
+    "[mson][utility]")
 {
     std::vector<std::string> attributes;
     snowcrash::ParseResult<TypeDefinition> typeDefinition;
@@ -451,19 +458,27 @@ TEST_CASE("Parse type definition with non recognized type attribute", "[mson][ut
 
     pd.namedTypeBaseTable["Person"] = mson::ObjectBaseType;
 
-    parseTypeDefinition(markdownAST.children().begin(), pd, attributes, typeDefinition.report, typeDefinition.node);
+    parseTypeDefinition(markdownAST.children().begin(),
+        pd,
+        attributes,
+        typeDefinition.report,
+        typeDefinition.node);
 
     REQUIRE(typeDefinition.report.error.code == snowcrash::Error::OK);
     REQUIRE(typeDefinition.report.warnings.size() == 1);
 
-    REQUIRE(typeDefinition.node.typeSpecification.name.base == UndefinedTypeName);
-    REQUIRE(typeDefinition.node.typeSpecification.name.symbol.literal == "Person");
-    REQUIRE(typeDefinition.node.typeSpecification.name.symbol.variable == false);
+    REQUIRE(
+        typeDefinition.node.typeSpecification.name.base == UndefinedTypeName);
+    REQUIRE(
+        typeDefinition.node.typeSpecification.name.symbol.literal == "Person");
+    REQUIRE(
+        typeDefinition.node.typeSpecification.name.symbol.variable == false);
     REQUIRE(typeDefinition.node.typeSpecification.nestedTypes.empty());
     REQUIRE(typeDefinition.node.attributes == 0);
 }
 
-TEST_CASE("Parse type definition when non-structure type has nested types", "[mson][utility]")
+TEST_CASE("Parse type definition when non-structure type has nested types",
+    "[mson][utility]")
 {
     std::vector<std::string> attributes;
     snowcrash::ParseResult<TypeDefinition> typeDefinition;
@@ -480,15 +495,23 @@ TEST_CASE("Parse type definition when non-structure type has nested types", "[ms
 
     pd.namedTypeBaseTable["Person"] = mson::ObjectBaseType;
 
-    parseTypeDefinition(markdownAST.children().begin(), pd, attributes, typeDefinition.report, typeDefinition.node);
+    parseTypeDefinition(markdownAST.children().begin(),
+        pd,
+        attributes,
+        typeDefinition.report,
+        typeDefinition.node);
 
     REQUIRE(typeDefinition.report.error.code == snowcrash::Error::OK);
     REQUIRE(typeDefinition.report.warnings.size() == 1);
-    REQUIRE(typeDefinition.report.warnings[0].code == snowcrash::LogicalErrorWarning);
+    REQUIRE(typeDefinition.report.warnings[0].code
+        == snowcrash::LogicalErrorWarning);
 
-    REQUIRE(typeDefinition.node.typeSpecification.name.base == UndefinedTypeName);
-    REQUIRE(typeDefinition.node.typeSpecification.name.symbol.literal == "Person");
-    REQUIRE(typeDefinition.node.typeSpecification.name.symbol.variable == false);
+    REQUIRE(
+        typeDefinition.node.typeSpecification.name.base == UndefinedTypeName);
+    REQUIRE(
+        typeDefinition.node.typeSpecification.name.symbol.literal == "Person");
+    REQUIRE(
+        typeDefinition.node.typeSpecification.name.symbol.variable == false);
     REQUIRE(typeDefinition.node.typeSpecification.nestedTypes.size() == 2);
     REQUIRE(typeDefinition.node.attributes == 0);
 }
@@ -586,7 +609,11 @@ TEST_CASE("Parse canonical property name", "[mson][utility]")
     markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
-    parsePropertyName(markdownAST.children().begin(), pd, id, propertyName.report, propertyName.node);
+    parsePropertyName(markdownAST.children().begin(),
+        pd,
+        id,
+        propertyName.report,
+        propertyName.node);
 
     REQUIRE(propertyName.report.error.code == snowcrash::Error::OK);
     REQUIRE(propertyName.report.warnings.empty());
@@ -608,9 +635,14 @@ TEST_CASE("Parse variable property name", "[mson][utility]")
     markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
-    parsePropertyName(markdownAST.children().begin(), pd, id, propertyName.report, propertyName.node);
+    parsePropertyName(markdownAST.children().begin(),
+        pd,
+        id,
+        propertyName.report,
+        propertyName.node);
 
-    REQUIRE(propertyName.report.error.code == snowcrash::MSONError); // Unknown named type
+    REQUIRE(propertyName.report.error.code
+        == snowcrash::MSONError); // Unknown named type
     REQUIRE(propertyName.report.warnings.empty());
 
     REQUIRE(propertyName.node.literal.empty());
@@ -618,9 +650,15 @@ TEST_CASE("Parse variable property name", "[mson][utility]")
     REQUIRE(propertyName.node.variable.values[0].literal == "rel");
     REQUIRE(propertyName.node.variable.values[0].variable == false);
     REQUIRE(propertyName.node.variable.typeDefinition.attributes == 0);
-    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name.base == UndefinedTypeName);
-    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name.symbol.literal == "Custom String");
-    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name.symbol.variable == false);
+    REQUIRE(
+        propertyName.node.variable.typeDefinition.typeSpecification.name.base
+        == UndefinedTypeName);
+    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name
+                .symbol.literal
+        == "Custom String");
+    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name
+                .symbol.variable
+        == false);
 }
 
 TEST_CASE("Parse multi-value variable property name", "[mson][utility]")
@@ -638,7 +676,11 @@ TEST_CASE("Parse multi-value variable property name", "[mson][utility]")
 
     pd.namedTypeBaseTable["Custom"] = mson::ValueBaseType;
 
-    parsePropertyName(markdownAST.children().begin(), pd, id, propertyName.report, propertyName.node);
+    parsePropertyName(markdownAST.children().begin(),
+        pd,
+        id,
+        propertyName.report,
+        propertyName.node);
 
     REQUIRE(propertyName.report.error.code == snowcrash::Error::OK);
     REQUIRE(propertyName.report.warnings.empty());
@@ -648,7 +690,13 @@ TEST_CASE("Parse multi-value variable property name", "[mson][utility]")
     REQUIRE(propertyName.node.variable.values[0].literal == "1, 2");
     REQUIRE(propertyName.node.variable.values[0].variable == false);
     REQUIRE(propertyName.node.variable.typeDefinition.attributes == 0);
-    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name.base == UndefinedTypeName);
-    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name.symbol.literal == "Custom");
-    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name.symbol.variable == false);
+    REQUIRE(
+        propertyName.node.variable.typeDefinition.typeSpecification.name.base
+        == UndefinedTypeName);
+    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name
+                .symbol.literal
+        == "Custom");
+    REQUIRE(propertyName.node.variable.typeDefinition.typeSpecification.name
+                .symbol.variable
+        == false);
 }

--- a/test/test-MSONValueMemberParser.cc
+++ b/test/test-MSONValueMemberParser.cc
@@ -26,16 +26,23 @@ TEST_CASE("Parse canonical mson value member", "[mson][value_member]")
     REQUIRE(valueMember.node.description == "A color");
     REQUIRE(valueMember.node.valueDefinition.values.size() == 1);
     REQUIRE(valueMember.node.valueDefinition.values[0].literal == "red");
-    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::StringTypeName);
-    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification.name.symbol.empty());
-    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification.nestedTypes.empty());
-    REQUIRE(valueMember.node.valueDefinition.typeDefinition.attributes == mson::RequiredTypeAttribute);
+    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::StringTypeName);
+    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.symbol.empty());
+    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification
+                .nestedTypes.empty());
+    REQUIRE(valueMember.node.valueDefinition.typeDefinition.attributes
+        == mson::RequiredTypeAttribute);
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 32);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 32);
     SourceMapHelper::check(valueMember.sourceMap.description.sourceMap, 2, 32);
 }
 
-TEST_CASE("Parse mson value member with description not on new line", "[mson][value_member]")
+TEST_CASE("Parse mson value member with description not on new line",
+    "[mson][value_member]")
 {
     mdp::ByteBuffer source
         = "- red (string, required) - A color\n"
@@ -51,17 +58,27 @@ TEST_CASE("Parse mson value member with description not on new line", "[mson][va
     REQUIRE(valueMember.node.description == "A color");
     REQUIRE(valueMember.node.valueDefinition.values.size() == 1);
     REQUIRE(valueMember.node.sections.size() == 1);
-    REQUIRE(valueMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(valueMember.node.sections[0].content.description == "Which is also very nice");
+    REQUIRE(valueMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(valueMember.node.sections[0].content.description
+        == "Which is also very nice");
     REQUIRE(valueMember.node.sections[0].content.elements().empty());
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 33, 37, 24);
-    SourceMapHelper::check(valueMember.sourceMap.description.sourceMap, 2, 33, 37, 24);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 33, 37, 24);
+    SourceMapHelper::check(
+        valueMember.sourceMap.description.sourceMap, 2, 33, 37, 24);
     REQUIRE(valueMember.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(valueMember.sourceMap.sections.collection[0].description.sourceMap, 2, 33, 37, 24);
+    SourceMapHelper::check(
+        valueMember.sourceMap.sections.collection[0].description.sourceMap,
+        2,
+        33,
+        37,
+        24);
 }
 
-TEST_CASE("Parse mson value member with block description", "[mson][value_member]")
+TEST_CASE(
+    "Parse mson value member with block description", "[mson][value_member]")
 {
     mdp::ByteBuffer source
         = "- red (string, required) - A color\n\n"
@@ -78,18 +95,28 @@ TEST_CASE("Parse mson value member with block description", "[mson][value_member
 
     REQUIRE(valueMember.node.description == "A color");
     REQUIRE(valueMember.node.valueDefinition.values.size() == 1);
-    REQUIRE(valueMember.node.valueDefinition.typeDefinition.attributes == mson::RequiredTypeAttribute);
+    REQUIRE(valueMember.node.valueDefinition.typeDefinition.attributes
+        == mson::RequiredTypeAttribute);
     REQUIRE(valueMember.node.sections.size() == 1);
-    REQUIRE(valueMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(valueMember.node.sections[0].content.description == "Which is also very nice\n\n- and awesome");
+    REQUIRE(valueMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(valueMember.node.sections[0].content.description
+        == "Which is also very nice\n\n- and awesome");
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 34);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 34);
     SourceMapHelper::check(valueMember.sourceMap.description.sourceMap, 2, 34);
     REQUIRE(valueMember.sourceMap.sections.collection.size() == 1);
-    SourceMapHelper::check(valueMember.sourceMap.sections.collection[0].description.sourceMap, 40, 24, 69, 14);
+    SourceMapHelper::check(
+        valueMember.sourceMap.sections.collection[0].description.sourceMap,
+        40,
+        24,
+        69,
+        14);
 }
 
-TEST_CASE("Parse mson value member with block description, default and sample", "[mson][value_member]")
+TEST_CASE("Parse mson value member with block description, default and sample",
+    "[mson][value_member]")
 {
     mdp::ByteBuffer source
         = "- red (string) - A color\n\n"
@@ -110,19 +137,31 @@ TEST_CASE("Parse mson value member with block description, default and sample", 
     REQUIRE(valueMember.node.valueDefinition.values.size() == 1);
     REQUIRE(valueMember.node.valueDefinition.values[0].literal == "red");
     REQUIRE(valueMember.node.sections.size() == 3);
-    REQUIRE(valueMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(valueMember.node.sections[0].content.description == "Which is also very nice\n\n- and awesome");
-    REQUIRE(valueMember.node.sections[1].klass == mson::TypeSection::DefaultClass);
+    REQUIRE(valueMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(valueMember.node.sections[0].content.description
+        == "Which is also very nice\n\n- and awesome");
+    REQUIRE(
+        valueMember.node.sections[1].klass == mson::TypeSection::DefaultClass);
     REQUIRE(valueMember.node.sections[1].content.value == "yellow");
-    REQUIRE(valueMember.node.sections[2].klass == mson::TypeSection::SampleClass);
+    REQUIRE(
+        valueMember.node.sections[2].klass == mson::TypeSection::SampleClass);
     REQUIRE(valueMember.node.sections[2].content.value == "green\n");
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 24);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 24);
     SourceMapHelper::check(valueMember.sourceMap.description.sourceMap, 2, 24);
     REQUIRE(valueMember.sourceMap.sections.collection.size() == 3);
-    SourceMapHelper::check(valueMember.sourceMap.sections.collection[0].description.sourceMap, 30, 24, 59, 14);
-    SourceMapHelper::check(valueMember.sourceMap.sections.collection[1].value.sourceMap, 80, 16);
-    SourceMapHelper::check(valueMember.sourceMap.sections.collection[2].value.sourceMap, 118, 6);
+    SourceMapHelper::check(
+        valueMember.sourceMap.sections.collection[0].description.sourceMap,
+        30,
+        24,
+        59,
+        14);
+    SourceMapHelper::check(
+        valueMember.sourceMap.sections.collection[1].value.sourceMap, 80, 16);
+    SourceMapHelper::check(
+        valueMember.sourceMap.sections.collection[2].value.sourceMap, 118, 6);
 }
 
 TEST_CASE("Parse mson value member array with sample", "[mson][value_member]")
@@ -146,19 +185,30 @@ TEST_CASE("Parse mson value member array with sample", "[mson][value_member]")
     REQUIRE(valueMember.node.description == "List of colors");
     REQUIRE(valueMember.node.valueDefinition.values.empty());
     REQUIRE(valueMember.node.sections.size() == 2);
-    REQUIRE(valueMember.node.sections[0].klass == mson::TypeSection::BlockDescriptionClass);
-    REQUIRE(valueMember.node.sections[0].content.description == "Lots and lots of them");
-    REQUIRE(valueMember.node.sections[1].klass == mson::TypeSection::SampleClass);
+    REQUIRE(valueMember.node.sections[0].klass
+        == mson::TypeSection::BlockDescriptionClass);
+    REQUIRE(valueMember.node.sections[0].content.description
+        == "Lots and lots of them");
+    REQUIRE(
+        valueMember.node.sections[1].klass == mson::TypeSection::SampleClass);
     REQUIRE(valueMember.node.sections[1].content.elements().size() == 4);
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 26);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 26);
     SourceMapHelper::check(valueMember.sourceMap.description.sourceMap, 2, 26);
     REQUIRE(valueMember.sourceMap.sections.collection.size() == 2);
-    SourceMapHelper::check(valueMember.sourceMap.sections.collection[0].description.sourceMap, 32, 22);
-    REQUIRE(valueMember.sourceMap.sections.collection[1].elements().collection.size() == 4);
+    SourceMapHelper::check(
+        valueMember.sourceMap.sections.collection[0].description.sourceMap,
+        32,
+        22);
+    REQUIRE(valueMember.sourceMap.sections.collection[1]
+                .elements()
+                .collection.size()
+        == 4);
 }
 
-TEST_CASE("Parse mson value member with multiple values", "[mson][value_member]")
+TEST_CASE(
+    "Parse mson value member with multiple values", "[mson][value_member]")
 {
     mdp::ByteBuffer source = "- 1, yellow, true";
 
@@ -176,7 +226,8 @@ TEST_CASE("Parse mson value member with multiple values", "[mson][value_member]"
     REQUIRE(valueMember.node.valueDefinition.values[1].literal == "yellow");
     REQUIRE(valueMember.node.valueDefinition.values[2].literal == "true");
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 15);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 15);
     REQUIRE(valueMember.sourceMap.description.sourceMap.empty());
     REQUIRE(valueMember.sourceMap.sections.collection.empty());
 }
@@ -197,33 +248,61 @@ TEST_CASE("Parse mson value member array with items", "[mson][value_member]")
 
     REQUIRE(valueMember.node.description.empty());
     REQUIRE(valueMember.node.valueDefinition.values.empty());
-    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
+    REQUIRE(valueMember.node.valueDefinition.typeDefinition.typeSpecification
+                .name.base
+        == mson::ArrayTypeName);
     REQUIRE(valueMember.node.sections.size() == 1);
 
     REQUIRE(valueMember.node.sections[0].content.description.empty());
-    REQUIRE(valueMember.node.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(valueMember.node.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(valueMember.node.sections[0].content.elements().size() == 2);
-    REQUIRE(valueMember.node.sections[0].content.elements().at(0).klass == mson::Element::ValueClass);
-    REQUIRE(valueMember.node.sections[0].content.elements().at(0).content.value.valueDefinition.values.size() == 1);
-    REQUIRE(valueMember.node.sections[0].content.elements().at(0).content.value.description == "A sample value");
-    REQUIRE(valueMember.node.sections[0].content.elements().at(1).klass == mson::Element::ValueClass);
-    REQUIRE(valueMember.node.sections[0].content.elements().at(1).content.value.valueDefinition.values.size() == 1);
+    REQUIRE(valueMember.node.sections[0].content.elements().at(0).klass
+        == mson::Element::ValueClass);
+    REQUIRE(valueMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.value.valueDefinition.values.size()
+        == 1);
+    REQUIRE(valueMember.node.sections[0]
+                .content.elements()
+                .at(0)
+                .content.value.description
+        == "A sample value");
+    REQUIRE(valueMember.node.sections[0].content.elements().at(1).klass
+        == mson::Element::ValueClass);
+    REQUIRE(valueMember.node.sections[0]
+                .content.elements()
+                .at(1)
+                .content.value.valueDefinition.values.size()
+        == 1);
 
-    SourceMapHelper::check(valueMember.sourceMap.valueDefinition.sourceMap, 2, 8);
+    SourceMapHelper::check(
+        valueMember.sourceMap.valueDefinition.sourceMap, 2, 8);
     REQUIRE(valueMember.sourceMap.sections.collection.size() == 1);
-    REQUIRE(valueMember.sourceMap.sections.collection[0].elements().collection.size() == 2);
+    REQUIRE(valueMember.sourceMap.sections.collection[0]
+                .elements()
+                .collection.size()
+        == 2);
 
     SourceMap<mson::ValueMember> valueMemberSM;
 
-    valueMemberSM = valueMember.sourceMap.sections.collection[0].elements().collection[0].value;
+    valueMemberSM = valueMember.sourceMap.sections.collection[0]
+                        .elements()
+                        .collection[0]
+                        .value;
     SourceMapHelper::check(valueMemberSM.valueDefinition.sourceMap, 16, 30);
     SourceMapHelper::check(valueMemberSM.description.sourceMap, 16, 30);
 
-    valueMemberSM = valueMember.sourceMap.sections.collection[0].elements().collection[1].value;
+    valueMemberSM = valueMember.sourceMap.sections.collection[0]
+                        .elements()
+                        .collection[1]
+                        .value;
     SourceMapHelper::check(valueMemberSM.valueDefinition.sourceMap, 52, 14);
 }
 
-TEST_CASE("Check warnings for object in array with defined value", "[mson][value_member]")
+TEST_CASE("Check warnings for object in array with defined value",
+    "[mson][value_member]")
 {
     mdp::ByteBuffer source
         = "- (array)\n"
@@ -239,7 +318,8 @@ TEST_CASE("Check warnings for object in array with defined value", "[mson][value
     REQUIRE(valueMember.report.warnings.size() == 2);
 }
 
-TEST_CASE("Check warnings for object with defined value", "[mson][value_member]")
+TEST_CASE(
+    "Check warnings for object with defined value", "[mson][value_member]")
 {
     mdp::ByteBuffer source
         = "- (object)\n"
@@ -260,6 +340,10 @@ TEST_CASE("Parse undisclosed item list", "[mson][value_member]")
           "    -\n";
 
     ParseResult<mson::ValueMember> valueMember;
-    REQUIRE_NOTHROW((SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(
-        source, MSONValueMemberSectionType, valueMember, ExportSourcemapOption)));
+    REQUIRE_NOTHROW(
+        (SectionParserHelper<mson::ValueMember, MSONValueMemberParser>::parse(
+            source,
+            MSONValueMemberSectionType,
+            valueMember,
+            ExportSourcemapOption)));
 }

--- a/test/test-ModelTable.cc
+++ b/test/test-ModelTable.cc
@@ -20,12 +20,14 @@ TEST_CASE("Parse object resource model", "[model_table]")
           "+ Super Model (text/plain)\n\n"
           "          {...}\n";
 
-    // Check we will get error parsing the same symbol again with the same symbol table
+    // Check we will get error parsing the same symbol again with the same
+    // symbol table
     Models models;
     ModelHelper::build("Super", models);
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ModelBodySectionType, resource, 0, models);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ModelBodySectionType, resource, 0, models);
 
     REQUIRE(resource.report.error.code != Error::OK);
 }

--- a/test/test-ParameterParser.cc
+++ b/test/test-ParameterParser.cc
@@ -27,7 +27,8 @@ TEST_CASE("Recognize parameter definition signature", "[parameter]")
     markdownParser.parse(ParameterFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
@@ -38,40 +39,49 @@ TEST_CASE("Recognize parameter with just parameter name", "[parameter]")
     markdownParser.parse("+ id", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with escaped identifier for new syntax", "[parameter]")
+TEST_CASE(
+    "Recognize parameter with escaped identifier for new syntax", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ `user-name`", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with parameter name and without any values or description", "[parameter]")
+TEST_CASE(
+    "Recognize parameter with parameter name and without any values or "
+    "description",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ id (optional, string)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with parameter type as first trait", "[parameter]")
+TEST_CASE(
+    "Recognize parameter with parameter type as first trait", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ id (string, optional)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
@@ -82,29 +92,37 @@ TEST_CASE("Recognize parameter with new syntax example value", "[parameter]")
     markdownParser.parse("+ id : ``1`0`` (number)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with only new syntax example value", "[parameter]")
+TEST_CASE(
+    "Recognize parameter with only new syntax example value", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ id: 10", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with new syntax description which has old description identifier", "[parameter]")
+TEST_CASE(
+    "Recognize parameter with new syntax description which has old description "
+    "identifier",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
-    markdownParser.parse("+ id (string) - This is nice and ... awesome", markdownAST);
+    markdownParser.parse(
+        "+ id (string) - This is nice and ... awesome", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
@@ -112,10 +130,12 @@ TEST_CASE("Recognize parameter with new syntax description", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
-    markdownParser.parse("+ id (string) - This is nice and awesome", markdownAST);
+    markdownParser.parse(
+        "+ id (string) - This is nice and awesome", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
@@ -126,40 +146,50 @@ TEST_CASE("Recognize parameter with only old syntax description", "[parameter]")
     markdownParser.parse("+ id ... The user id", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with brackets in old syntax example value", "[parameter]")
+TEST_CASE("Recognize parameter with brackets in old syntax example value",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
-    markdownParser.parse("+ id (optional, oData, `substringof('homer', id)`) ... test", markdownAST);
+    markdownParser.parse(
+        "+ id (optional, oData, `substringof('homer', id)`) ... test",
+        markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
-TEST_CASE("Recognize escaped parameter with brackets in old syntax example value", "[parameter]")
+TEST_CASE(
+    "Recognize escaped parameter with brackets in old syntax example value",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ `id` (optional, oData, `example`)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with old syntax description after attributes", "[parameter]")
+TEST_CASE("Recognize parameter with old syntax description after attributes",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ id (optional, string) ... test", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
@@ -170,7 +200,8 @@ TEST_CASE("Recognize parameter with sample value in attributes", "[parameter]")
     markdownParser.parse("+ id (string, `10`)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
@@ -181,33 +212,43 @@ TEST_CASE("Recognize parameter with enum in attributes", "[parameter]")
     markdownParser.parse("+ id (enum[string])", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with both sample value and enum in attributes", "[parameter]")
+TEST_CASE("Recognize parameter with both sample value and enum in attributes",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ id (enum[string], `10`)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with old syntax default value but have enum in attributes", "[parameter]")
+TEST_CASE(
+    "Recognize parameter with old syntax default value but have enum in "
+    "attributes",
+    "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse("+ id = 10 (enum[number])", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for default value", "[parameter][336]")
+TEST_CASE(
+    "Recognize parameter with ambiguous signature but uses MSON syntax for "
+    "default value",
+    "[parameter][336]")
 {
     mdp::ByteBuffer source
         = "+ id (optional)\n"
@@ -218,11 +259,15 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for sample value", "[parameter][336]")
+TEST_CASE(
+    "Recognize parameter with ambiguous signature but uses MSON syntax for "
+    "sample value",
+    "[parameter][336]")
 {
     mdp::ByteBuffer source
         = "+ id (optional)\n"
@@ -233,11 +278,15 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for values", "[parameter][336]")
+TEST_CASE(
+    "Recognize parameter with ambiguous signature but uses MSON syntax for "
+    "values",
+    "[parameter][336]")
 {
     mdp::ByteBuffer source
         = "+ id (optional)\n"
@@ -248,11 +297,15 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == MSONParameterSectionType);
 }
 
-TEST_CASE("Recognize parameter with ambiguous signature but uses old syntax for values", "[parameter][336]")
+TEST_CASE(
+    "Recognize parameter with ambiguous signature but uses old syntax for "
+    "values",
+    "[parameter][336]")
 {
     mdp::ByteBuffer source
         = "+ id (optional)\n"
@@ -263,15 +316,18 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses old syntax for 
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameter>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParameterSectionType);
 }
 
 TEST_CASE("Parse canonical parameter definition", "[parameter]")
 {
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(
-        ParameterFixture, ParameterSectionType, parameter, ExportSourcemapOption);
+    SectionParserHelper<Parameter, ParameterParser>::parse(ParameterFixture,
+        ParameterSectionType,
+        parameter,
+        ExportSourcemapOption);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     CHECK(parameter.report.warnings.empty());
@@ -294,9 +350,12 @@ TEST_CASE("Parse canonical parameter definition", "[parameter]")
     SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 46, 12);
     SourceMapHelper::check(parameter.sourceMap.use.sourceMap, 2, 40);
     REQUIRE(parameter.sourceMap.values.collection.size() == 3);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[0].sourceMap, 80, 9);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[1].sourceMap, 97, 9);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[2].sourceMap, 114, 9);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[0].sourceMap, 80, 9);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[1].sourceMap, 97, 9);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[2].sourceMap, 114, 9);
 }
 
 TEST_CASE("Warn when re-setting the values attribute", "[parameter]")
@@ -323,18 +382,21 @@ TEST_CASE("Warn when re-setting the values attribute", "[parameter]")
 
     SourceMapHelper::check(parameter.sourceMap.name.sourceMap, 2, 3);
     REQUIRE(parameter.sourceMap.values.collection.size() == 1);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[0].sourceMap, 56, 10);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[0].sourceMap, 56, 10);
     REQUIRE(parameter.sourceMap.use.sourceMap.empty());
 }
 
-TEST_CASE("Warn when there are no values in the values attribute", "[parameter]")
+TEST_CASE(
+    "Warn when there are no values in the values attribute", "[parameter]")
 {
     mdp::ByteBuffer source
         = "+ id\n"
           "    + Values\n";
 
     ParseResult<Parameter> parameter;
-    SectionParserHelper<Parameter, ParameterParser>::parse(source, ParameterSectionType, parameter);
+    SectionParserHelper<Parameter, ParameterParser>::parse(
+        source, ParameterSectionType, parameter);
 
     REQUIRE(parameter.report.error.code == Error::OK);
     REQUIRE(parameter.report.warnings.size() == 1);
@@ -346,7 +408,8 @@ TEST_CASE("Warn when there are no values in the values attribute", "[parameter]"
 
 TEST_CASE("Parse full abbreviated syntax", "[parameter]")
 {
-    mdp::ByteBuffer source = "+ limit = `20` (optional, number, `42`) ... This is a limit\n";
+    mdp::ByteBuffer source
+        = "+ limit = `20` (optional, number, `42`) ... This is a limit\n";
 
     ParseResult<Parameter> parameter;
     SectionParserHelper<Parameter, ParameterParser>::parse(
@@ -372,9 +435,11 @@ TEST_CASE("Parse full abbreviated syntax", "[parameter]")
     REQUIRE(parameter.sourceMap.values.collection.empty());
 }
 
-TEST_CASE("Warn on error in abbreviated syntax attribute bracket", "[parameter]")
+TEST_CASE(
+    "Warn on error in abbreviated syntax attribute bracket", "[parameter]")
 {
-    mdp::ByteBuffer source = "+ limit (string1, string2, string3) ... This is a limit\n";
+    mdp::ByteBuffer source
+        = "+ limit (string1, string2, string3) ... This is a limit\n";
 
     ParseResult<Parameter> parameter;
     SectionParserHelper<Parameter, ParameterParser>::parse(
@@ -426,7 +491,8 @@ TEST_CASE("Warn about required vs default clash", "[parameter]")
     REQUIRE(parameter.sourceMap.values.collection.empty());
 }
 
-TEST_CASE("Warn about implicit required vs default clash", "[parameter_definition][source]")
+TEST_CASE("Warn about implicit required vs default clash",
+    "[parameter_definition][source]")
 {
     mdp::ByteBuffer source = "+ id = `42`\n";
 
@@ -474,7 +540,8 @@ TEST_CASE("Unrecognized 'values' keyword", "[parameter]")
     REQUIRE(parameter.sourceMap.type.sourceMap.empty());
     REQUIRE(parameter.sourceMap.defaultValue.sourceMap.empty());
     REQUIRE(parameter.sourceMap.exampleValue.sourceMap.empty());
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 12, 10, 26, 14);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 12, 10, 26, 14);
     REQUIRE(parameter.sourceMap.use.sourceMap.empty());
     REQUIRE(parameter.sourceMap.values.collection.empty());
 }
@@ -499,7 +566,8 @@ TEST_CASE("Warn missing example item in values", "[parameter]")
     REQUIRE(parameter.node.defaultValue == "Value2");
 
     REQUIRE(parameter.sourceMap.values.collection.size() == 1);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[0].sourceMap, 66, 11);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[0].sourceMap, 66, 11);
 }
 
 TEST_CASE("Warn missing default value in values", "[parameter]")
@@ -522,7 +590,8 @@ TEST_CASE("Warn missing default value in values", "[parameter]")
     REQUIRE(parameter.node.defaultValue == "Value1");
 
     REQUIRE(parameter.sourceMap.values.collection.size() == 1);
-    SourceMapHelper::check(parameter.sourceMap.values.collection[0].sourceMap, 66, 11);
+    SourceMapHelper::check(
+        parameter.sourceMap.values.collection[0].sourceMap, 66, 11);
 }
 
 TEST_CASE("Parse parameters with dot in its name", "[parameter]")
@@ -587,18 +656,21 @@ TEST_CASE("Parameter with additional description", "[parameter]")
 
     REQUIRE(parameter.node.name == "id");
     REQUIRE(parameter.node.type == "string");
-    REQUIRE(parameter.node.description == "lorem (ipsum)\n\nAdditional description");
+    REQUIRE(parameter.node.description
+        == "lorem (ipsum)\n\nAdditional description");
 
     SourceMapHelper::check(parameter.sourceMap.name.sourceMap, 2, 31);
     SourceMapHelper::check(parameter.sourceMap.type.sourceMap, 2, 31);
     REQUIRE(parameter.sourceMap.defaultValue.sourceMap.empty());
     REQUIRE(parameter.sourceMap.exampleValue.sourceMap.empty());
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 2, 31, 35, 22);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 2, 31, 35, 22);
     REQUIRE(parameter.sourceMap.use.sourceMap.empty());
     REQUIRE(parameter.sourceMap.values.collection.empty());
 }
 
-TEST_CASE("Parameter with additional description as continuation of signature", "[parameter]")
+TEST_CASE("Parameter with additional description as continuation of signature",
+    "[parameter]")
 {
     mdp::ByteBuffer source
         = "+ id (string) ... lorem (ipsum)\n"
@@ -613,13 +685,15 @@ TEST_CASE("Parameter with additional description as continuation of signature", 
 
     REQUIRE(parameter.node.name == "id");
     REQUIRE(parameter.node.type == "string");
-    REQUIRE(parameter.node.description == "lorem (ipsum)\nAdditional description");
+    REQUIRE(
+        parameter.node.description == "lorem (ipsum)\nAdditional description");
 
     SourceMapHelper::check(parameter.sourceMap.name.sourceMap, 2, 30, 34, 23);
     SourceMapHelper::check(parameter.sourceMap.type.sourceMap, 2, 30, 34, 23);
     REQUIRE(parameter.sourceMap.defaultValue.sourceMap.empty());
     REQUIRE(parameter.sourceMap.exampleValue.sourceMap.empty());
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 2, 30, 34, 23);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 2, 30, 34, 23);
     REQUIRE(parameter.sourceMap.use.sourceMap.empty());
     REQUIRE(parameter.sourceMap.values.collection.empty());
 }
@@ -647,8 +721,11 @@ TEST_CASE("Parameter with list in description", "[parameter]")
     SourceMapHelper::check(parameter.sourceMap.name.sourceMap, 2, 40, 44, 15);
     REQUIRE(parameter.sourceMap.description.sourceMap.size() == 4);
     SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 2, 40, 1);
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 44, 15, 2);
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 62, 14, 3);
-    SourceMapHelper::check(parameter.sourceMap.description.sourceMap, 78, 21, 4);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 44, 15, 2);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 62, 14, 3);
+    SourceMapHelper::check(
+        parameter.sourceMap.description.sourceMap, 78, 21, 4);
     REQUIRE(parameter.sourceMap.values.collection.empty());
 }

--- a/test/test-ParametersParser.cc
+++ b/test/test-ParametersParser.cc
@@ -30,15 +30,18 @@ TEST_CASE("Recognize Parameters section block", "[parameters]")
     markdownParser.parse(ParametersFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Parameters>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Parameters>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ParametersSectionType);
 }
 
 TEST_CASE("Parse canonical parameters", "[parameters]")
 {
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(
-        ParametersFixture, ParametersSectionType, parameters, ExportSourcemapOption);
+    SectionParserHelper<Parameters, ParametersParser>::parse(ParametersFixture,
+        ParametersSectionType,
+        parameters,
+        ExportSourcemapOption);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());
@@ -50,8 +53,10 @@ TEST_CASE("Parse canonical parameters", "[parameters]")
     REQUIRE(parameters.node[1].description.empty());
 
     REQUIRE(parameters.sourceMap.collection.size() == 2);
-    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 19, 40);
-    SourceMapHelper::check(parameters.sourceMap.collection[1].name.sourceMap, 165, 5);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[0].name.sourceMap, 19, 40);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[1].name.sourceMap, 165, 5);
 }
 
 TEST_CASE("Parse ilegal parameter", "[parameters]")
@@ -61,7 +66,8 @@ TEST_CASE("Parse ilegal parameter", "[parameters]")
           "    + i;legal\n\n";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(
+        source, ParametersSectionType, parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.size() == 2);
@@ -95,9 +101,11 @@ TEST_CASE("Parse illegal parameter among legal ones", "[parameters]")
     REQUIRE(parameters.node[1].description.empty());
 
     REQUIRE(parameters.sourceMap.collection.size() == 2);
-    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 19, 5);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[0].name.sourceMap, 19, 5);
     REQUIRE(parameters.sourceMap.collection[0].description.sourceMap.empty());
-    SourceMapHelper::check(parameters.sourceMap.collection[1].name.sourceMap, 44, 5);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[1].name.sourceMap, 44, 5);
     REQUIRE(parameters.sourceMap.collection[1].description.sourceMap.empty());
 }
 
@@ -121,11 +129,13 @@ TEST_CASE("Warn about additional content in parameters section", "[parameters]")
     REQUIRE(parameters.node[0].description.empty());
 
     REQUIRE(parameters.sourceMap.collection.size() == 1);
-    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 30, 3);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[0].name.sourceMap, 30, 3);
     REQUIRE(parameters.sourceMap.collection[0].description.sourceMap.empty());
 }
 
-TEST_CASE("Warn about additional content block in parameters section", "[parameters]")
+TEST_CASE(
+    "Warn about additional content block in parameters section", "[parameters]")
 {
     mdp::ByteBuffer source
         = "+ Parameters\n\n"
@@ -145,7 +155,8 @@ TEST_CASE("Warn about additional content block in parameters section", "[paramet
     REQUIRE(parameters.node[0].description.empty());
 
     REQUIRE(parameters.sourceMap.collection.size() == 1);
-    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 31, 3);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[0].name.sourceMap, 31, 3);
     REQUIRE(parameters.sourceMap.collection[0].description.sourceMap.empty());
 }
 
@@ -170,18 +181,21 @@ TEST_CASE("Warn about multiple parameters with the same name", "[parameters]")
     REQUIRE(parameters.node[0].exampleValue == "43");
 
     REQUIRE(parameters.sourceMap.collection.size() == 1);
-    SourceMapHelper::check(parameters.sourceMap.collection[0].name.sourceMap, 35, 10);
+    SourceMapHelper::check(
+        parameters.sourceMap.collection[0].name.sourceMap, 35, 10);
 }
 
 TEST_CASE(
-    "Recognize parameter when there is no description on its signature and remaining description is not a new node",
+    "Recognize parameter when there is no description on its signature and "
+    "remaining description is not a new node",
     "[parameters]")
 {
     mdp::ByteBuffer source
         = "+ Parameters\n\n"
           "    + id (number) ... The ID number of the car\n"
           "    + state (string)\n"
-          "        The desired state of the panoramic roof. The approximate percent open values for each state are "
+          "        The desired state of the panoramic roof. The approximate "
+          "percent open values for each state are "
           "`open` = 100%, `close` = 0%, `comfort` = 80%, and `vent` = ~15%\n"
           "        + Values\n"
           "            + `open`\n"
@@ -230,7 +244,8 @@ TEST_CASE("Parentheses in parameter example ", "[parameters][issue][109]")
           "\n";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(
+        source, ParametersSectionType, parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());
@@ -242,7 +257,8 @@ TEST_CASE("Parentheses in parameter example ", "[parameters][issue][109]")
     REQUIRE(parameters.node[0].description == "test");
 }
 
-TEST_CASE("Parse parameters when it has parameter of both old and new syntax", "[parameter]")
+TEST_CASE("Parse parameters when it has parameter of both old and new syntax",
+    "[parameter]")
 {
     mdp::ByteBuffer source
         = "+ Parameters\n"
@@ -250,7 +266,8 @@ TEST_CASE("Parse parameters when it has parameter of both old and new syntax", "
           "    + percent_off: 25 (required, number)";
 
     ParseResult<Parameters> parameters;
-    SectionParserHelper<Parameters, ParametersParser>::parse(source, ParametersSectionType, parameters);
+    SectionParserHelper<Parameters, ParametersParser>::parse(
+        source, ParametersSectionType, parameters);
 
     REQUIRE(parameters.report.error.code == Error::OK);
     REQUIRE(parameters.report.warnings.empty());
@@ -264,7 +281,8 @@ TEST_CASE("Parse parameters when it has parameter of both old and new syntax", "
     REQUIRE(parameters.node[1].exampleValue == "25");
 }
 
-TEST_CASE("Percentage encoded characters in parameter name ", "[parameters][percentageencoding][issue][107]")
+TEST_CASE("Percentage encoded characters in parameter name ",
+    "[parameters][percentageencoding][issue][107]")
 {
     // Blueprint in question:
     // R"(
@@ -277,7 +295,8 @@ TEST_CASE("Percentage encoded characters in parameter name ", "[parameters][perc
     mdp::ByteBuffer source
         = "# GET /{id%5b%5d}\n"
           "+ Parameters\n"
-          "  + id%5b%5d (optional, oData, `substringof('homer', id)`) ... test\n"
+          "  + id%5b%5d (optional, oData, `substringof('homer', id)`) ... "
+          "test\n"
           "\n"
           "+ response 204\n";
 
@@ -288,22 +307,31 @@ TEST_CASE("Percentage encoded characters in parameter name ", "[parameters][perc
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].parameters.size() == 1);
     REQUIRE(resource.actions[0].parameters[0].name == "id%5b%5d");
     REQUIRE(resource.actions[0].parameters[0].type == "oData");
-    REQUIRE(resource.actions[0].parameters[0].exampleValue == "substringof('homer', id)");
+    REQUIRE(resource.actions[0].parameters[0].exampleValue
+        == "substringof('homer', id)");
     REQUIRE(resource.actions[0].parameters[0].description == "test");
 }
 
-TEST_CASE(
-    "Invalid percentage encoded characters in parameter name ", "[invalid][parameters][percentageencoding][issue][107]")
+TEST_CASE("Invalid percentage encoded characters in parameter name ",
+    "[invalid][parameters][percentageencoding][issue][107]")
 {
     // Blueprint in question:
     // R"(
@@ -352,7 +380,9 @@ TEST_CASE("Incomplete percentage encoded characters in parameter name ",
     REQUIRE(blueprint.report.warnings.size() == 3);
 }
 
-TEST_CASE("Parse old style parameter in parameters with non-complete default value", "[parameter]")
+TEST_CASE(
+    "Parse old style parameter in parameters with non-complete default value",
+    "[parameter]")
 {
     mdp::ByteBuffer source
         = "+ Parameters\n"
@@ -370,7 +400,9 @@ TEST_CASE("Parse old style parameter in parameters with non-complete default val
     REQUIRE(parameters.node[0].defaultValue == "`10");
 }
 
-TEST_CASE("Parse old style parameter in parameters with non-complete example value", "[parameter]")
+TEST_CASE(
+    "Parse old style parameter in parameters with non-complete example value",
+    "[parameter]")
 {
     mdp::ByteBuffer source
         = "+ Parameters\n"

--- a/test/test-PayloadParser.cc
+++ b/test/test-PayloadParser.cc
@@ -45,7 +45,8 @@ TEST_CASE("recognize request signature", "[payload]")
     markdownParser.parse(RequestFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Payload>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RequestSectionType);
 }
 
@@ -56,7 +57,8 @@ TEST_CASE("recognize abbreviated request signature", "[payload]")
     markdownParser.parse(RequestBodyFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Payload>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RequestBodySectionType);
 }
 
@@ -67,18 +69,21 @@ TEST_CASE("recognize abbreviated response signature", "[payload]")
     markdownParser.parse(ResponseBodyFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Payload>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ResponseBodySectionType);
 }
 
-TEST_CASE("recognize empty body response signature as non-abbreviated", "[payload]")
+TEST_CASE(
+    "recognize empty body response signature as non-abbreviated", "[payload]")
 {
     mdp::MarkdownParser markdownParser;
     mdp::MarkdownNode markdownAST;
     markdownParser.parse(EmptyBodyFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
+    SectionType sectionType = SectionProcessor<Payload>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ResponseSectionType);
 }
 
@@ -106,8 +111,10 @@ TEST_CASE("Parse request payload", "[payload]")
     SourceMapHelper::check(payload.sourceMap.description.sourceMap, 38, 12);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.size() == 2);
-    SourceMapHelper::check(payload.sourceMap.headers.collection[0].sourceMap, 2, 34);
-    SourceMapHelper::check(payload.sourceMap.headers.collection[1].sourceMap, 78, 12);
+    SourceMapHelper::check(
+        payload.sourceMap.headers.collection[0].sourceMap, 2, 34);
+    SourceMapHelper::check(
+        payload.sourceMap.headers.collection[1].sourceMap, 78, 12);
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 112, 9);
     SourceMapHelper::check(payload.sourceMap.schema.sourceMap, 144, 11);
 }
@@ -115,8 +122,10 @@ TEST_CASE("Parse request payload", "[payload]")
 TEST_CASE("Parse abbreviated payload body", "[payload]")
 {
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(
-        ResponseBodyFixture, ResponseBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(ResponseBodyFixture,
+        ResponseBodySectionType,
+        payload,
+        ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -132,7 +141,8 @@ TEST_CASE("Parse abbreviated payload body", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.size() == 1);
-    SourceMapHelper::check(payload.sourceMap.headers.collection[0].sourceMap, 2, 27);
+    SourceMapHelper::check(
+        payload.sourceMap.headers.collection[0].sourceMap, 2, 27);
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 33, 17);
 }
 
@@ -142,7 +152,8 @@ TEST_CASE("Parse abbreviated inline payload body", "[payload]")
     source += "  B\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.size() == 1); // preformatted code block
@@ -181,7 +192,8 @@ TEST_CASE("Parse payload description with list", "[payload]")
           "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.empty());
@@ -220,7 +232,8 @@ TEST_CASE("Parse payload with foreign list item", "[payload]")
           "    + Bar\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     CHECK(payload.report.warnings.size() == 1); // dangling block
@@ -257,7 +270,8 @@ TEST_CASE("Parse payload with dangling body", "[payload]")
     source += "    Bar\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1); // dangling block
@@ -283,8 +297,11 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     ModelHelper::build("Symbol", models);
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(
-        ModelFixture, RequestBodySectionType, payload, ExportSourcemapOption, models);
+    SectionParserHelper<Payload, PayloadParser>::parse(ModelFixture,
+        RequestBodySectionType,
+        payload,
+        ExportSourcemapOption,
+        models);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 0);
@@ -303,7 +320,8 @@ TEST_CASE("Parse inline payload with symbol reference", "[payload]")
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 0, 1);
 }
 
-TEST_CASE("Parse inline payload with symbol reference with extra indentation", "[payload]")
+TEST_CASE("Parse inline payload with symbol reference with extra indentation",
+    "[payload]")
 {
     mdp::ByteBuffer source
         = "+ Request\n\n"
@@ -334,7 +352,8 @@ TEST_CASE("Parse inline payload with symbol reference with extra indentation", "
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 15, 15);
 }
 
-TEST_CASE("Parse inline payload with symbol reference with foreign content", "[payload]")
+TEST_CASE("Parse inline payload with symbol reference with foreign content",
+    "[payload]")
 {
     mdp::ByteBuffer source = ModelFixture;
     source += "\n    Foreign\n";
@@ -376,7 +395,8 @@ TEST_CASE("Parse named model", "[payload]")
     source += "        Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, ModelBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -394,7 +414,8 @@ TEST_CASE("Parse named model", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.size() == 1);
-    SourceMapHelper::check(payload.sourceMap.headers.collection[0].sourceMap, 2, 26);
+    SourceMapHelper::check(
+        payload.sourceMap.headers.collection[0].sourceMap, 2, 26);
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 32, 17);
 }
 
@@ -411,7 +432,8 @@ TEST_CASE("Parse nameless model", "[payload]")
     source += "        Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ModelBodySectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, ModelBodySectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -429,7 +451,8 @@ TEST_CASE("Parse nameless model", "[payload]")
     REQUIRE(payload.sourceMap.description.sourceMap.empty());
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     REQUIRE(payload.sourceMap.headers.collection.size() == 1);
-    SourceMapHelper::check(payload.sourceMap.headers.collection[0].sourceMap, 2, 20);
+    SourceMapHelper::check(
+        payload.sourceMap.headers.collection[0].sourceMap, 2, 20);
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 26, 17);
     REQUIRE(payload.sourceMap.schema.sourceMap.empty());
 }
@@ -455,7 +478,8 @@ TEST_CASE("Warn on malformed payload signature", "[payload]")
     source += "            Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -485,14 +509,17 @@ TEST_CASE("Warn on malformed request payload signature", "[payload]")
     source += "            Hello World!\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
     REQUIRE(payload.report.warnings[0].code == FormattingWarning);
 }
 
-TEST_CASE("Give a warning of empty message body for requests with certain headers", "[payload]")
+TEST_CASE(
+    "Give a warning of empty message body for requests with certain headers",
+    "[payload]")
 {
     mdp::ByteBuffer source
         = "+ Request\n"
@@ -501,7 +528,8 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
           "            Content-Length: 100\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -515,7 +543,10 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     REQUIRE(payload.sourceMap.body.sourceMap.empty());
 }
 
-TEST_CASE("Give a warning of empty message body for requests with certain headers and has parameters", "[payload]")
+TEST_CASE(
+    "Give a warning of empty message body for requests with certain headers "
+    "and has parameters",
+    "[payload]")
 {
     mdp::ByteBuffer source
         = "+ Request\n"
@@ -527,7 +558,8 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
           "            Content-Length: 100\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -545,7 +577,8 @@ TEST_CASE("Give a warning of empty message body for requests with certain header
     REQUIRE(payload.sourceMap.body.sourceMap.empty());
 }
 
-TEST_CASE("Do not report empty message body for requests with only headers", "[payload]")
+TEST_CASE("Do not report empty message body for requests with only headers",
+    "[payload]")
 {
     mdp::ByteBuffer source
         = "+ Request\n"
@@ -554,21 +587,24 @@ TEST_CASE("Do not report empty message body for requests with only headers", "[p
           "            Accept: application/json, application/javascript\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
 
     REQUIRE(payload.node.headers.size() == 1);
     REQUIRE(payload.node.headers[0].first == "Accept");
-    REQUIRE(payload.node.headers[0].second == "application/json, application/javascript");
+    REQUIRE(payload.node.headers[0].second
+        == "application/json, application/javascript");
     REQUIRE(payload.node.body.empty());
     REQUIRE(payload.node.schema.empty());
     REQUIRE(payload.node.attributes.empty());
     REQUIRE(payload.node.parameters.empty());
 }
 
-TEST_CASE("Do not report empty message body for requests with only parameters", "[payload]")
+TEST_CASE("Do not report empty message body for requests with only parameters",
+    "[payload]")
 {
     mdp::ByteBuffer source
         = "+ Request\n"
@@ -576,7 +612,8 @@ TEST_CASE("Do not report empty message body for requests with only parameters", 
           "        + limit: 1\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -596,7 +633,8 @@ TEST_CASE("Give a warning when 100 response has a body", "[payload]")
           "        {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseBodySectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, ResponseBodySectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -605,7 +643,8 @@ TEST_CASE("Give a warning when 100 response has a body", "[payload]")
     REQUIRE(payload.node.body == "{}\n");
 }
 
-TEST_CASE("Empty body section should shouldn't be parsed as description", "[payload]")
+TEST_CASE(
+    "Empty body section should shouldn't be parsed as description", "[payload]")
 {
     ParseResult<Payload> payload;
     SectionParserHelper<Payload, PayloadParser>::parse(
@@ -629,7 +668,8 @@ TEST_CASE("Parse request parameters", "[payload]")
           "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -659,7 +699,8 @@ TEST_CASE("Values section should be taken as a description node", "[payload]")
           "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, ResponseSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -667,12 +708,14 @@ TEST_CASE("Values section should be taken as a description node", "[payload]")
     REQUIRE(payload.node.description == "+ Values\n\n    + id");
     REQUIRE(payload.node.body == "{}\n");
 
-    SourceMapHelper::check(payload.sourceMap.description.sourceMap, 20, 10, 34, 9);
+    SourceMapHelper::check(
+        payload.sourceMap.description.sourceMap, 20, 10, 34, 9);
     REQUIRE(payload.sourceMap.parameters.collection.empty());
     SourceMapHelper::check(payload.sourceMap.body.sourceMap, 64, 7);
 }
 
-TEST_CASE("Parameters section in response section should give a warning", "[payload]")
+TEST_CASE(
+    "Parameters section in response section should give a warning", "[payload]")
 {
     mdp::ByteBuffer source
         = "+ Response 200\n\n"
@@ -682,7 +725,8 @@ TEST_CASE("Parameters section in response section should give a warning", "[payl
           "            {}\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload, ExportSourcemapOption);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, ResponseSectionType, payload, ExportSourcemapOption);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -709,7 +753,8 @@ TEST_CASE("Report ignoring nested request objects", "[payload][163][189]")
           "            Hello World\n";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.size() == 1);
@@ -727,11 +772,14 @@ TEST_CASE("Parse a payload with attributes", "[payload]")
           "        + id: 250FF (string)\n"
           "        + created: 1415203908 (number) - Time stamp\n"
           "        + percent_off: 25 (number)\n\n"
-          "          A positive integer between 1 and 100 that represents the discount the coupon will apply.\n\n"
-          "        + redeem_by (number) - Date after which the coupon can no longer be redeemed";
+          "          A positive integer between 1 and 100 that represents the "
+          "discount the coupon will apply.\n\n"
+          "        + redeem_by (number) - Date after which the coupon can no "
+          "longer be redeemed";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, ResponseSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, ResponseSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -742,9 +790,11 @@ TEST_CASE("Parse a payload with attributes", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.attributes.name.empty());
     REQUIRE(payload.node.attributes.typeDefinition.attributes == 0);
-    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.name.base == mson::ObjectTypeName);
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.name.base
+        == mson::ObjectTypeName);
     REQUIRE(payload.node.attributes.sections.size() == 1);
-    REQUIRE(payload.node.attributes.sections[0].klass == mson::TypeSection::MemberTypeClass);
+    REQUIRE(payload.node.attributes.sections[0].klass
+        == mson::TypeSection::MemberTypeClass);
     REQUIRE(payload.node.attributes.sections[0].content.elements().size() == 4);
 }
 
@@ -757,7 +807,8 @@ TEST_CASE("Parse a request with attributes and no body", "[payload]")
           "    + Attributes (array[Coupon])";
 
     ParseResult<Payload> payload;
-    SectionParserHelper<Payload, PayloadParser>::parse(source, RequestSectionType, payload);
+    SectionParserHelper<Payload, PayloadParser>::parse(
+        source, RequestSectionType, payload);
 
     REQUIRE(payload.report.error.code == Error::OK);
     REQUIRE(payload.report.warnings.empty());
@@ -768,9 +819,15 @@ TEST_CASE("Parse a request with attributes and no body", "[payload]")
     REQUIRE(payload.node.description.empty());
     REQUIRE(payload.node.attributes.name.empty());
     REQUIRE(payload.node.attributes.typeDefinition.attributes == 0);
-    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.name.base
+        == mson::ArrayTypeName);
+    REQUIRE(payload.node.attributes.typeDefinition.typeSpecification.nestedTypes
+                .size()
+        == 1);
+    REQUIRE(
+        payload.node.attributes.typeDefinition.typeSpecification.nestedTypes[0]
+            .symbol.literal
+        == "Coupon");
     REQUIRE(payload.node.attributes.sections.empty());
 }
 

--- a/test/test-RegexMatch.cc
+++ b/test/test-RegexMatch.cc
@@ -13,25 +13,35 @@ using namespace snowcrash;
 
 TEST_CASE("regexmatch/simple", "Simple regex test")
 {
-    REQUIRE(RegexMatch("The quick brown fox jumps over the lazy dog", "fox[[:space:]]") == true);
-    REQUIRE(RegexMatch("The quick brown fox jumps over the lazy dog", "box") == false);
+    REQUIRE(RegexMatch(
+                "The quick brown fox jumps over the lazy dog", "fox[[:space:]]")
+        == true);
+    REQUIRE(RegexMatch("The quick brown fox jumps over the lazy dog", "box")
+        == false);
 }
 
 TEST_CASE("regexmatch/complex", "Complex regex test")
 {
-    REQUIRE(RegexMatch("The quick brown  fox jumps over the lazy dog", "[[:space:]]{2}fox[[:space:]]jumps+") == true);
-    REQUIRE(RegexMatch("The quick brown  fox jumps over the lazy dog", "^The") == true);
-    REQUIRE(RegexMatch("The quick brown fox jumps over the lazy dog", "[[:space:]]{2}fox[[:space:]]sjumps+") == false);
+    REQUIRE(RegexMatch("The quick brown  fox jumps over the lazy dog",
+                "[[:space:]]{2}fox[[:space:]]jumps+")
+        == true);
+    REQUIRE(RegexMatch("The quick brown  fox jumps over the lazy dog", "^The")
+        == true);
+    REQUIRE(RegexMatch("The quick brown fox jumps over the lazy dog",
+                "[[:space:]]{2}fox[[:space:]]sjumps+")
+        == false);
 }
 
 TEST_CASE("regexmatch/resource-header", "Match resource test")
 {
-    REQUIRE(RegexMatch("HEAD /resource/{id}", "^((GET|HEAD)[[:space:]]+)?/.*$") == true);
+    REQUIRE(RegexMatch("HEAD /resource/{id}", "^((GET|HEAD)[[:space:]]+)?/.*$")
+        == true);
 }
 
 TEST_CASE("regexmatch/request-payload", "Match request payload test")
 {
     REQUIRE(RegexMatch("Request My Id (application/json)",
-                "^[Rr]equest([[:space:]]+([A-Za-z0-9_]|[[:space:]])*)?([[:space:]]\\([^\\)]*\\))?$")
+                "^[Rr]equest([[:space:]]+([A-Za-z0-9_]|[[:space:]])*)?([[:"
+                "space:]]\\([^\\)]*\\))?$")
         == true);
 }

--- a/test/test-RelationParser.cc
+++ b/test/test-RelationParser.cc
@@ -22,7 +22,8 @@ TEST_CASE("Recognize relation signature", "[relation]")
     markdownParser.parse(RelationFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Relation>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RelationSectionType);
 }
 
@@ -36,7 +37,8 @@ TEST_CASE("Relation signature without colon", "[relation]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Relation>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType != RelationSectionType);
 }
 
@@ -63,11 +65,13 @@ TEST_CASE("Relation identifier starting with non lower alphabet", "[relation]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Relation>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(
+        source, RelationSectionType, relation, ExportSourcemapOption);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.size() == 1);
@@ -85,11 +89,13 @@ TEST_CASE("Relation identifier containing capital letters", "[relation]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Relation>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(
+        source, RelationSectionType, relation, ExportSourcemapOption);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.size() == 1);
@@ -107,11 +113,13 @@ TEST_CASE("Relation identifier containing special characters", "[relation]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Relation>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(
+        source, RelationSectionType, relation, ExportSourcemapOption);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.size() == 1);
@@ -129,11 +137,13 @@ TEST_CASE("Relation identifier consisting of dots and dashes", "[relation]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Relation>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == RelationSectionType);
 
     ParseResult<Relation> relation;
-    SectionParserHelper<Relation, RelationParser>::parse(source, RelationSectionType, relation, ExportSourcemapOption);
+    SectionParserHelper<Relation, RelationParser>::parse(
+        source, RelationSectionType, relation, ExportSourcemapOption);
 
     REQUIRE(relation.report.error.code == Error::OK);
     REQUIRE(relation.report.warnings.empty());

--- a/test/test-ResourceGroupParser.cc
+++ b/test/test-ResourceGroupParser.cc
@@ -38,9 +38,11 @@ TEST_CASE("Resource group block classifier", "[resource_group]")
     markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<ResourceGroup>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<ResourceGroup>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ResourceGroupSectionType);
-    sectionType = SectionProcessor<ResourceGroup>::sectionType(markdownAST.children().begin() + 8);
+    sectionType = SectionProcessor<ResourceGroup>::sectionType(
+        markdownAST.children().begin() + 8);
     REQUIRE(sectionType == ResourceGroupSectionType);
 }
 
@@ -48,7 +50,10 @@ TEST_CASE("Parse canonical resource group", "[resource_group]")
 {
     ParseResult<ResourceGroup> resourceGroup;
     SectionParserHelper<ResourceGroup, ResourceGroupParser>::parse(
-        ResourceGroupFixture, ResourceGroupSectionType, resourceGroup, ExportSourcemapOption);
+        ResourceGroupFixture,
+        ResourceGroupSectionType,
+        resourceGroup,
+        ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
     REQUIRE(resourceGroup.report.warnings.empty());
@@ -57,17 +62,31 @@ TEST_CASE("Parse canonical resource group", "[resource_group]")
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
 
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(resourceGroup.node.content.elements().at(0).content.copy == "Fiber Optics");
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).content.copy
+        == "Fiber Optics");
 
-    REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
-    REQUIRE(resourceGroup.node.content.elements().at(1).content.resource.uriTemplate == "/resource/{id}");
-    REQUIRE(resourceGroup.node.content.elements().at(1).content.resource.name == "My Resource");
+    REQUIRE(resourceGroup.node.content.elements().at(1).element
+        == Element::ResourceElement);
+    REQUIRE(
+        resourceGroup.node.content.elements().at(1).content.resource.uriTemplate
+        == "/resource/{id}");
+    REQUIRE(resourceGroup.node.content.elements().at(1).content.resource.name
+        == "My Resource");
 
-    SourceMapHelper::check(resourceGroup.sourceMap.attributes.name.sourceMap, 0, 15);
-    SourceMapHelper::check(resourceGroup.sourceMap.content.elements().collection[0].content.copy.sourceMap, 15, 14);
     SourceMapHelper::check(
-        resourceGroup.sourceMap.content.elements().collection[1].content.resource.name.sourceMap, 29, 32);
+        resourceGroup.sourceMap.attributes.name.sourceMap, 0, 15);
+    SourceMapHelper::check(resourceGroup.sourceMap.content.elements()
+                               .collection[0]
+                               .content.copy.sourceMap,
+        15,
+        14);
+    SourceMapHelper::check(resourceGroup.sourceMap.content.elements()
+                               .collection[1]
+                               .content.resource.name.sourceMap,
+        29,
+        32);
 }
 
 TEST_CASE("Parse resource group with empty resource", "[resource_group]")
@@ -88,16 +107,28 @@ TEST_CASE("Parse resource group with empty resource", "[resource_group]")
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
 
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::CopyElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::CopyElement);
     REQUIRE(resourceGroup.node.content.elements().at(0).content.copy == "p1");
 
-    REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
-    REQUIRE(resourceGroup.node.content.elements().at(1).content.resource.uriTemplate == "/resource");
+    REQUIRE(resourceGroup.node.content.elements().at(1).element
+        == Element::ResourceElement);
+    REQUIRE(
+        resourceGroup.node.content.elements().at(1).content.resource.uriTemplate
+        == "/resource");
 
-    SourceMapHelper::check(resourceGroup.sourceMap.attributes.name.sourceMap, 0, 13);
-    SourceMapHelper::check(resourceGroup.sourceMap.content.elements().collection[0].content.copy.sourceMap, 13, 3);
     SourceMapHelper::check(
-        resourceGroup.sourceMap.content.elements().collection[1].content.resource.uriTemplate.sourceMap, 16, 12);
+        resourceGroup.sourceMap.attributes.name.sourceMap, 0, 13);
+    SourceMapHelper::check(resourceGroup.sourceMap.content.elements()
+                               .collection[0]
+                               .content.copy.sourceMap,
+        13,
+        3);
+    SourceMapHelper::check(resourceGroup.sourceMap.content.elements()
+                               .collection[1]
+                               .content.resource.uriTemplate.sourceMap,
+        16,
+        12);
 }
 
 TEST_CASE("Parse multiple resource in anonymous group", "[resource_group]")
@@ -120,13 +151,23 @@ TEST_CASE("Parse multiple resource in anonymous group", "[resource_group]")
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
 
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(resourceGroup.node.content.elements().at(0).content.resource.uriTemplate == "/r1");
-    REQUIRE(resourceGroup.node.content.elements().at(0).content.resource.description == "p1");
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(
+        resourceGroup.node.content.elements().at(0).content.resource.uriTemplate
+        == "/r1");
+    REQUIRE(
+        resourceGroup.node.content.elements().at(0).content.resource.description
+        == "p1");
 
-    REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
-    REQUIRE(resourceGroup.node.content.elements().at(1).content.resource.uriTemplate == "/r2");
-    REQUIRE(resourceGroup.node.content.elements().at(1).content.resource.description == "p2");
+    REQUIRE(resourceGroup.node.content.elements().at(1).element
+        == Element::ResourceElement);
+    REQUIRE(
+        resourceGroup.node.content.elements().at(1).content.resource.uriTemplate
+        == "/r2");
+    REQUIRE(
+        resourceGroup.node.content.elements().at(1).content.resource.description
+        == "p2");
 
     REQUIRE(resourceGroup.sourceMap.attributes.name.sourceMap.empty());
     REQUIRE(resourceGroup.sourceMap.content.elements().collection.size() == 2);
@@ -154,8 +195,10 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
 
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
-    Resource resource1 = resourceGroup.node.content.elements().at(0).content.resource;
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
+    Resource resource1
+        = resourceGroup.node.content.elements().at(0).content.resource;
 
     REQUIRE(resource1.uriTemplate == "/1");
     REQUIRE(resource1.description.empty());
@@ -169,7 +212,8 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resource1.actions[0].examples[0].requests[0].body.empty());
     REQUIRE(resource1.actions[0].examples[0].responses.empty());
 
-    Resource resource2 = resourceGroup.node.content.elements().at(1).content.resource;
+    Resource resource2
+        = resourceGroup.node.content.elements().at(1).content.resource;
     REQUIRE(resource2.uriTemplate == "/2");
     REQUIRE(resource2.description.empty());
     REQUIRE(resource2.actions.size() == 1);
@@ -223,14 +267,17 @@ TEST_CASE("Parse resource with list in its description", "[resource_group]")
         source, ResourceGroupSectionType, resourceGroup, ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
-    REQUIRE(resourceGroup.report.warnings.size() == 3); // preformatted asset & ignoring unrecognized node & no response
+    REQUIRE(resourceGroup.report.warnings.size()
+        == 3); // preformatted asset & ignoring unrecognized node & no response
 
     REQUIRE(resourceGroup.node.attributes.name.empty());
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    Resource resource
+        = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/1");
     REQUIRE(resource.description.empty());
     REQUIRE(resource.actions.size() == 1);
@@ -259,14 +306,22 @@ TEST_CASE("Parse resource groups with hr in description", "[resource_group]")
     REQUIRE(resourceGroup.node.attributes.name == "1");
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(resourceGroup.node.content.elements().at(0).content.copy == "---\n\nA");
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(
+        resourceGroup.node.content.elements().at(0).content.copy == "---\n\nA");
 
-    SourceMapHelper::check(resourceGroup.sourceMap.attributes.name.sourceMap, 0, 10);
-    SourceMapHelper::check(resourceGroup.sourceMap.content.elements().collection[0].content.copy.sourceMap, 10, 6);
+    SourceMapHelper::check(
+        resourceGroup.sourceMap.attributes.name.sourceMap, 0, 10);
+    SourceMapHelper::check(resourceGroup.sourceMap.content.elements()
+                               .collection[0]
+                               .content.copy.sourceMap,
+        10,
+        6);
 }
 
-TEST_CASE("Make sure method followed by a group does not eat the group", "[resource_group]")
+TEST_CASE("Make sure method followed by a group does not eat the group",
+    "[resource_group]")
 {
     mdp::ByteBuffer source
         = "# Group One\n"
@@ -284,19 +339,23 @@ TEST_CASE("Make sure method followed by a group does not eat the group", "[resou
     REQUIRE(resourceGroup.node.attributes.name == "One");
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    Resource resource
+        = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/1");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "POST");
     REQUIRE(resource.actions[0].description.empty());
 
-    SourceMapHelper::check(resourceGroup.sourceMap.attributes.name.sourceMap, 0, 12);
+    SourceMapHelper::check(
+        resourceGroup.sourceMap.attributes.name.sourceMap, 0, 12);
     REQUIRE(resourceGroup.sourceMap.content.elements().collection.size() == 1);
 }
 
-TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[resource_group]")
+TEST_CASE("Parse resource method abbreviation followed by a foreign method",
+    "[resource_group]")
 {
     mdp::ByteBuffer source
         = "# GET /resource\n"
@@ -307,16 +366,19 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
         source, ResourceGroupSectionType, resourceGroup, ExportSourcemapOption);
 
     REQUIRE(resourceGroup.report.error.code == Error::OK);
-    REQUIRE(resourceGroup.report.warnings.size() == 2); // no response && unexpected action POST
+    REQUIRE(resourceGroup.report.warnings.size()
+        == 2); // no response && unexpected action POST
     REQUIRE(resourceGroup.report.warnings[0].code == EmptyDefinitionWarning);
     REQUIRE(resourceGroup.report.warnings[1].code == IgnoringWarning);
 
     REQUIRE(resourceGroup.node.attributes.name.empty());
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    Resource resource
+        = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.model.name.empty());
@@ -328,7 +390,8 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
     REQUIRE(resourceGroup.sourceMap.content.elements().collection.size() == 1);
 }
 
-TEST_CASE("Parse resource method abbreviation followed by another", "[resource_group]")
+TEST_CASE("Parse resource method abbreviation followed by another",
+    "[resource_group]")
 {
     mdp::ByteBuffer source
         = "# GET /resource\n"
@@ -346,10 +409,13 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     REQUIRE(resourceGroup.node.attributes.name.empty());
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(1).element
+        == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    Resource resource
+        = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.model.name.empty());
@@ -369,7 +435,8 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     REQUIRE(resourceGroup.sourceMap.content.elements().collection.size() == 2);
 }
 
-TEST_CASE("Resource followed by a complete action", "[resource_group][regression][185]")
+TEST_CASE("Resource followed by a complete action",
+    "[resource_group][regression][185]")
 {
     mdp::ByteBuffer source
         = "# Resource [/A]\n"
@@ -386,10 +453,13 @@ TEST_CASE("Resource followed by a complete action", "[resource_group][regression
     REQUIRE(resourceGroup.node.attributes.name.empty());
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(resourceGroup.node.content.elements().at(1).element
+        == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    Resource resource
+        = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name == "Resource");
     REQUIRE(resource.uriTemplate == "/A");
 
@@ -399,18 +469,24 @@ TEST_CASE("Resource followed by a complete action", "[resource_group][regression
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "POST");
 
-    SourceMap<Resource> resourceSM = resourceGroup.sourceMap.content.elements().collection[0].content.resource;
+    SourceMap<Resource> resourceSM = resourceGroup.sourceMap.content.elements()
+                                         .collection[0]
+                                         .content.resource;
     SourceMapHelper::check(resourceSM.name.sourceMap, 0, 16);
     SourceMapHelper::check(resourceSM.uriTemplate.sourceMap, 0, 16);
 
-    resourceSM = resourceGroup.sourceMap.content.elements().collection[1].content.resource;
+    resourceSM = resourceGroup.sourceMap.content.elements()
+                     .collection[1]
+                     .content.resource;
     REQUIRE(resourceSM.name.sourceMap.empty());
     SourceMapHelper::check(resourceSM.uriTemplate.sourceMap, 16, 10);
     REQUIRE(resourceSM.actions.collection.size() == 1);
-    SourceMapHelper::check(resourceSM.actions.collection[0].method.sourceMap, 16, 10);
+    SourceMapHelper::check(
+        resourceSM.actions.collection[0].method.sourceMap, 16, 10);
 }
 
-TEST_CASE("Too eager complete action processing", "[resource_group][regression][187]")
+TEST_CASE(
+    "Too eager complete action processing", "[resource_group][regression][187]")
 {
     mdp::ByteBuffer source
         = "# Group A\n"
@@ -431,8 +507,14 @@ TEST_CASE("Too eager complete action processing", "[resource_group][regression][
     REQUIRE(resourceGroup.node.attributes.name == "A");
     REQUIRE(resourceGroup.node.element == Element::CategoryElement);
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
-    REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(resourceGroup.node.content.elements().at(0).content.copy == "```\nGET /A\n```\n\nLorem Ipsum");
+    REQUIRE(resourceGroup.node.content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(resourceGroup.node.content.elements().at(0).content.copy
+        == "```\nGET /A\n```\n\nLorem Ipsum");
 
-    SourceMapHelper::check(resourceGroup.sourceMap.content.elements().collection[0].content.copy.sourceMap, 11, 28);
+    SourceMapHelper::check(resourceGroup.sourceMap.content.elements()
+                               .collection[0]
+                               .content.copy.sourceMap,
+        11,
+        28);
 }

--- a/test/test-ResourceParser.cc
+++ b/test/test-ResourceParser.cc
@@ -39,22 +39,26 @@ TEST_CASE("Resource block classifier", "[resource]")
     markdownParser.parse(ResourceFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    sectionType = SectionProcessor<Resource>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Resource>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ResourceSectionType);
 
     // Nameless resource: "/resource"
     markdownAST.children().front().text = "/resource";
-    sectionType = SectionProcessor<Resource>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Resource>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ResourceSectionType);
 
     // Keyword "group"
     markdownAST.children().front().text = "Group A";
-    sectionType = SectionProcessor<Resource>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Resource>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == UndefinedSectionType);
 
     // Resource Method
     markdownAST.children().front().text = "GET /resource";
-    sectionType = SectionProcessor<Resource>::sectionType(markdownAST.children().begin());
+    sectionType = SectionProcessor<Resource>::sectionType(
+        markdownAST.children().begin());
     REQUIRE(sectionType == ResourceSectionType);
 }
 
@@ -88,12 +92,15 @@ TEST_CASE("Parse resource", "[resource]")
     SourceMapHelper::check(resource.sourceMap.uriTemplate.sourceMap, 0, 40);
     REQUIRE(resource.sourceMap.headers.collection.size() == 0);
     REQUIRE(resource.sourceMap.parameters.collection.size() == 2);
-    SourceMapHelper::check(resource.sourceMap.parameters.collection[0].name.sourceMap, 125, 40);
-    SourceMapHelper::check(resource.sourceMap.parameters.collection[1].name.sourceMap, 271, 6);
+    SourceMapHelper::check(
+        resource.sourceMap.parameters.collection[0].name.sourceMap, 125, 40);
+    SourceMapHelper::check(
+        resource.sourceMap.parameters.collection[1].name.sourceMap, 271, 6);
     SourceMapHelper::check(resource.sourceMap.model.name.sourceMap, 63, 29);
     SourceMapHelper::check(resource.sourceMap.model.body.sourceMap, 96, 9);
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].method.sourceMap, 278, 20);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].method.sourceMap, 278, 20);
 }
 
 TEST_CASE("Parse partially defined resource", "[resource]")
@@ -105,10 +112,12 @@ TEST_CASE("Parse partially defined resource", "[resource]")
           "p1\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
-    REQUIRE(resource.report.warnings.size() == 2); // no response & preformatted asset
+    REQUIRE(resource.report.warnings.size()
+        == 2); // no response & preformatted asset
     REQUIRE(resource.report.warnings[0].code == IndentationWarning);
     REQUIRE(resource.report.warnings[1].code == EmptyDefinitionWarning);
 
@@ -121,16 +130,25 @@ TEST_CASE("Parse partially defined resource", "[resource]")
     REQUIRE(resource.node.actions.front().method == "GET");
     REQUIRE(resource.node.actions.front().description.empty());
     REQUIRE(!resource.node.actions.front().examples.empty());
-    REQUIRE(resource.node.actions.front().examples.front().requests.size() == 1);
-    REQUIRE(resource.node.actions.front().examples.front().requests.front().name.empty());
-    REQUIRE(resource.node.actions.front().examples.front().requests.front().description.empty());
-    REQUIRE(resource.node.actions.front().examples.front().requests.front().body == "p1\n\n");
+    REQUIRE(
+        resource.node.actions.front().examples.front().requests.size() == 1);
+    REQUIRE(resource.node.actions.front()
+                .examples.front()
+                .requests.front()
+                .name.empty());
+    REQUIRE(resource.node.actions.front()
+                .examples.front()
+                .requests.front()
+                .description.empty());
+    REQUIRE(resource.node.actions.front().examples.front().requests.front().body
+        == "p1\n\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
     SourceMapHelper::check(resource.sourceMap.uriTemplate.sourceMap, 0, 5);
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].method.sourceMap, 5, 7);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].method.sourceMap, 5, 7);
 }
 
 TEST_CASE("Parse multiple method descriptions", "[resource]")
@@ -143,7 +161,8 @@ TEST_CASE("Parse multiple method descriptions", "[resource]")
           "p2\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2); // 2x no response
@@ -162,8 +181,10 @@ TEST_CASE("Parse multiple method descriptions", "[resource]")
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
     SourceMapHelper::check(resource.sourceMap.uriTemplate.sourceMap, 0, 5);
     REQUIRE(resource.sourceMap.actions.collection.size() == 2);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].method.sourceMap, 5, 6);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[1].method.sourceMap, 14, 7);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].method.sourceMap, 5, 6);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[1].method.sourceMap, 14, 7);
 }
 
 TEST_CASE("Parse multiple methods", "[resource]")
@@ -186,10 +207,12 @@ TEST_CASE("Parse multiple methods", "[resource]")
           "E\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
-    REQUIRE(resource.report.warnings.size() == 2); // empty reuqest asset & no response
+    REQUIRE(resource.report.warnings.size()
+        == 2); // empty reuqest asset & no response
 
     REQUIRE(resource.node.uriTemplate == "/1");
     REQUIRE(resource.node.description == "A");
@@ -203,19 +226,24 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.node.actions[0].examples[0].requests.empty());
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].description.empty());
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "Code 1\n");
+    REQUIRE(
+        resource.node.actions[0].examples[0].responses[0].description.empty());
+    REQUIRE(
+        resource.node.actions[0].examples[0].responses[0].body == "Code 1\n");
 
     REQUIRE(resource.node.actions[1].method == "POST");
     REQUIRE(resource.node.actions[1].description == "C");
     REQUIRE(resource.node.actions[1].examples.size() == 1);
     REQUIRE(resource.node.actions[1].examples[0].requests.size() == 1);
     REQUIRE(resource.node.actions[1].examples[0].requests[0].name == "D");
-    REQUIRE(resource.node.actions[1].examples[0].requests[0].description.empty());
-    REQUIRE(resource.node.actions[1].examples[0].requests[0].description.empty());
+    REQUIRE(
+        resource.node.actions[1].examples[0].requests[0].description.empty());
+    REQUIRE(
+        resource.node.actions[1].examples[0].requests[0].description.empty());
     REQUIRE(resource.node.actions[1].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[1].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[1].examples[0].responses[0].description.empty());
+    REQUIRE(
+        resource.node.actions[1].examples[0].responses[0].description.empty());
     REQUIRE(resource.node.actions[1].examples[0].responses[0].body == "{}\n");
 
     REQUIRE(resource.node.actions[2].method == "PUT");
@@ -225,9 +253,12 @@ TEST_CASE("Parse multiple methods", "[resource]")
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     SourceMapHelper::check(resource.sourceMap.uriTemplate.sourceMap, 0, 5);
     REQUIRE(resource.sourceMap.actions.collection.size() == 3);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].method.sourceMap, 7, 7);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[1].method.sourceMap, 63, 8);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[2].method.sourceMap, 128, 7);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].method.sourceMap, 7, 7);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[1].method.sourceMap, 63, 8);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[2].method.sourceMap, 128, 7);
 }
 
 TEST_CASE("Parse description with list", "[resource]")
@@ -239,7 +270,8 @@ TEST_CASE("Parse description with list", "[resource]")
           "p1\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -265,7 +297,8 @@ TEST_CASE("Parse resource with a HR", "[resource][block]")
           "B\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -292,7 +325,8 @@ TEST_CASE("Parse resource method abbreviation", "[resource]")
           "            {}\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -304,14 +338,16 @@ TEST_CASE("Parse resource method abbreviation", "[resource]")
     REQUIRE(resource.node.actions[0].description == "Description");
 
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].description.empty());
+    REQUIRE(
+        resource.node.actions[0].examples[0].responses[0].description.empty());
     REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "{}\n");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
     SourceMapHelper::check(resource.sourceMap.uriTemplate.sourceMap, 0, 16);
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].method.sourceMap, 0, 16);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].method.sourceMap, 0, 16);
 }
 
 TEST_CASE("Parse resource without name", "[resource]")
@@ -319,7 +355,8 @@ TEST_CASE("Parse resource without name", "[resource]")
     mdp::ByteBuffer source = "# /resource\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -349,7 +386,8 @@ TEST_CASE("Warn about parameters not in URI template", "[resource][source]")
           "+ Response 204\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2);
@@ -369,7 +407,8 @@ TEST_CASE("Warn about parameters not in URI template", "[resource][source]")
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
 }
 
-TEST_CASE("Parse nameless resource with named model", "[resource][model][source]")
+TEST_CASE(
+    "Parse nameless resource with named model", "[resource][model][source]")
 {
     mdp::ByteBuffer source
         = "# /message\n"
@@ -379,7 +418,8 @@ TEST_CASE("Parse nameless resource with named model", "[resource][model][source]
           "\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -396,7 +436,8 @@ TEST_CASE("Parse nameless resource with named model", "[resource][model][source]
     REQUIRE(resource.sourceMap.actions.collection.empty());
 }
 
-TEST_CASE("Parse nameless resource with nameless model", "[resource][model][source]")
+TEST_CASE(
+    "Parse nameless resource with nameless model", "[resource][model][source]")
 {
     mdp::ByteBuffer source
         = "# /message\n"
@@ -406,7 +447,8 @@ TEST_CASE("Parse nameless resource with nameless model", "[resource][model][sour
           "\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == ModelError);
     REQUIRE(resource.report.warnings.empty());
@@ -421,7 +463,8 @@ TEST_CASE("Parse nameless resource with nameless model", "[resource][model][sour
     REQUIRE(resource.sourceMap.actions.collection.empty());
 }
 
-TEST_CASE("Parse named resource with nameless model", "[resource][model][source]")
+TEST_CASE(
+    "Parse named resource with nameless model", "[resource][model][source]")
 {
     mdp::ByteBuffer source
         = "# Message [/message]\n"
@@ -433,7 +476,8 @@ TEST_CASE("Parse named resource with nameless model", "[resource][model][source]
           "    [Message][]\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -470,7 +514,8 @@ TEST_CASE("Parse model with unrecognised resource", "[resource][model]")
           "            [Resource][]";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1);
@@ -484,11 +529,14 @@ TEST_CASE("Parse model with unrecognised resource", "[resource][model]")
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "[Resource][]\n");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].description == "");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body
+        == "[Resource][]\n");
+    REQUIRE(
+        resource.node.actions[0].examples[0].responses[0].description == "");
 }
 
-TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue][84]")
+TEST_CASE("Parse named resource with lazy referencing",
+    "[resource][model][issue][84]")
 {
     mdp::ByteBuffer source
         = "#api name\n\n"
@@ -510,11 +558,19 @@ TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue
     REQUIRE(blueprint.node.description == "");
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.uriTemplate == "/1");
     REQUIRE(resource.name == "Resource 1");
 
@@ -525,29 +581,46 @@ TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].body == "`resource model` 2\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body
+        == "`resource model` 2\n");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first == "Content-Type");
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second == "text/plain");
+    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first
+        == "Content-Type");
+    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second
+        == "text/plain");
 
-    REQUIRE(resource.actions[0].examples[0].responses[0].reference.id == "Resource 2");
-    REQUIRE(resource.actions[0].examples[0].responses[0].reference.type == Reference::ModelReference);
-    REQUIRE(resource.actions[0].examples[0].responses[0].reference.meta.state == Reference::StateResolved);
+    REQUIRE(resource.actions[0].examples[0].responses[0].reference.id
+        == "Resource 2");
+    REQUIRE(resource.actions[0].examples[0].responses[0].reference.type
+        == Reference::ModelReference);
+    REQUIRE(resource.actions[0].examples[0].responses[0].reference.meta.state
+        == Reference::StateResolved);
 
-    SourceMap<TransactionExamples> examplesSourceMap = blueprint.sourceMap.content.elements()
-                                                           .collection[0]
-                                                           .content.elements()
-                                                           .collection[0]
-                                                           .content.resource.actions.collection[0]
-                                                           .examples;
+    SourceMap<TransactionExamples> examplesSourceMap
+        = blueprint.sourceMap.content.elements()
+              .collection[0]
+              .content.elements()
+              .collection[0]
+              .content.resource.actions.collection[0]
+              .examples;
 
-    SourceMapHelper::check(
-        examplesSourceMap.collection[0].responses.collection[0].headers.collection[0].sourceMap, 104, 20);
+    SourceMapHelper::check(examplesSourceMap.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[0]
+                               .sourceMap,
+        104,
+        20);
 
-    SourceMapHelper::check(examplesSourceMap.collection[0].responses.collection[0].reference.sourceMap, 68, 15);
+    SourceMapHelper::check(examplesSourceMap.collection[0]
+                               .responses.collection[0]
+                               .reference.sourceMap,
+        68,
+        15);
 }
 
-TEST_CASE("Parse named resource with lazy referencing with both response and request", "[resource][model]")
+TEST_CASE(
+    "Parse named resource with lazy referencing with both response and request",
+    "[resource][model]")
 {
     mdp::ByteBuffer source
         = "# API\n"
@@ -581,11 +654,19 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(blueprint.node.description == "");
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.uriTemplate == "/items");
     REQUIRE(resource.name == "Collection of Items");
 
@@ -599,24 +680,33 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(resource.actions[0].examples[0].requests[0].name == "");
     REQUIRE(resource.actions[0].examples[0].requests[0].body == "{ item }\n");
     REQUIRE(resource.actions[0].examples[0].requests[0].headers.size() == 1);
-    REQUIRE(resource.actions[0].examples[0].requests[0].headers[0].first == "Content-Type");
-    REQUIRE(resource.actions[0].examples[0].requests[0].headers[0].second == "application/json");
+    REQUIRE(resource.actions[0].examples[0].requests[0].headers[0].first
+        == "Content-Type");
+    REQUIRE(resource.actions[0].examples[0].requests[0].headers[0].second
+        == "application/json");
 
     REQUIRE(resource.actions[0].examples[0].requests[0].reference.id == "Item");
-    REQUIRE(resource.actions[0].examples[0].requests[0].reference.type == Reference::ModelReference);
-    REQUIRE(resource.actions[0].examples[0].requests[0].reference.meta.state == Reference::StateResolved);
+    REQUIRE(resource.actions[0].examples[0].requests[0].reference.type
+        == Reference::ModelReference);
+    REQUIRE(resource.actions[0].examples[0].requests[0].reference.meta.state
+        == Reference::StateResolved);
 
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].body == "[ { item 1 }, { item 2 } ]\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body
+        == "[ { item 1 }, { item 2 } ]\n");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
 
-    REQUIRE(resource.actions[0].examples[0].responses[0].reference.id == "Collection of Items");
-    REQUIRE(resource.actions[0].examples[0].responses[0].reference.type == Reference::ModelReference);
-    REQUIRE(resource.actions[0].examples[0].responses[0].reference.meta.state == Reference::StateResolved);
+    REQUIRE(resource.actions[0].examples[0].responses[0].reference.id
+        == "Collection of Items");
+    REQUIRE(resource.actions[0].examples[0].responses[0].reference.type
+        == Reference::ModelReference);
+    REQUIRE(resource.actions[0].examples[0].responses[0].reference.meta.state
+        == Reference::StateResolved);
 }
 
-TEST_CASE("Expect to have a warning when 100 responce's reference has a body", "[resource][model]")
+TEST_CASE("Expect to have a warning when 100 responce's reference has a body",
+    "[resource][model]")
 {
     mdp::ByteBuffer source
         = "# API\n"
@@ -649,7 +739,10 @@ TEST_CASE("Expect to have a warning when 100 responce's reference has a body", "
     REQUIRE(blueprint.report.warnings[0].code == EmptyDefinitionWarning);
 }
 
-TEST_CASE("Parse named resource with nameless model but reference a non-existing model", "[resource]")
+TEST_CASE(
+    "Parse named resource with nameless model but reference a non-existing "
+    "model",
+    "[resource]")
 {
     mdp::ByteBuffer source
         = "# Posts [/posts]\n"
@@ -672,7 +765,8 @@ TEST_CASE("Parse root resource", "[resource]")
     mdp::ByteBuffer source = "# API Root [/]\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -693,7 +787,8 @@ TEST_CASE("Parse resource with invalid URI Tempalte", "[resource]")
     mdp::ByteBuffer source = "# Resource [/id{? limit}]\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1);
@@ -724,7 +819,8 @@ TEST_CASE("Deprecated resource and action headers", "[resource]")
           "            header3: value3\n\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 2);
@@ -736,13 +832,20 @@ TEST_CASE("Deprecated resource and action headers", "[resource]")
     REQUIRE(resource.node.actions[0].headers.empty());
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers.size() == 3);
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[0].first == "header1");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[0].second == "value1");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[1].first == "header2");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[1].second == "value2");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[2].first == "header3");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[2].second == "value3");
+    REQUIRE(
+        resource.node.actions[0].examples[0].responses[0].headers.size() == 3);
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[0].first
+        == "header1");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[0].second
+        == "value1");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[1].first
+        == "header2");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[1].second
+        == "value2");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[2].first
+        == "header3");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].headers[2].second
+        == "value3");
 
     REQUIRE(resource.sourceMap.name.sourceMap.empty());
     REQUIRE(resource.sourceMap.description.sourceMap.empty());
@@ -750,30 +853,46 @@ TEST_CASE("Deprecated resource and action headers", "[resource]")
     REQUIRE(resource.sourceMap.parameters.collection.empty());
     REQUIRE(resource.sourceMap.headers.collection.empty());
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].headers.collection.empty());
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection
-                [0].headers.collection.size()
+    REQUIRE(
+        resource.sourceMap.actions.collection[0].headers.collection.empty());
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection.size()
+        == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection.size()
+        == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection[0]
+                .headers.collection.size()
         == 3);
-    SourceMapHelper::check(
-        resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection
-            [0].sourceMap,
+    SourceMapHelper::check(resource.sourceMap.actions.collection[0]
+                               .examples.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[0]
+                               .sourceMap,
         23,
         15);
-    SourceMapHelper::check(
-        resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection
-            [1].sourceMap,
+    SourceMapHelper::check(resource.sourceMap.actions.collection[0]
+                               .examples.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[1]
+                               .sourceMap,
         66,
         15);
-    SourceMapHelper::check(
-        resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection
-            [2].sourceMap,
+    SourceMapHelper::check(resource.sourceMap.actions.collection[0]
+                               .examples.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[2]
+                               .sourceMap,
         125,
         15);
 }
 
-TEST_CASE("Bug fix for recognition of model as a part of other word or as a quote, issue #92 and #152", "[model]")
+TEST_CASE(
+    "Bug fix for recognition of model as a part of other word or as a quote, "
+    "issue #92 and #152",
+    "[model]")
 {
     mdp::ByteBuffer source
         = "## Resource [/resource]\n"
@@ -784,7 +903,8 @@ TEST_CASE("Bug fix for recognition of model as a part of other word or as a quot
           "- `model`\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 0);
@@ -803,7 +923,8 @@ TEST_CASE("Parse resource with multi-word named model", "[resource][model]")
           "        body of the `model`\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -831,7 +952,8 @@ TEST_CASE("Dangling transaction example assets", "[resource]")
           "```\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 3);
@@ -847,20 +969,37 @@ TEST_CASE("Dangling transaction example assets", "[resource]")
     REQUIRE(resource.node.actions[0].examples.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].requests.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].requests[0].name == "A");
-    REQUIRE(resource.node.actions[0].examples[0].requests[0].body == "dangling request body\n\n");
+    REQUIRE(resource.node.actions[0].examples[0].requests[0].body
+        == "dangling request body\n\n");
 
     REQUIRE(resource.node.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.node.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.node.actions[0].examples[0].responses[0].body == "dangling response body\n\n");
+    REQUIRE(resource.node.actions[0].examples[0].responses[0].body
+        == "dangling response body\n\n");
 
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection.size() == 1);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection.size() == 1);
-    SourceMapHelper::check(
-        resource.sourceMap.actions.collection[0].examples.collection[0].requests.collection[0].body.sourceMap, 29, 33);
-    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection.size() == 1);
-    SourceMapHelper::check(
-        resource.sourceMap.actions.collection[0].examples.collection[0].responses.collection[0].body.sourceMap, 78, 31);
+    REQUIRE(resource.sourceMap.actions.collection[0].examples.collection.size()
+        == 1);
+    REQUIRE(resource.sourceMap.actions.collection[0]
+                .examples.collection[0]
+                .requests.collection.size()
+        == 1);
+    SourceMapHelper::check(resource.sourceMap.actions.collection[0]
+                               .examples.collection[0]
+                               .requests.collection[0]
+                               .body.sourceMap,
+        29,
+        33);
+    REQUIRE(resource.sourceMap.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection.size()
+        == 1);
+    SourceMapHelper::check(resource.sourceMap.actions.collection[0]
+                               .examples.collection[0]
+                               .responses.collection[0]
+                               .body.sourceMap,
+        78,
+        31);
 }
 
 TEST_CASE("Body list item in description", "[resource][regression][190]")
@@ -876,16 +1015,19 @@ TEST_CASE("Body list item in description", "[resource][regression][190]")
           "+ Response 200\n";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.actions.size() == 1);
-    REQUIRE(resource.node.actions[0].description == "Lorem Ipsum\n\n+ Body\n\n    { ... }");
+    REQUIRE(resource.node.actions[0].description
+        == "Lorem Ipsum\n\n+ Body\n\n    { ... }");
 
     REQUIRE(resource.sourceMap.actions.collection.size() == 1);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].description.sourceMap, 10, 34);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].description.sourceMap, 10, 34);
 }
 
 TEST_CASE("Parse resource attributes", "[resource]")
@@ -902,17 +1044,28 @@ TEST_CASE("Parse resource attributes", "[resource]")
 
     NamedTypeHelper::build("Coupon", mson::ObjectBaseType, namedTypes);
     NamedTypeHelper::build("Coupons", mson::ValueBaseType, namedTypes);
-    SectionParserHelper<Resource, ResourceParser>::parse(
-        source, ResourceSectionType, resource, ExportSourcemapOption, Models(), NULL, namedTypes);
+    SectionParserHelper<Resource, ResourceParser>::parse(source,
+        ResourceSectionType,
+        resource,
+        ExportSourcemapOption,
+        Models(),
+        NULL,
+        namedTypes);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.name == "Coupons");
     REQUIRE(resource.node.attributes.name.symbol.literal == "Coupons");
-    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.name.base
+        == mson::ArrayTypeName);
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification
+                .nestedTypes.size()
+        == 1);
+    REQUIRE(
+        resource.node.attributes.typeDefinition.typeSpecification.nestedTypes[0]
+            .symbol.literal
+        == "Coupon");
 
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].examples.size() == 1);
@@ -932,17 +1085,29 @@ TEST_CASE("Parse unnamed resource attributes", "[resource]")
     NamedTypes namedTypes;
 
     NamedTypeHelper::build("Coupon", mson::ObjectBaseType, namedTypes);
-    SectionParserHelper<Resource, ResourceParser>::parse(
-        source, ResourceSectionType, resource, ExportSourcemapOption, Models(), NULL, namedTypes);
+    SectionParserHelper<Resource, ResourceParser>::parse(source,
+        ResourceSectionType,
+        resource,
+        ExportSourcemapOption,
+        Models(),
+        NULL,
+        namedTypes);
 
-    REQUIRE(resource.report.error.code == snowcrash::MSONError); // Unknown type 'Coupons'
+    REQUIRE(resource.report.error.code
+        == snowcrash::MSONError); // Unknown type 'Coupons'
     REQUIRE(resource.report.warnings.empty());
 
     REQUIRE(resource.node.name.empty());
     REQUIRE(resource.node.attributes.name.empty());
-    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.name.base == mson::ArrayTypeName);
-    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes.size() == 1);
-    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.nestedTypes[0].symbol.literal == "Coupon");
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification.name.base
+        == mson::ArrayTypeName);
+    REQUIRE(resource.node.attributes.typeDefinition.typeSpecification
+                .nestedTypes.size()
+        == 1);
+    REQUIRE(
+        resource.node.attributes.typeDefinition.typeSpecification.nestedTypes[0]
+            .symbol.literal
+        == "Coupon");
 
     REQUIRE(resource.node.actions.size() == 1);
     REQUIRE(resource.node.actions[0].examples.size() == 1);
@@ -967,7 +1132,8 @@ TEST_CASE("Parse inline action", "[resource]")
           "        {}";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -981,13 +1147,20 @@ TEST_CASE("Parse inline action", "[resource]")
     REQUIRE(resource.node.actions[1].uriTemplate == "/tasks");
 
     REQUIRE(resource.sourceMap.actions.collection.size() == 2);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[0].method.sourceMap, 52, 18);
-    REQUIRE(resource.sourceMap.actions.collection[0].uriTemplate.sourceMap.empty());
-    SourceMapHelper::check(resource.sourceMap.actions.collection[1].method.sourceMap, 117, 31);
-    SourceMapHelper::check(resource.sourceMap.actions.collection[1].uriTemplate.sourceMap, 117, 31);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[0].method.sourceMap, 52, 18);
+    REQUIRE(
+        resource.sourceMap.actions.collection[0].uriTemplate.sourceMap.empty());
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[1].method.sourceMap, 117, 31);
+    SourceMapHelper::check(
+        resource.sourceMap.actions.collection[1].uriTemplate.sourceMap,
+        117,
+        31);
 }
 
-TEST_CASE("Parameters for action should consider action's uri template", "[resource]")
+TEST_CASE(
+    "Parameters for action should consider action's uri template", "[resource]")
 {
     mdp::ByteBuffer source
         = "## Users [/users]\n"
@@ -1005,7 +1178,8 @@ TEST_CASE("Parameters for action should consider action's uri template", "[resou
           "+ Response 204";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.empty());
@@ -1025,7 +1199,8 @@ TEST_CASE("Relation identifiers should be unique for a resource", "[resource]")
           "+ Response 204";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 1);
@@ -1036,7 +1211,8 @@ TEST_CASE("Relation identifiers should be unique for a resource", "[resource]")
     REQUIRE(resource.node.actions[1].relation.str == "create");
 }
 
-TEST_CASE("Detect invalid reference to action URI Template parameters", "[resource]")
+TEST_CASE(
+    "Detect invalid reference to action URI Template parameters", "[resource]")
 {
     mdp::ByteBuffer source
         = "## Orders [/orders]\n\n"
@@ -1048,7 +1224,8 @@ TEST_CASE("Detect invalid reference to action URI Template parameters", "[resour
           "+ Response 200";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 3);
@@ -1065,7 +1242,8 @@ TEST_CASE("Detect invalid reference to action URI Template parameters", "[resour
     SourceMapHelper::check(resource.report.warnings[2].location, 21, 30);
 }
 
-TEST_CASE("Detect invalid reference to resource URI Template parameters", "[resource]")
+TEST_CASE("Detect invalid reference to resource URI Template parameters",
+    "[resource]")
 {
     mdp::ByteBuffer source
         = "## Orders [/orders{?abc}]\n\n"
@@ -1077,7 +1255,8 @@ TEST_CASE("Detect invalid reference to resource URI Template parameters", "[reso
           "+ Response 200";
 
     ParseResult<Resource> resource;
-    SectionParserHelper<Resource, ResourceParser>::parse(source, ResourceSectionType, resource, ExportSourcemapOption);
+    SectionParserHelper<Resource, ResourceParser>::parse(
+        source, ResourceSectionType, resource, ExportSourcemapOption);
 
     REQUIRE(resource.report.error.code == Error::OK);
     REQUIRE(resource.report.warnings.size() == 3);

--- a/test/test-SectionParser.cc
+++ b/test/test-SectionParser.cc
@@ -32,14 +32,20 @@ TEST_CASE("Header adapter with header section", "[adapter]")
 
     REQUIRE(!markdownAST.children().empty());
 
-    REQUIRE_NOTHROW(HeaderSectionAdapter::startingNode(markdownAST.children().begin(), pd));
-    MarkdownNodeIterator it = HeaderSectionAdapter::startingNode(markdownAST.children().begin(), pd);
+    REQUIRE_NOTHROW(
+        HeaderSectionAdapter::startingNode(markdownAST.children().begin(), pd));
+    MarkdownNodeIterator it = HeaderSectionAdapter::startingNode(
+        markdownAST.children().begin(), pd);
     REQUIRE(it->text == "Signature");
 
-    const MarkdownNodes& collection = HeaderSectionAdapter::startingNodeSiblings(it, markdownAST.children());
+    const MarkdownNodes& collection
+        = HeaderSectionAdapter::startingNodeSiblings(
+            it, markdownAST.children());
     REQUIRE(collection.size() == 2);
 
-    REQUIRE(HeaderSectionAdapter::nextStartingNode(markdownAST.children().begin(), markdownAST.children(), it)->text
+    REQUIRE(HeaderSectionAdapter::nextStartingNode(
+                markdownAST.children().begin(), markdownAST.children(), it)
+                ->text
         == "Signature");
 }
 
@@ -53,7 +59,9 @@ TEST_CASE("Header adapter with list section", "[adapter]")
 
     REQUIRE(!markdownAST.children().empty());
 
-    REQUIRE_THROWS_AS(HeaderSectionAdapter::startingNode(markdownAST.children().begin(), pd), Error);
+    REQUIRE_THROWS_AS(
+        HeaderSectionAdapter::startingNode(markdownAST.children().begin(), pd),
+        Error);
 }
 
 TEST_CASE("List adapter with List section", "[adapter]")
@@ -66,15 +74,18 @@ TEST_CASE("List adapter with List section", "[adapter]")
 
     REQUIRE(!markdownAST.children().empty());
 
-    REQUIRE_NOTHROW(ListSectionAdapter::startingNode(markdownAST.children().begin(), pd));
-    MarkdownNodeIterator it = ListSectionAdapter::startingNode(markdownAST.children().begin(), pd);
+    REQUIRE_NOTHROW(
+        ListSectionAdapter::startingNode(markdownAST.children().begin(), pd));
+    MarkdownNodeIterator it
+        = ListSectionAdapter::startingNode(markdownAST.children().begin(), pd);
     REQUIRE(it->text == "Signature");
 
-    MarkdownNodes collection
-        = ListSectionAdapter::startingNodeSiblings(markdownAST.children().begin(), markdownAST.children());
+    MarkdownNodes collection = ListSectionAdapter::startingNodeSiblings(
+        markdownAST.children().begin(), markdownAST.children());
     REQUIRE(collection.size() == 2);
 
-    REQUIRE(ListSectionAdapter::nextStartingNode(markdownAST.children().begin(), markdownAST.children(), it)
+    REQUIRE(ListSectionAdapter::nextStartingNode(
+                markdownAST.children().begin(), markdownAST.children(), it)
         == markdownAST.children().end());
 }
 
@@ -88,5 +99,7 @@ TEST_CASE("List adapter with Header section", "[adapter]")
 
     REQUIRE(!markdownAST.children().empty());
 
-    REQUIRE_THROWS_AS(ListSectionAdapter::startingNode(markdownAST.children().begin(), pd), Error);
+    REQUIRE_THROWS_AS(
+        ListSectionAdapter::startingNode(markdownAST.children().begin(), pd),
+        Error);
 }

--- a/test/test-Signature.cc
+++ b/test/test-Signature.cc
@@ -8,26 +8,35 @@
 
 #include "snowcrashtest.h"
 
-static const mdp::ByteBuffer PropertySignatureFixture = "id: 42 (yes, no) - a good message";
-static const mdp::ByteBuffer EscapedPropertySignatureFixture = "`*id*(data):3`: `42` (yes, no) - a good message";
+static const mdp::ByteBuffer PropertySignatureFixture
+    = "id: 42 (yes, no) - a good message";
+static const mdp::ByteBuffer EscapedPropertySignatureFixture
+    = "`*id*(data):3`: `42` (yes, no) - a good message";
 
-static const mdp::ByteBuffer ElementSignatureFixture = "42 (number) - a good number";
-static const mdp::ByteBuffer EscapedElementSignatureFixture = "`*42*(data):3` (number) - a good number";
+static const mdp::ByteBuffer ElementSignatureFixture
+    = "42 (number) - a good number";
+static const mdp::ByteBuffer EscapedElementSignatureFixture
+    = "`*42*(data):3` (number) - a good number";
 
 using namespace snowcrash;
 using namespace snowcrashtest;
 
-static const scpl::SignatureTraits::Traits PropertyMemberTypeTraits = scpl::SignatureTraits::IdentifierTrait
-    | scpl::SignatureTraits::ValuesTrait | scpl::SignatureTraits::AttributesTrait | scpl::SignatureTraits::ContentTrait;
+static const scpl::SignatureTraits::Traits PropertyMemberTypeTraits
+    = scpl::SignatureTraits::IdentifierTrait
+    | scpl::SignatureTraits::ValuesTrait
+    | scpl::SignatureTraits::AttributesTrait
+    | scpl::SignatureTraits::ContentTrait;
 
 static const scpl::SignatureTraits::Traits ElementMemberTypeTraits
-    = scpl::SignatureTraits::ValuesTrait | scpl::SignatureTraits::AttributesTrait | scpl::SignatureTraits::ContentTrait;
+    = scpl::SignatureTraits::ValuesTrait
+    | scpl::SignatureTraits::AttributesTrait
+    | scpl::SignatureTraits::ContentTrait;
 
 TEST_CASE("Property signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse(PropertySignatureFixture, blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        PropertySignatureFixture, blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -46,8 +55,8 @@ TEST_CASE("Property signature parsing", "[signature]")
 TEST_CASE("Escaped property signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse(EscapedPropertySignatureFixture, blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        EscapedPropertySignatureFixture, blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -66,8 +75,8 @@ TEST_CASE("Escaped property signature parsing", "[signature]")
 TEST_CASE("Multiline signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse("id\nLine 2\nLine 3\n", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "id\nLine 2\nLine 3\n", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -83,7 +92,8 @@ TEST_CASE("Multiline signature parsing", "[signature]")
 TEST_CASE("Identifier only signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("id", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "id", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -99,8 +109,8 @@ TEST_CASE("Identifier only signature parsing", "[signature]")
 TEST_CASE("Identifier enclosed by asterisk", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse("*rel (Custom String)* (object)", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "*rel (Custom String)* (object)", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -118,7 +128,9 @@ TEST_CASE("Identifier enclosed by underscore", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
     scpl::Signature signature
-        = SignatureParserHelper::parse("_rel (*Custom* String)_ (object)", blueprint, PropertyMemberTypeTraits);
+        = SignatureParserHelper::parse("_rel (*Custom* String)_ (object)",
+            blueprint,
+            PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -136,7 +148,9 @@ TEST_CASE("Identifier enclosed by backticks", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
     scpl::Signature signature
-        = SignatureParserHelper::parse("```username `is` g``ood``` (object)", blueprint, PropertyMemberTypeTraits);
+        = SignatureParserHelper::parse("```username `is` g``ood``` (object)",
+            blueprint,
+            PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -153,7 +167,8 @@ TEST_CASE("Identifier enclosed by backticks", "[signature]")
 TEST_CASE("Identifier enclosing not completed", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("_rel (object)", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "_rel (object)", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -170,7 +185,8 @@ TEST_CASE("Identifier enclosing not completed", "[signature]")
 TEST_CASE("Extra space content after identifier enclosure", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("`a`   : 42", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "`a`   : 42", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -187,7 +203,8 @@ TEST_CASE("Extra space content after identifier enclosure", "[signature]")
 TEST_CASE("Extra non-space content after identifier enclosure", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("`a`b : 42", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "`a`b : 42", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 0);
@@ -204,7 +221,8 @@ TEST_CASE("Extra non-space content after identifier enclosure", "[signature]")
 TEST_CASE("Identifier description signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("id - a good - info", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "id - a good - info", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -220,7 +238,8 @@ TEST_CASE("Identifier description signature parsing", "[signature]")
 TEST_CASE("Identifier value signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("id : a good data", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "id : a good data", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -237,7 +256,8 @@ TEST_CASE("Identifier value signature parsing", "[signature]")
 TEST_CASE("Identifier attributes signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("id (number)", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "id (number)", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -254,8 +274,8 @@ TEST_CASE("Identifier attributes signature parsing", "[signature]")
 TEST_CASE("Element signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse(ElementSignatureFixture, blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        ElementSignatureFixture, blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -273,8 +293,8 @@ TEST_CASE("Element signature parsing", "[signature]")
 TEST_CASE("Escaped element signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse(EscapedElementSignatureFixture, blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        EscapedElementSignatureFixture, blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -292,7 +312,8 @@ TEST_CASE("Escaped element signature parsing", "[signature]")
 TEST_CASE("Element value signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("42", blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "42", blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -309,7 +330,8 @@ TEST_CASE("Element value signature parsing", "[signature]")
 TEST_CASE("Element attributes signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("(number)", blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "(number)", blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -326,8 +348,8 @@ TEST_CASE("Element attributes signature parsing", "[signature]")
 TEST_CASE("Element attributes description signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse("(number) - something () cool", blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "(number) - something () cool", blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -344,8 +366,8 @@ TEST_CASE("Element attributes description signature parsing", "[signature]")
 TEST_CASE("Property signature parsing with element traits", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse(PropertySignatureFixture, blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        PropertySignatureFixture, blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -364,7 +386,8 @@ TEST_CASE("Property signature parsing with element traits", "[signature]")
 TEST_CASE("Property signature parsing without identifier", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("(x)", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "(x)", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -381,7 +404,8 @@ TEST_CASE("Property signature parsing without identifier", "[signature]")
 TEST_CASE("Property signature parsing without a value", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("id: (number)", blueprint, PropertyMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "id: (number)", blueprint, PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -395,15 +419,18 @@ TEST_CASE("Property signature parsing without a value", "[signature]")
     REQUIRE(signature.remainingContent.empty());
 }
 
-TEST_CASE("Element signature parsing without value and attributes", "[signature]")
+TEST_CASE(
+    "Element signature parsing without value and attributes", "[signature]")
 {
     mdp::MarkdownNode source(mdp::RootMarkdownNodeType, NULL, "");
-    mdp::MarkdownNode paragraph(mdp::ParagraphMarkdownNodeType, &source, "- content is the king");
+    mdp::MarkdownNode paragraph(
+        mdp::ParagraphMarkdownNodeType, &source, "- content is the king");
 
     source.children().push_back(paragraph);
 
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature = SignatureParserHelper::parse("", blueprint, ElementMemberTypeTraits, &source);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "", blueprint, ElementMemberTypeTraits, &source);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.size() == 1);
@@ -420,8 +447,8 @@ TEST_CASE("Escaped array element signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
 
-    scpl::Signature signature
-        = SignatureParserHelper::parse("`1 `, 00 ``2, `3` da(t)a`` 45 ", blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "`1 `, 00 ``2, `3` da(t)a`` 45 ", blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -440,7 +467,9 @@ TEST_CASE("Unescaped array element signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
     scpl::Signature signature
-        = SignatureParserHelper::parse("1 , 2,3 (optional, array) - numbers", blueprint, ElementMemberTypeTraits);
+        = SignatureParserHelper::parse("1 , 2,3 (optional, array) - numbers",
+            blueprint,
+            ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -461,8 +490,8 @@ TEST_CASE("Unescaped array element signature parsing", "[signature]")
 TEST_CASE("Escaped attributes signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::Signature signature
-        = SignatureParserHelper::parse("1 (`optio)nal, array` , fixed)", blueprint, ElementMemberTypeTraits);
+    scpl::Signature signature = SignatureParserHelper::parse(
+        "1 (`optio)nal, array` , fixed)", blueprint, ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -482,7 +511,9 @@ TEST_CASE("Attributes with many brackets signature parsing", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
     scpl::Signature signature = SignatureParserHelper::parse(
-        "1 ([op(t[io]na)l, p][], [A](http://a.com))", blueprint, ElementMemberTypeTraits);
+        "1 ([op(t[io]na)l, p][], [A](http://a.com))",
+        blueprint,
+        ElementMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -501,8 +532,11 @@ TEST_CASE("Attributes with many brackets signature parsing", "[signature]")
 TEST_CASE("Identifier and values only", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
-    scpl::SignatureTraits::Traits traits = scpl::SignatureTraits::IdentifierTrait | scpl::SignatureTraits::ValuesTrait;
-    scpl::Signature signature = SignatureParserHelper::parse("Sample: 10 (1), 20", blueprint, traits);
+    scpl::SignatureTraits::Traits traits
+        = scpl::SignatureTraits::IdentifierTrait
+        | scpl::SignatureTraits::ValuesTrait;
+    scpl::Signature signature
+        = SignatureParserHelper::parse("Sample: 10 (1), 20", blueprint, traits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());
@@ -521,7 +555,9 @@ TEST_CASE("Identifier with an underscore", "[signature]")
 {
     ParseResult<Blueprint> blueprint;
     scpl::Signature signature
-        = SignatureParserHelper::parse("site_admin: false (boolean, default)", blueprint, PropertyMemberTypeTraits);
+        = SignatureParserHelper::parse("site_admin: false (boolean, default)",
+            blueprint,
+            PropertyMemberTypeTraits);
 
     REQUIRE(blueprint.report.error.code == Error::OK);
     REQUIRE(blueprint.report.warnings.empty());

--- a/test/test-StringUtility.cc
+++ b/test/test-StringUtility.cc
@@ -36,8 +36,10 @@ TEST_CASE("Templates for compare equality", "[utility]")
 
     SECTION("Both version should not throw while testing diferent types")
     {
-        REQUIRE_NOTHROW(IsEqual()('a', 1));  // allow compare diferent types - not throw
-        REQUIRE_NOTHROW(IsIEqual()('a', 1)); // allow compare diferent types - not throw
+        REQUIRE_NOTHROW(
+            IsEqual()('a', 1)); // allow compare diferent types - not throw
+        REQUIRE_NOTHROW(
+            IsIEqual()('a', 1)); // allow compare diferent types - not throw
     }
 }
 
@@ -45,22 +47,28 @@ TEST_CASE("Container comparation", "[utility]")
 {
     REQUIRE(MatchContainers(std::string("abc"), std::string("abc"), IsEqual()));
 
-    REQUIRE_FALSE(MatchContainers(std::string("ABC"), std::string("abc"), IsEqual()));
+    REQUIRE_FALSE(
+        MatchContainers(std::string("ABC"), std::string("abc"), IsEqual()));
 
-    REQUIRE(MatchContainers(std::string("abc"), std::string("abc"), IsIEqual()));
-    REQUIRE(MatchContainers(std::string("abc"), std::string("ABC"), IsIEqual()));
+    REQUIRE(
+        MatchContainers(std::string("abc"), std::string("abc"), IsIEqual()));
+    REQUIRE(
+        MatchContainers(std::string("abc"), std::string("ABC"), IsIEqual()));
 
-    REQUIRE_FALSE(MatchContainers(std::string("def"), std::string("ABC"), IsIEqual()));
+    REQUIRE_FALSE(
+        MatchContainers(std::string("def"), std::string("ABC"), IsIEqual()));
 }
 
 TEST_CASE("Comapare string", "[utility]")
 {
     REQUIRE(Equal<std::string>()(std::string("abc"), std::string("abc")));
-    REQUIRE_FALSE(Equal<std::string>()(std::string("abcd"), std::string("abc")));
+    REQUIRE_FALSE(
+        Equal<std::string>()(std::string("abcd"), std::string("abc")));
 
     REQUIRE(IEqual<std::string>()(std::string("abc"), std::string("ABC")));
     REQUIRE(IEqual<std::string>()(std::string("ABC"), std::string("ABC")));
-    REQUIRE_FALSE(IEqual<std::string>()(std::string("abcd"), std::string("abc")));
+    REQUIRE_FALSE(
+        IEqual<std::string>()(std::string("abcd"), std::string("abc")));
 }
 
 TEST_CASE("Remove markdown link")

--- a/test/test-SymbolIdentifier.cc
+++ b/test/test-SymbolIdentifier.cc
@@ -23,11 +23,19 @@ TEST_CASE("Punctuation in identifiers", "[symbol_identifier]")
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.name == "Parcel's sticker @#!$%^&*=-?><,.~`\"'");
     REQUIRE(resource.uriTemplate == "/");
     REQUIRE(resource.actions.empty());
@@ -41,7 +49,10 @@ TEST_CASE("Non ASCII characters in identifiers", "[symbol_identifier]")
     //");
 
     // "Kategorii in Russian"
-    mdp::ByteBuffer source = "# \xD0\x9A\xD0\xB0\xD1\x82\xD0\xB5\xD0\xB3\xD0\xBE\xD1\x80\xD0\xB8\xD0\xB8 [/]\n";
+    mdp::ByteBuffer source
+        = "# "
+          "\xD0\x9A\xD0\xB0\xD1\x82\xD0\xB5\xD0\xB3\xD0\xBE\xD1\x80\xD0\xB8\xD0"
+          "\xB8 [/]\n";
 
     ParseResult<Blueprint> blueprint;
     parse(source, 0, blueprint);
@@ -50,11 +61,19 @@ TEST_CASE("Non ASCII characters in identifiers", "[symbol_identifier]")
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.name == "\xD0\x9A\xD0\xB0\xD1\x82\xD0\xB5\xD0\xB3\xD0\xBE\xD1\x80\xD0\xB8\xD0\xB8");
     REQUIRE(resource.uriTemplate == "/");
     REQUIRE(resource.actions.empty());

--- a/test/test-UriTemplateParser.cc
+++ b/test/test-UriTemplateParser.cc
@@ -11,7 +11,8 @@
 
 using namespace snowcrash;
 
-TEST_CASE("Parse a valid uri into seperate parts", "[validuriparser][issue][79]")
+TEST_CASE(
+    "Parse a valid uri into seperate parts", "[validuriparser][issue][79]")
 {
 
     const snowcrash::URI uri = "http://www.test.com/other/{id}";
@@ -27,7 +28,8 @@ TEST_CASE("Parse a valid uri into seperate parts", "[validuriparser][issue][79]"
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE("Parse an invalid uri into seperate parts", "[invaliduriparser][issue][79]")
+TEST_CASE(
+    "Parse an invalid uri into seperate parts", "[invaliduriparser][issue][79]")
 {
 
     const snowcrash::URI uri = "http://www.test.com/other/{id}[2]";
@@ -43,7 +45,8 @@ TEST_CASE("Parse an invalid uri into seperate parts", "[invaliduriparser][issue]
     REQUIRE(result.report.warnings.size() == 1);
 }
 
-TEST_CASE("Parse uri template for invalid format curly brackets (nested brackets)",
+TEST_CASE(
+    "Parse uri template for invalid format curly brackets (nested brackets)",
     "[invalidcurlybracketparsingnested][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/{id{}}";
@@ -57,7 +60,9 @@ TEST_CASE("Parse uri template for invalid format curly brackets (nested brackets
     REQUIRE(result.report.warnings.size() == 1);
 }
 
-TEST_CASE("Parse uri template for invalid format curly brackets (missing end bracket)",
+TEST_CASE(
+    "Parse uri template for invalid format curly brackets (missing end "
+    "bracket)",
     "[invalidcurlybracketparsingmissingendbracket][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/{id";
@@ -85,10 +90,13 @@ TEST_CASE("Parse uri template for supported level one variable expansion",
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE("Parse uri template for supported variables with % encoding and explode modifier",
+TEST_CASE(
+    "Parse uri template for supported variables with % encoding and explode "
+    "modifier",
     "[supportedpercentencodedvariablesandexplodemodifier][issue][78]")
 {
-    const snowcrash::URI uri = "http://www.test.com/{id}/{?test%20one,test%20two*}";
+    const snowcrash::URI uri
+        = "http://www.test.com/{id}/{?test%20one,test%20two*}";
 
     URITemplateParser parser;
     ParsedURITemplate result;
@@ -99,9 +107,11 @@ TEST_CASE("Parse uri template for supported variables with % encoding and explod
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE("Parse uri template for invalid % encoding", "[invalidpercentencoding][issue][78]")
+TEST_CASE("Parse uri template for invalid % encoding",
+    "[invalidpercentencoding][issue][78]")
 {
-    const snowcrash::URI uri = "http://www.test.com/{id}/{?test%20one,test%2Ztwo}";
+    const snowcrash::URI uri
+        = "http://www.test.com/{id}/{?test%20one,test%2Ztwo}";
 
     URITemplateParser parser;
     ParsedURITemplate result;
@@ -112,7 +122,8 @@ TEST_CASE("Parse uri template for invalid % encoding", "[invalidpercentencoding]
     REQUIRE(result.report.warnings.size() == 1);
 }
 
-TEST_CASE("Parse uri template for invalid expansion", "[invalidexpression][issue][78]")
+TEST_CASE("Parse uri template for invalid expansion",
+    "[invalidexpression][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/{@id}/{|test}";
 
@@ -139,7 +150,9 @@ TEST_CASE("Parse uri template for supported level two fragment expansion",
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE("Parse uri template for supported level three form style query string expansion",
+TEST_CASE(
+    "Parse uri template for supported level three form style query string "
+    "expansion",
     "[supportedlevelthreeformstylequeryexpansionexpression][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/path{?varone,vartwo}";
@@ -181,7 +194,8 @@ TEST_CASE("Parse uri template for unsupported level three label expansion",
     REQUIRE(result.report.warnings.size() == 1);
 }
 
-TEST_CASE("Parse uri template for unsupported level three path segment expansion",
+TEST_CASE(
+    "Parse uri template for unsupported level three path segment expansion",
     "[unsupportedlevelthreepathsegmentexpansionexpression][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/path{/varone}";
@@ -195,7 +209,9 @@ TEST_CASE("Parse uri template for unsupported level three path segment expansion
     REQUIRE(result.report.warnings.size() == 1);
 }
 
-TEST_CASE("Parse uri template for unsupported level three path style parameter expansion",
+TEST_CASE(
+    "Parse uri template for unsupported level three path style parameter "
+    "expansion",
     "[unsupportedlevelthreepathstyleparameterexpression][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/path{;varone,vartwo}";
@@ -209,10 +225,13 @@ TEST_CASE("Parse uri template for unsupported level three path style parameter e
     REQUIRE(result.report.warnings.size() == 1);
 }
 
-TEST_CASE("Parse uri template for supported level three form style query continuation expansion",
+TEST_CASE(
+    "Parse uri template for supported level three form style query "
+    "continuation expansion",
     "[supportedlevelthreeformstylequerycontinuationexpression][issue][78]")
 {
-    const snowcrash::URI uri = "http://www.test.com/{id}?path=test{&varone,vartwo}";
+    const snowcrash::URI uri
+        = "http://www.test.com/{id}?path=test{&varone,vartwo}";
 
     URITemplateParser parser;
     ParsedURITemplate result;
@@ -223,8 +242,8 @@ TEST_CASE("Parse uri template for supported level three form style query continu
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE(
-    "Parse uri template for invalid variable name, contains spaces", "[invalidvariablenamecontainingspaces][issue][78]")
+TEST_CASE("Parse uri template for invalid variable name, contains spaces",
+    "[invalidvariablenamecontainingspaces][issue][78]")
 {
     const snowcrash::URI uri = "http://www.test.com/path{?varone, vartwo}";
 
@@ -256,7 +275,8 @@ TEST_CASE("Parse uri template for invalid variable name, contains hyphens",
 TEST_CASE("Parse uri template for invalid variable name, contains assignment",
     "[invalidvariablenamecontainingsassignment][issue][78]")
 {
-    const snowcrash::URITemplate uri = "http://www.test.com/{id}{?varone=vartwo}";
+    const snowcrash::URITemplate uri
+        = "http://www.test.com/{id}{?varone=vartwo}";
 
     URITemplateParser parser;
     ParsedURITemplate result;
@@ -283,7 +303,8 @@ TEST_CASE("Parse uri template for invalid variable name, invalid % encoded",
     REQUIRE(result.report.warnings[0].message == "URI template expression \"?varone%2z\" contains invalid characters. Allowed characters for expressions are A-Z a-z 0-9 _ and percent encoded characters");
 }
 
-TEST_CASE("Parse uri template for variable name containing dot", "[validvariablenamecontainingdot][issue][78]")
+TEST_CASE("Parse uri template for variable name containing dot",
+    "[validvariablenamecontainingdot][issue][78]")
 {
     const snowcrash::URITemplate uri = "http://www.test.com/{id}{?varone.data}";
 
@@ -296,10 +317,13 @@ TEST_CASE("Parse uri template for variable name containing dot", "[validvariable
     REQUIRE(result.report.warnings.size() == 0);
 }
 
-TEST_CASE("Parse uri template for invalid variable name containing multiple contiguous dots",
+TEST_CASE(
+    "Parse uri template for invalid variable name containing multiple "
+    "contiguous dots",
     "[invalidvariablenamecontiguousdots][issue][78]")
 {
-    const snowcrash::URITemplate uri = "http://www.test.com/{id}{?varone..data}";
+    const snowcrash::URITemplate uri
+        = "http://www.test.com/{id}{?varone..data}";
 
     URITemplateParser parser;
     ParsedURITemplate result;

--- a/test/test-ValuesParser.cc
+++ b/test/test-ValuesParser.cc
@@ -26,14 +26,16 @@ TEST_CASE("Recognize values signature", "[values]")
     markdownParser.parse(ValuesFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
-    SectionType sectionType = SectionProcessor<Values>::sectionType(markdownAST.children().begin());
+    SectionType sectionType
+        = SectionProcessor<Values>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == ValuesSectionType);
 }
 
 TEST_CASE("Parse canonical values", "[values]")
 {
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(ValuesFixture, ValuesSectionType, values, ExportSourcemapOption);
+    SectionParserHelper<Values, ValuesParser>::parse(
+        ValuesFixture, ValuesSectionType, values, ExportSourcemapOption);
 
     REQUIRE(values.report.error.code == Error::OK);
     CHECK(values.report.warnings.empty());
@@ -57,7 +59,8 @@ TEST_CASE("Warn superfluous content in values attribute", "[values]")
           "    + `Hello`\n";
 
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values, ExportSourcemapOption);
+    SectionParserHelper<Values, ValuesParser>::parse(
+        source, ValuesSectionType, values, ExportSourcemapOption);
 
     REQUIRE(values.report.error.code == Error::OK);
     REQUIRE(values.report.warnings.size() == 1);
@@ -79,7 +82,8 @@ TEST_CASE("Warn about illegal entities in values attribute", "[values]")
           "    + `Hi`\n";
 
     ParseResult<Values> values;
-    SectionParserHelper<Values, ValuesParser>::parse(source, ValuesSectionType, values, ExportSourcemapOption);
+    SectionParserHelper<Values, ValuesParser>::parse(
+        source, ValuesSectionType, values, ExportSourcemapOption);
 
     REQUIRE(values.report.error.code == Error::OK);
     REQUIRE(values.report.warnings.size() == 1);

--- a/test/test-Warnings.cc
+++ b/test/test-Warnings.cc
@@ -52,7 +52,8 @@ TEST_CASE("Warn about brackets in URI template", "[warnings][79]")
     REQUIRE(blueprint.report.warnings[0].code == URIWarning);
 }
 
-TEST_CASE("Warn about unsupported uri template label expansion", "[warnings][78]")
+TEST_CASE(
+    "Warn about unsupported uri template label expansion", "[warnings][78]")
 {
     mdp::ByteBuffer source
         = "FORMAT: 1A\n"
@@ -72,7 +73,8 @@ TEST_CASE("Warn about unsupported uri template label expansion", "[warnings][78]
     REQUIRE(blueprint.report.warnings[0].code == URIWarning);
 }
 
-TEST_CASE("Warn about unsupported uri template in abbreviated blueprint", "[warnings][78]")
+TEST_CASE("Warn about unsupported uri template in abbreviated blueprint",
+    "[warnings][78]")
 {
     mdp::ByteBuffer source
         = "FORMAT: 1A\n"

--- a/test/test-csnowcrash.cc
+++ b/test/test-csnowcrash.cc
@@ -41,10 +41,13 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     REQUIRE(sc_warnings_size(warns) == 1);
 
     const sc_warning_t* warn = sc_warning_handler(warns, 0);
-    REQUIRE(std::string(sc_warning_message(warn)) == "the resource '/message' is already defined");
+    REQUIRE(std::string(sc_warning_message(warn))
+        == "the resource '/message' is already defined");
 
-    const sc_metadata_collection_t* meta_col = sc_metadata_collection_handle(blueprint);
-    const sc_sm_metadata_collection_t* sm_meta_col = sc_sm_metadata_collection_handle(sm_blueprint);
+    const sc_metadata_collection_t* meta_col
+        = sc_metadata_collection_handle(blueprint);
+    const sc_sm_metadata_collection_t* sm_meta_col
+        = sc_sm_metadata_collection_handle(sm_blueprint);
 
     REQUIRE(sc_metadata_collection_size(meta_col) == 1);
     REQUIRE(sc_sm_metadata_collection_size(sm_meta_col) == 1);
@@ -53,29 +56,36 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     REQUIRE(std::string(sc_metadata_key(meta)) == "FORMAT");
     REQUIRE(std::string(sc_metadata_value(meta)) == "1A");
 
-    const sc_source_map_t* sm_meta = sc_sm_metadata(sc_sm_metadata_handle(sm_meta_col, 0));
+    const sc_source_map_t* sm_meta
+        = sc_sm_metadata(sc_sm_metadata_handle(sm_meta_col, 0));
 
     REQUIRE(sc_source_map_size(sm_meta) == 1);
     REQUIRE(sc_source_map_location(sm_meta, 0) == 0);
     REQUIRE(sc_source_map_length(sm_meta, 0) == 12);
 
-    const sc_resource_group_collection_t* res_gr_col = sc_resource_group_collection_handle(blueprint);
-    const sc_sm_resource_group_collection_t* sm_res_gr_col = sc_sm_resource_group_collection_handle(sm_blueprint);
+    const sc_resource_group_collection_t* res_gr_col
+        = sc_resource_group_collection_handle(blueprint);
+    const sc_sm_resource_group_collection_t* sm_res_gr_col
+        = sc_sm_resource_group_collection_handle(sm_blueprint);
 
     REQUIRE(sc_resource_group_collection_size(res_gr_col) == 2);
     REQUIRE(sc_sm_resource_group_collection_size(sm_res_gr_col) == 2);
 
     const sc_resource_group_t* res_gr = sc_resource_group_handle(res_gr_col, 0);
-    const sc_sm_resource_group_t* sm_res_gr = sc_sm_resource_group_handle(sm_res_gr_col, 0);
+    const sc_sm_resource_group_t* sm_res_gr
+        = sc_sm_resource_group_handle(sm_res_gr_col, 0);
 
     REQUIRE(std::string(sc_resource_group_name(res_gr)) == "");
 
-    const sc_source_map_t* sm_res_gr_name = sc_sm_resource_group_name(sm_res_gr);
+    const sc_source_map_t* sm_res_gr_name
+        = sc_sm_resource_group_name(sm_res_gr);
 
     REQUIRE(sc_source_map_size(sm_res_gr_name) == 0);
 
-    const sc_resource_collection_t* re_col = sc_resource_collection_handle(res_gr);
-    const sc_sm_resource_collection_t* sm_re_col = sc_sm_resource_collection_handle(sm_res_gr);
+    const sc_resource_collection_t* re_col
+        = sc_resource_collection_handle(res_gr);
+    const sc_sm_resource_collection_t* sm_re_col
+        = sc_sm_resource_collection_handle(sm_res_gr);
 
     REQUIRE(sc_resource_collection_size(re_col) == 1);
     REQUIRE(sc_sm_resource_collection_size(sm_re_col) == 1);
@@ -85,14 +95,16 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
 
     REQUIRE(std::string(sc_resource_uritemplate(res)) == "/message");
 
-    const sc_source_map_t* sm_res_uritemplate = sc_sm_resource_uritemplate(sm_res);
+    const sc_source_map_t* sm_res_uritemplate
+        = sc_sm_resource_uritemplate(sm_res);
 
     REQUIRE(sc_source_map_size(sm_res_uritemplate) == 1);
     REQUIRE(sc_source_map_location(sm_res_uritemplate, 0) == 47);
     REQUIRE(sc_source_map_length(sm_res_uritemplate, 0) == 22);
 
     const sc_action_collection_t* act_col = sc_action_collection_handle(res);
-    const sc_sm_action_collection_t* sm_act_col = sc_sm_action_collection_handle(sm_res);
+    const sc_sm_action_collection_t* sm_act_col
+        = sc_sm_action_collection_handle(sm_res);
 
     REQUIRE(sc_action_collection_size(act_col) == 1);
     REQUIRE(sc_sm_action_collection_size(sm_act_col) == 1);
@@ -108,23 +120,30 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     REQUIRE(sc_source_map_location(sm_act_httpmethod, 0) == 69);
     REQUIRE(sc_source_map_length(sm_act_httpmethod, 0) == 8);
 
-    const sc_transaction_example_collection_t* trans_col = sc_transaction_example_collection_handle(act);
-    const sc_sm_transaction_example_collection_t* sm_trans_col = sc_sm_transaction_example_collection_handle(sm_act);
+    const sc_transaction_example_collection_t* trans_col
+        = sc_transaction_example_collection_handle(act);
+    const sc_sm_transaction_example_collection_t* sm_trans_col
+        = sc_sm_transaction_example_collection_handle(sm_act);
 
     REQUIRE(sc_transaction_example_collection_size(trans_col) == 1);
     REQUIRE(sc_sm_transaction_example_collection_size(sm_trans_col) == 1);
 
-    const sc_transaction_example_t* trans = sc_transaction_example_handle(trans_col, 0);
-    const sc_sm_transaction_example_t* sm_trans = sc_sm_transaction_example_handle(sm_trans_col, 0);
+    const sc_transaction_example_t* trans
+        = sc_transaction_example_handle(trans_col, 0);
+    const sc_sm_transaction_example_t* sm_trans
+        = sc_sm_transaction_example_handle(sm_trans_col, 0);
 
     REQUIRE(std::string(sc_transaction_example_name(trans)) == "");
 
-    const sc_source_map_t* sm_trans_name = sc_sm_transaction_example_name(sm_trans);
+    const sc_source_map_t* sm_trans_name
+        = sc_sm_transaction_example_name(sm_trans);
 
     REQUIRE(sc_source_map_size(sm_trans_name) == 0);
 
-    const sc_payload_collection_t* resp_col = sc_payload_collection_handle_responses(trans);
-    const sc_sm_payload_collection_t* sm_resp_col = sc_sm_payload_collection_handle_responses(sm_trans);
+    const sc_payload_collection_t* resp_col
+        = sc_payload_collection_handle_responses(trans);
+    const sc_sm_payload_collection_t* sm_resp_col
+        = sc_sm_payload_collection_handle_responses(sm_trans);
 
     REQUIRE(sc_payload_collection_size(resp_col) == 1);
     REQUIRE(sc_sm_payload_collection_size(sm_resp_col) == 1);
@@ -155,8 +174,10 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     REQUIRE(sc_source_map_location(sm_resp_body, 0) == 110);
     REQUIRE(sc_source_map_length(sm_resp_body, 0) == 17);
 
-    const sc_header_collection_t* header_col = sc_header_collection_handle_payload(resp);
-    const sc_sm_header_collection_t* sm_header_col = sc_sm_header_collection_handle_payload(sm_resp);
+    const sc_header_collection_t* header_col
+        = sc_header_collection_handle_payload(resp);
+    const sc_sm_header_collection_t* sm_header_col
+        = sc_sm_header_collection_handle_payload(sm_resp);
 
     REQUIRE(sc_header_collection_size(header_col) == 1);
     REQUIRE(sc_sm_header_collection_size(sm_header_col) == 1);
@@ -166,7 +187,8 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     REQUIRE(std::string(sc_header_key(header)) == "Content-Type");
     REQUIRE(std::string(sc_header_value(header)) == "text/plain");
 
-    const sc_source_map_t* sm_header = sc_sm_header(sc_sm_header_handle(sm_header_col, 0));
+    const sc_source_map_t* sm_header
+        = sc_sm_header(sc_sm_header_handle(sm_header_col, 0));
 
     REQUIRE(sc_source_map_size(sm_header) == 1);
     REQUIRE(sc_source_map_location(sm_header, 0) == 79);
@@ -177,7 +199,9 @@ TEST_CASE("Parse simple blueprint with C interface", "[cinterface]")
     sc_report_free(report);
 }
 
-TEST_CASE("Parse blueprint with multiple requests and responses via C interface", "[cinterface]")
+TEST_CASE(
+    "Parse blueprint with multiple requests and responses via C interface",
+    "[cinterface]")
 {
     const std::string blueprintSource
         = "# /resource\n"
@@ -210,23 +234,29 @@ TEST_CASE("Parse blueprint with multiple requests and responses via C interface"
         &blueprint,
         &sm_blueprint);
 
-    const sc_resource_group_collection_t* res_gr_col = sc_resource_group_collection_handle(blueprint);
-    const sc_sm_resource_group_collection_t* sm_res_gr_col = sc_sm_resource_group_collection_handle(sm_blueprint);
+    const sc_resource_group_collection_t* res_gr_col
+        = sc_resource_group_collection_handle(blueprint);
+    const sc_sm_resource_group_collection_t* sm_res_gr_col
+        = sc_sm_resource_group_collection_handle(sm_blueprint);
 
     REQUIRE(sc_resource_group_collection_size(res_gr_col) == 1);
     REQUIRE(sc_sm_resource_group_collection_size(sm_res_gr_col) == 1);
 
     const sc_resource_group_t* res_gr = sc_resource_group_handle(res_gr_col, 0);
-    const sc_sm_resource_group_t* sm_res_gr = sc_sm_resource_group_handle(sm_res_gr_col, 0);
+    const sc_sm_resource_group_t* sm_res_gr
+        = sc_sm_resource_group_handle(sm_res_gr_col, 0);
 
     REQUIRE(std::string(sc_resource_group_name(res_gr)) == "");
 
-    const sc_source_map_t* sm_res_gr_name = sc_sm_resource_group_name(sm_res_gr);
+    const sc_source_map_t* sm_res_gr_name
+        = sc_sm_resource_group_name(sm_res_gr);
 
     REQUIRE(sc_source_map_size(sm_res_gr_name) == 0);
 
-    const sc_resource_collection_t* re_col = sc_resource_collection_handle(res_gr);
-    const sc_sm_resource_collection_t* sm_re_col = sc_sm_resource_collection_handle(sm_res_gr);
+    const sc_resource_collection_t* re_col
+        = sc_resource_collection_handle(res_gr);
+    const sc_sm_resource_collection_t* sm_re_col
+        = sc_sm_resource_collection_handle(sm_res_gr);
 
     REQUIRE(sc_resource_collection_size(re_col) == 1);
     REQUIRE(sc_sm_resource_collection_size(sm_re_col) == 1);
@@ -236,14 +266,16 @@ TEST_CASE("Parse blueprint with multiple requests and responses via C interface"
 
     REQUIRE(std::string(sc_resource_uritemplate(res)) == "/resource");
 
-    const sc_source_map_t* sm_res_uritemplate = sc_sm_resource_uritemplate(sm_res);
+    const sc_source_map_t* sm_res_uritemplate
+        = sc_sm_resource_uritemplate(sm_res);
 
     REQUIRE(sc_source_map_size(sm_res_uritemplate) == 1);
     REQUIRE(sc_source_map_location(sm_res_uritemplate, 0) == 0);
     REQUIRE(sc_source_map_length(sm_res_uritemplate, 0) == 12);
 
     const sc_action_collection_t* act_col = sc_action_collection_handle(res);
-    const sc_sm_action_collection_t* sm_act_col = sc_sm_action_collection_handle(sm_res);
+    const sc_sm_action_collection_t* sm_act_col
+        = sc_sm_action_collection_handle(sm_res);
 
     REQUIRE(sc_action_collection_size(act_col) == 1);
     REQUIRE(sc_sm_action_collection_size(sm_act_col) == 1);
@@ -259,8 +291,10 @@ TEST_CASE("Parse blueprint with multiple requests and responses via C interface"
     REQUIRE(sc_source_map_location(sm_act_httpmethod, 0) == 12);
     REQUIRE(sc_source_map_length(sm_act_httpmethod, 0) == 8);
 
-    const sc_transaction_example_collection_t* trans_col = sc_transaction_example_collection_handle(act);
-    const sc_sm_transaction_example_collection_t* sm_trans_col = sc_sm_transaction_example_collection_handle(sm_act);
+    const sc_transaction_example_collection_t* trans_col
+        = sc_transaction_example_collection_handle(act);
+    const sc_sm_transaction_example_collection_t* sm_trans_col
+        = sc_sm_transaction_example_collection_handle(sm_act);
 
     REQUIRE(sc_transaction_example_collection_size(trans_col) == 2);
     REQUIRE(sc_sm_transaction_example_collection_size(sm_trans_col) == 2);
@@ -302,11 +336,15 @@ TEST_CASE("CBlueprint issue on sc_resource_group_handle", "[cinterface]")
 
     sc_c_parse(blueprintSource.c_str(), 0, &report, &blueprint, &sm_blueprint);
 
-    const sc_resource_group_collection_t* res_gr_col = sc_resource_group_collection_handle(blueprint);
-    const sc_resource_group_t* res_gr1 = sc_resource_group_handle(res_gr_col, 0);
-    const sc_resource_group_t* res_gr2 = sc_resource_group_handle(res_gr_col, 1);
+    const sc_resource_group_collection_t* res_gr_col
+        = sc_resource_group_collection_handle(blueprint);
+    const sc_resource_group_t* res_gr1
+        = sc_resource_group_handle(res_gr_col, 0);
+    const sc_resource_group_t* res_gr2
+        = sc_resource_group_handle(res_gr_col, 1);
 
-    const sc_sm_resource_group_collection_t* sm_res_gr_col = sc_sm_resource_group_collection_handle(sm_blueprint);
+    const sc_sm_resource_group_collection_t* sm_res_gr_col
+        = sc_sm_resource_group_collection_handle(sm_blueprint);
 
     REQUIRE(sc_sm_resource_group_collection_size(sm_res_gr_col) == 0);
     REQUIRE(sc_resource_group_collection_size(res_gr_col) == 2);
@@ -314,10 +352,12 @@ TEST_CASE("CBlueprint issue on sc_resource_group_handle", "[cinterface]")
     REQUIRE(std::string(sc_resource_group_name(res_gr1)) == "A");
     REQUIRE(std::string(sc_resource_group_name(res_gr2)) == "B");
 
-    const sc_resource_collection_t* res_col1 = sc_resource_collection_handle(res_gr1);
+    const sc_resource_collection_t* res_col1
+        = sc_resource_collection_handle(res_gr1);
     REQUIRE(sc_resource_collection_size(res_col1) == 1);
 
-    const sc_resource_collection_t* res_col2 = sc_resource_collection_handle(res_gr2);
+    const sc_resource_collection_t* res_col2
+        = sc_resource_collection_handle(res_gr2);
     REQUIRE(sc_resource_collection_size(res_col2) == 2);
 
     sc_sm_blueprint_free(sm_blueprint);
@@ -325,7 +365,8 @@ TEST_CASE("CBlueprint issue on sc_resource_group_handle", "[cinterface]")
     sc_report_free(report);
 }
 
-TEST_CASE("Parse blueprint with multiple reference via C interface", "[cinterface]")
+TEST_CASE(
+    "Parse blueprint with multiple reference via C interface", "[cinterface]")
 {
     const std::string blueprintSource
         = "#api name\n\n"
@@ -350,13 +391,15 @@ TEST_CASE("Parse blueprint with multiple reference via C interface", "[cinterfac
 
     sc_c_parse(blueprintSource.c_str(), 0, &report, &blueprint, &sm_blueprint);
 
-    const sc_resource_group_collection_t* res_gr_col = sc_resource_group_collection_handle(blueprint);
+    const sc_resource_group_collection_t* res_gr_col
+        = sc_resource_group_collection_handle(blueprint);
     REQUIRE(sc_resource_group_collection_size(res_gr_col) == 1);
 
     const sc_resource_group_t* res_gr = sc_resource_group_handle(res_gr_col, 0);
     REQUIRE(std::string(sc_resource_group_name(res_gr)) == "");
 
-    const sc_resource_collection_t* sm_res_gr_col = sc_resource_collection_handle(res_gr);
+    const sc_resource_collection_t* sm_res_gr_col
+        = sc_resource_collection_handle(res_gr);
     REQUIRE(sc_resource_collection_size(sm_res_gr_col) == 4);
 
     const sc_resource_t* res = sc_resource_handle(sm_res_gr_col, 1);
@@ -370,13 +413,16 @@ TEST_CASE("Parse blueprint with multiple reference via C interface", "[cinterfac
     REQUIRE(std::string(sc_action_httpmethod(action)) == "GET");
     REQUIRE(std::string(sc_action_name(action)) == "Retrieve");
 
-    const sc_transaction_example_collection_t* example_col = sc_transaction_example_collection_handle(action);
+    const sc_transaction_example_collection_t* example_col
+        = sc_transaction_example_collection_handle(action);
     REQUIRE(sc_transaction_example_collection_size(example_col) == 1);
 
-    const sc_transaction_example_t* example = sc_transaction_example_handle(example_col, 0);
+    const sc_transaction_example_t* example
+        = sc_transaction_example_handle(example_col, 0);
     REQUIRE(std::string(sc_transaction_example_name(example)) == "");
 
-    const sc_payload_collection_t* response_col = sc_payload_collection_handle_responses(example);
+    const sc_payload_collection_t* response_col
+        = sc_payload_collection_handle_responses(example);
     REQUIRE(sc_payload_collection_size(response_col) == 1);
 
     const sc_payload_t* response = sc_payload_handle(response_col, 0);

--- a/test/test-snowcrash.cc
+++ b/test/test-snowcrash.cc
@@ -51,11 +51,19 @@ TEST_CASE("Parse simple blueprint", "[parser]")
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name.empty());
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.actions.size() == 1);
 
@@ -86,7 +94,8 @@ TEST_CASE("Parse blueprint with unsupported characters", "[parser]")
     SourceMapHelper::check(blueprint2.report.error.location, 4, 1);
 }
 
-TEST_CASE("Do not report duplicate response when media type differs", "[method][14]")
+TEST_CASE(
+    "Do not report duplicate response when media type differs", "[method][14]")
 {
     mdp::ByteBuffer source
         = "# GET /message\n"
@@ -118,11 +127,19 @@ TEST_CASE("Support description ending with an list item", "[parser][8]")
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description == "+ a description item");
     REQUIRE(resource.actions[0].examples.size() == 1);
@@ -131,7 +148,8 @@ TEST_CASE("Support description ending with an list item", "[parser][8]")
     REQUIRE(resource.actions[0].examples[0].responses[0].body == "...\n");
 }
 
-TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[parser][13]")
+TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes",
+    "[parser][13]")
 {
     mdp::ByteBuffer source
         = "# GET /1\n"
@@ -144,11 +162,19 @@ TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples.size() == 1);
@@ -204,17 +230,26 @@ TEST_CASE("Parse adjacent asset blocks", "[parser][9]")
     REQUIRE(blueprint.report.warnings.size() == 2);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 2);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
-    REQUIRE(resource.actions[0].examples[0].responses[0].body == "asset\n\npre\n\n");
+    REQUIRE(resource.actions[0].examples[0].responses[0].body
+        == "asset\n\npre\n\n");
     REQUIRE(resource.actions[0].examples[0].responses[1].name == "404");
     REQUIRE(resource.actions[0].examples[0].responses[1].body == "Not found\n");
 }
@@ -234,11 +269,19 @@ TEST_CASE("Parse adjacent asset list blocks", "[parser][9]")
     REQUIRE(blueprint.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -267,11 +310,19 @@ TEST_CASE("Parse adjacent nested asset blocks", "[parser][9]")
     REQUIRE(blueprint.report.warnings[1].code == IndentationWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -279,7 +330,8 @@ TEST_CASE("Parse adjacent nested asset blocks", "[parser][9]")
     REQUIRE(resource.actions[0].examples[0].responses[0].body == "A\nB\nC\n\n");
 }
 
-TEST_CASE("Exception while parsing a blueprint with leading empty space", "[regression][parser]")
+TEST_CASE("Exception while parsing a blueprint with leading empty space",
+    "[regression][parser]")
 {
     mdp::ByteBuffer source
         = "\n"
@@ -306,7 +358,8 @@ TEST_CASE("Invalid source map without closing newline", "[regression][parser]")
     SourceMapHelper::check(blueprint.report.warnings[0].location, 0, 13);
 }
 
-TEST_CASE("Warn about missing API name if there is an API description", "[parser][regression]")
+TEST_CASE("Warn about missing API name if there is an API description",
+    "[parser][regression]")
 {
     mdp::ByteBuffer source1 = "Hello World\n";
 
@@ -365,11 +418,19 @@ TEST_CASE("Resource with incorrect URI segfault", "[parser][regression]")
     REQUIRE(blueprint.node.description.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name == "A");
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.copy
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.copy
         == "## Resource [wronguri]\n\n### Retrieve [GET]\n\n+ Response 200");
 }
 
@@ -394,11 +455,19 @@ TEST_CASE("Dangling block not recognized", "[parser][regression][186]")
     REQUIRE(blueprint.node.description.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.name == "A");
     REQUIRE(resource.uriTemplate == "/a");
     REQUIRE(resource.model.body == "    { ... }\n\n");
@@ -425,11 +494,19 @@ TEST_CASE("Ignoring block recovery", "[parser][regression][188]")
     REQUIRE(blueprint.report.warnings[1].code == EmptyDefinitionWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.name == "Note");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].name == "Remove a Note");
@@ -457,12 +534,22 @@ TEST_CASE("Ignoring dangling model assets", "[parser][regression][196]")
     REQUIRE(blueprint.report.warnings[0].code == IndentationWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(1).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(1).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(1).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(1)
+                            .content.resource;
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/B");
     REQUIRE(resource.actions.size() == 1);
@@ -494,31 +581,57 @@ TEST_CASE("Ignoring local media type", "[parser][regression][195]")
     REQUIRE(blueprint.report.warnings[0].code == IgnoringWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first == "Content-Type");
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second == "Y");
+    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first
+        == "Content-Type");
+    REQUIRE(
+        resource.actions[0].examples[0].responses[0].headers[0].second == "Y");
 
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 1);
-    REQUIRE(blueprint.sourceMap.content.elements().collection[0].content.elements().collection.size() == 1);
+    REQUIRE(blueprint.sourceMap.content.elements()
+                .collection[0]
+                .content.elements()
+                .collection.size()
+        == 1);
 
-    SourceMap<Resource> resourceSM
-        = blueprint.sourceMap.content.elements().collection[0].content.elements().collection[0].content.resource;
+    SourceMap<Resource> resourceSM = blueprint.sourceMap.content.elements()
+                                         .collection[0]
+                                         .content.elements()
+                                         .collection[0]
+                                         .content.resource;
     REQUIRE(resourceSM.actions.collection.size() == 1);
     REQUIRE(resourceSM.actions.collection[0].examples.collection.size() == 1);
-    REQUIRE(resourceSM.actions.collection[0].examples.collection[0].responses.collection.size() == 1);
-    REQUIRE(
-        resourceSM.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection.size() == 1);
-    SourceMapHelper::check(
-        resourceSM.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection[0].sourceMap,
+    REQUIRE(resourceSM.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection.size()
+        == 1);
+    REQUIRE(resourceSM.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection[0]
+                .headers.collection.size()
+        == 1);
+    SourceMapHelper::check(resourceSM.actions.collection[0]
+                               .examples.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[0]
+                               .sourceMap,
         11,
         11);
 }
@@ -543,31 +656,57 @@ TEST_CASE("Using local media type", "[parser][regression][195]")
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first == "Content-Type");
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second == "X");
+    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first
+        == "Content-Type");
+    REQUIRE(
+        resource.actions[0].examples[0].responses[0].headers[0].second == "X");
 
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 1);
-    REQUIRE(blueprint.sourceMap.content.elements().collection[0].content.elements().collection.size() == 1);
+    REQUIRE(blueprint.sourceMap.content.elements()
+                .collection[0]
+                .content.elements()
+                .collection.size()
+        == 1);
 
-    SourceMap<Resource> resourceSM
-        = blueprint.sourceMap.content.elements().collection[0].content.elements().collection[0].content.resource;
+    SourceMap<Resource> resourceSM = blueprint.sourceMap.content.elements()
+                                         .collection[0]
+                                         .content.elements()
+                                         .collection[0]
+                                         .content.resource;
     REQUIRE(resourceSM.actions.collection.size() == 1);
     REQUIRE(resourceSM.actions.collection[0].examples.collection.size() == 1);
-    REQUIRE(resourceSM.actions.collection[0].examples.collection[0].responses.collection.size() == 1);
-    REQUIRE(
-        resourceSM.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection.size() == 1);
-    SourceMapHelper::check(
-        resourceSM.actions.collection[0].examples.collection[0].responses.collection[0].headers.collection[0].sourceMap,
+    REQUIRE(resourceSM.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection.size()
+        == 1);
+    REQUIRE(resourceSM.actions.collection[0]
+                .examples.collection[0]
+                .responses.collection[0]
+                .headers.collection.size()
+        == 1);
+    SourceMapHelper::check(resourceSM.actions.collection[0]
+                               .examples.collection[0]
+                               .responses.collection[0]
+                               .headers.collection[0]
+                               .sourceMap,
         53,
         18);
 }
@@ -588,18 +727,28 @@ TEST_CASE("Parse ill-formated header", "[parser][198][regression]")
     REQUIRE(blueprint.report.warnings[0].code == IndentationWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses[0].name == "200");
     REQUIRE(resource.actions[0].examples[0].responses[0].headers.size() == 1);
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first == "Location");
-    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second == "new_url");
+    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].first
+        == "Location");
+    REQUIRE(resource.actions[0].examples[0].responses[0].headers[0].second
+        == "new_url");
 }
 
 TEST_CASE("Overshadow parameters", "[parser][201][regression][parameters]")
@@ -626,11 +775,19 @@ TEST_CASE("Overshadow parameters", "[parser][201][regression][parameters]")
     REQUIRE(blueprint.report.warnings[0].code == RedefinitionWarning);
 
     REQUIRE(blueprint.node.content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 1);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(0)
+                            .content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].parameters.size() == 3);
 
@@ -680,19 +837,35 @@ TEST_CASE("Don't remove link references", "[parser][213]")
     REQUIRE(blueprint.report.warnings.empty());
 
     REQUIRE(blueprint.node.name == "API");
-    REQUIRE(blueprint.node.description == "This is [first example][id]\n\n[id]: http://a.com");
+    REQUIRE(blueprint.node.description
+        == "This is [first example][id]\n\n[id]: http://a.com");
     REQUIRE(blueprint.node.content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(0).attributes.name == "A");
-    REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 2);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::CopyElement);
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).content.copy
+    REQUIRE(blueprint.node.content.elements().at(0).element
+        == Element::CategoryElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().size() == 2);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(0).element
+        == Element::CopyElement);
+    REQUIRE(blueprint.node.content.elements()
+                .at(0)
+                .content.elements()
+                .at(0)
+                .content.copy
         == "This is [second example][id]\n\n[id]: http://b.com");
-    REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(1).element == Element::ResourceElement);
+    REQUIRE(
+        blueprint.node.content.elements().at(0).content.elements().at(1).element
+        == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(1).content.resource;
+    Resource resource = blueprint.node.content.elements()
+                            .at(0)
+                            .content.elements()
+                            .at(1)
+                            .content.resource;
     REQUIRE(resource.uriTemplate == "/a");
-    REQUIRE(resource.description == "This is [third example][id]\n\n[id]: http://c.com");
+    REQUIRE(resource.description
+        == "This is [third example][id]\n\n[id]: http://c.com");
 }
 
 TEST_CASE("Don't mess up sourcemaps when there are references", "[parser][213]")
@@ -713,15 +886,26 @@ TEST_CASE("Don't mess up sourcemaps when there are references", "[parser][213]")
     REQUIRE(blueprint.report.warnings[0].code == EmptyDefinitionWarning);
 
     REQUIRE(blueprint.sourceMap.content.elements().collection.size() == 1);
-    REQUIRE(blueprint.sourceMap.content.elements().collection[0].content.elements().collection.size() == 1);
+    REQUIRE(blueprint.sourceMap.content.elements()
+                .collection[0]
+                .content.elements()
+                .collection.size()
+        == 1);
 
-    SourceMap<Resource> resourceSM
-        = blueprint.sourceMap.content.elements().collection[0].content.elements().collection[0].content.resource;
+    SourceMap<Resource> resourceSM = blueprint.sourceMap.content.elements()
+                                         .collection[0]
+                                         .content.elements()
+                                         .collection[0]
+                                         .content.resource;
     REQUIRE(resourceSM.actions.collection.size() == 1);
-    SourceMapHelper::check(resourceSM.actions.collection[0].method.sourceMap, 111, 8);
+    SourceMapHelper::check(
+        resourceSM.actions.collection[0].method.sourceMap, 111, 8);
 }
 
-TEST_CASE("doesn't crash while parsing response followed by a block quote and heading", "[parser][322]")
+TEST_CASE(
+    "doesn't crash while parsing response followed by a block quote and "
+    "heading",
+    "[parser][322]")
 {
     mdp::ByteBuffer source
         = "# GET /a\n\n"
@@ -736,14 +920,21 @@ TEST_CASE("doesn't crash while parsing response followed by a block quote and he
 
     REQUIRE(blueprint.report.error.code == Error::OK);
 
-    SourceMap<Resource> resourceSM
-        = blueprint.sourceMap.content.elements().collection[0].content.elements().collection[0].content.resource;
+    SourceMap<Resource> resourceSM = blueprint.sourceMap.content.elements()
+                                         .collection[0]
+                                         .content.elements()
+                                         .collection[0]
+                                         .content.resource;
     SourceMap<Action> actionSM = resourceSM.actions.collection[0];
-    SourceMap<Payload> payloadSM = actionSM.examples.collection[0].responses.collection[0];
+    SourceMap<Payload> payloadSM
+        = actionSM.examples.collection[0].responses.collection[0];
     SourceMapHelper::check(payloadSM.body.sourceMap, 30, 22);
 }
 
-TEST_CASE("doesn't crash while parsing response followed by a block quote settext heading", "[parser][322]")
+TEST_CASE(
+    "doesn't crash while parsing response followed by a block quote settext "
+    "heading",
+    "[parser][322]")
 {
     mdp::ByteBuffer source
         = "# GET /a\n\n"
@@ -759,10 +950,14 @@ TEST_CASE("doesn't crash while parsing response followed by a block quote settex
 
     REQUIRE(blueprint.report.error.code == Error::OK);
 
-    SourceMap<Resource> resourceSM
-        = blueprint.sourceMap.content.elements().collection[0].content.elements().collection[0].content.resource;
+    SourceMap<Resource> resourceSM = blueprint.sourceMap.content.elements()
+                                         .collection[0]
+                                         .content.elements()
+                                         .collection[0]
+                                         .content.resource;
     SourceMap<Action> actionSM = resourceSM.actions.collection[0];
-    SourceMap<Payload> payloadSM = actionSM.examples.collection[0].responses.collection[0];
+    SourceMap<Payload> payloadSM
+        = actionSM.examples.collection[0].responses.collection[0];
     SourceMapHelper::check(payloadSM.body.sourceMap, 30, 22, 1);
 }
 


### PR DESCRIPTION
Although historically the reason for an 80 column limit was monitor size, code bases still use it for different reasons:

- Typography 101: shorter lines are easier to read
- Two or three vertical buffers are feasible; especially useful for us vim users, but also for anyone doing a side-by-side diff or merge.
- Embedding code into documents, presentations or blog posts as-is
- One is forced to be concise about naming things (proper use of namespaces as contexts etc)

I find these arguments valid and therefore propose to enforce a column limit of 80 via clang-format.